### PR TITLE
Add array cursor optimized for navigation

### DIFF
--- a/core/shared/src/main/scala/io/circe/Cursor.scala
+++ b/core/shared/src/main/scala/io/circe/Cursor.scala
@@ -28,6 +28,8 @@ abstract class Cursor extends CursorOperations {
    * Create an [[HCursor]] for this cursor in order to track history.
    */
   def hcursor: HCursor = HCursor(this, Nil)
+
+  private[circe] def normalize: Cursor = this
 }
 
 object Cursor {
@@ -42,12 +44,14 @@ object Cursor {
   }
 
   implicit val eqCursor: Eq[Cursor] = Eq.instance {
-    case (CJson(j1), CJson(j2)) => Eq[Json].eqv(j1, j2)
-    case (CArray(f1, p1, _, l1, r1), CArray(f2, p2, _, l2, r2)) =>
-      eqCursor.eqv(p1, p2) && Eq[List[Json]].eqv(l1, l2) &&
-        Eq[Json].eqv(f1, f2) && Eq[List[Json]].eqv(r1, r2)
-    case (CObject(f1, k1, p1, _, o1), CObject(f2, k2, p2, _, o2)) =>
-      eqCursor.eqv(p1, p2) && Eq[JsonObject].eqv(o1, o2) && k1 == k2 && Eq[Json].eqv(f1, f2)
-    case (_, _) => false
+    case (a, b) => (a.normalize, b.normalize) match {
+      case (CJson(j1), CJson(j2)) => Eq[Json].eqv(j1, j2)
+      case (CArray(f1, p1, _, l1, r1), CArray(f2, p2, _, l2, r2)) =>
+        eqCursor.eqv(p1, p2) && Eq[List[Json]].eqv(l1, l2) &&
+          Eq[Json].eqv(f1, f2) && Eq[List[Json]].eqv(r1, r2)
+      case (CObject(f1, k1, p1, _, o1), CObject(f2, k2, p2, _, o2)) =>
+        eqCursor.eqv(p1, p2) && Eq[JsonObject].eqv(o1, o2) && k1 == k2 && Eq[Json].eqv(f1, f2)
+      case (_, _) => false
+    }
   }
 }

--- a/core/shared/src/main/scala/io/circe/cursor/CArray.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/CArray.scala
@@ -15,7 +15,7 @@ private[circe] case class CArray(
   def up: Option[Cursor] = Some {
     val newFocus = Json.fromValues((focus :: rs).reverse_:::(ls))
 
-    parent match {
+    parent.normalize match {
       case _: CJson => CJson(newFocus)
       case a: CArray => a.copy(focus = newFocus, changed = self.changed || a.changed)
       case o: CObject => o.copy(
@@ -29,7 +29,7 @@ private[circe] case class CArray(
   def delete: Option[Cursor] = Some {
     val newFocus = Json.fromValues(rs.reverse_:::(ls))
 
-    parent match {
+    parent.normalize match {
       case _: CJson => CJson(newFocus)
       case a: CArray => a.copy(focus = newFocus, changed = true)
       case o: CObject => o.copy(focus = newFocus, changed = true)

--- a/core/shared/src/main/scala/io/circe/cursor/CFastNavArray.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/CFastNavArray.scala
@@ -1,0 +1,52 @@
+package io.circe.cursor
+
+import cats.Functor
+import io.circe.{ Context, Cursor, Json }
+
+private[circe] case class CFastNavArray(
+  values: IndexedSeq[Json],
+  focusIndex: Int,
+  parent: Cursor
+) extends Cursor { self =>
+  private[circe] override def normalize: Cursor = CArray(
+    focus,
+    parent,
+    false,
+    values.take(focusIndex).reverse.toList,
+    values.drop(focusIndex + 1).toList
+  )
+
+  def focus: Json = values(focusIndex)
+  def context: List[Context] = Context.inArray(focus, focusIndex) :: parent.context
+  def up: Option[Cursor] = Some(parent)
+  def delete: Option[Cursor] = normalize.delete
+
+  def withFocus(f: Json => Json): Cursor = normalize.withFocus(f)
+  def withFocusM[F[_]](f: Json => F[Json])(implicit F: Functor[F]): F[Cursor] =
+    normalize.withFocusM(f)
+
+  override def lefts: Option[List[Json]] = Some(values.take(focusIndex).reverse.toList)
+  override def rights: Option[List[Json]] = Some(values.drop(focusIndex + 1).toList)
+
+  override def left: Option[Cursor] = if (focusIndex == 0) None else Some(
+    copy(focusIndex = focusIndex - 1)
+  )
+
+  override def right: Option[Cursor] = if (focusIndex == values.size - 1) None else Some(
+    copy(focusIndex = focusIndex + 1)
+  )
+
+  override def first: Option[Cursor] = if (values.isEmpty) None else Some(copy(focusIndex = 0))
+  override def last: Option[Cursor] = if (values.isEmpty) None else Some(
+    copy(focusIndex = values.size - 1)
+  )
+
+  override def deleteGoLeft: Option[Cursor] = normalize.deleteGoLeft
+  override def deleteGoRight: Option[Cursor] = normalize.deleteGoRight
+  override def deleteGoFirst: Option[Cursor] = normalize.deleteGoFirst
+  override def deleteGoLast: Option[Cursor] = normalize.deleteGoLast
+  override def deleteLefts: Option[Cursor] = normalize.deleteLefts
+  override def deleteRights: Option[Cursor] = normalize.deleteRights
+  override def setLefts(js: List[Json]): Option[Cursor] = normalize.setLefts(js)
+  override def setRights(js: List[Json]): Option[Cursor] = normalize.setRights(js)
+}

--- a/core/shared/src/main/scala/io/circe/cursor/CObject.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/CObject.scala
@@ -15,7 +15,7 @@ private[circe] case class CObject(
   def up: Option[Cursor] = Some {
     val newFocus = Json.fromJsonObject(if (changed) obj.add(key, focus) else obj)
 
-    parent match {
+    parent.normalize match {
       case _: CJson => CJson(newFocus)
       case a: CArray => a.copy(focus = newFocus, changed = self.changed || a.changed)
       case o: CObject => o.copy(focus = newFocus, changed = self.changed || o.changed)
@@ -25,7 +25,7 @@ private[circe] case class CObject(
   def delete: Option[Cursor] = Some {
     val newFocus = Json.fromJsonObject(obj.remove(key))
 
-    parent match {
+    parent.normalize match {
       case _: CJson => CJson(newFocus)
       case a: CArray => a.copy(focus = newFocus, changed = true)
       case o: CObject => o.copy(focus = newFocus, changed = true)

--- a/core/shared/src/main/scala/io/circe/cursor/HCursorOperations.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/HCursorOperations.scala
@@ -24,7 +24,6 @@ private[circe] trait HCursorOperations extends GenericCursor[HCursor] { this: HC
   def withFocusM[F[_]: Functor](f: Json => F[Json]): F[HCursor] =
     Functor[F].map(cursor.withFocusM(f))(c => HCursor(c, history))
 
-
   def lefts: Option[List[Json]]     = cursor.lefts
   def rights: Option[List[Json]]    = cursor.rights
   def fieldSet: Option[Set[String]] = cursor.fieldSet


### PR DESCRIPTION
This is a quick experiment in trying to improve performance ([related](https://github.com/travisbrown/circe/pull/86#issuecomment-155204248)) by adding a new `Cursor` implementation for arrays that's optimized for navigation (as opposed to modification). Because decoders generally only navigate arrays, this does help out, although not as much as I'd hoped (not really much for speed, and allocation rates are only 8-10% lower in the decoding benchmarks).

There are no changes to the public API, but there is some extra complexity, so I'm not sure I want to merge this, but I wanted to post it here for possible discussion.
