### PR TITLE
Introduce AbstractDecoder

### DIFF
--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -105,6 +105,21 @@ object Encoder extends TupleEncoders with LowPriorityEncoders {
   /**
    * @group Encoding
    */
+  implicit val encodeCursor: Encoder[Cursor] = instance(_.focus)
+
+  /**
+   * @group Encoding
+   */
+  implicit val encodeHCursor: Encoder[HCursor] = instance(_.cursor.focus)
+
+  /**
+   * @group Encoding
+   */
+  implicit val encodeACursor: Encoder[ACursor] = instance(_.any.cursor.focus)
+
+  /**
+   * @group Encoding
+   */
   implicit val encodeJsonObject: Encoder[JsonObject] = instance(Json.fromJsonObject)
 
   /**

--- a/core/shared/src/main/scala/io/circe/internal/AbstractDecoder.scala
+++ b/core/shared/src/main/scala/io/circe/internal/AbstractDecoder.scala
@@ -1,0 +1,21 @@
+package io.circe.internal
+
+import cats.data.Kleisli
+import io.circe.{ HCursor, Json }
+
+trait AbstractDecoder[F[_], A] extends Serializable {
+  /**
+   * Decode the given hcursor.
+   */
+  def apply(c: HCursor): F[A]
+
+  /**
+   * Decode the given [[Json]] value.
+   */
+  def decodeJson(j: Json): F[A] = apply(j.cursor.hcursor)
+
+  /**
+   * Convert to a Kleisli arrow.
+   */
+  def kleisli: Kleisli[F, HCursor, A] = Kleisli[F, HCursor, A](apply(_))
+}

--- a/core/shared/src/main/scala/io/circe/internal/PerfectDecoder.scala
+++ b/core/shared/src/main/scala/io/circe/internal/PerfectDecoder.scala
@@ -1,0 +1,37 @@
+package io.circe.internal
+
+import cats.{ Id, Monad }
+import io.circe.{ ACursor, Cursor, HCursor, Json }
+
+/**
+ * Represents a decoder that cannot fail.
+ */
+trait PerfectDecoder[A] extends AbstractDecoder[Id, A]
+
+object PerfectDecoder {
+  final val monadPerfectDecoder: Monad[PerfectDecoder] = new Monad[PerfectDecoder] {
+    def pure[A](a: A): PerfectDecoder[A] = new PerfectDecoder[A] {
+      def apply(c: HCursor): A = a
+    }
+    def flatMap[A, B](fa: PerfectDecoder[A])(f: A => PerfectDecoder[B]): PerfectDecoder[B] =
+      new PerfectDecoder[B] {
+        def apply(c: HCursor): B = f(fa(c))(c)
+      }
+  }
+
+  implicit final val decodeJson: PerfectDecoder[Json] = new PerfectDecoder[Json] {
+    def apply(c: HCursor): Json = c.focus
+  }
+
+  implicit final val decodeCursor: PerfectDecoder[Cursor] = new PerfectDecoder[Cursor] {
+    def apply(c: HCursor): Cursor = c.cursor
+  }
+
+  implicit final val decodeHCursor: PerfectDecoder[HCursor] = new PerfectDecoder[HCursor] {
+    def apply(c: HCursor): HCursor = c
+  }
+
+  implicit final val decodeACursor: PerfectDecoder[ACursor] = new PerfectDecoder[ACursor] {
+    def apply(c: HCursor): ACursor = c.acursor
+  }
+}


### PR DESCRIPTION
This abstraction helps with two things I'm working on—it lets us capture the behavior that `Decoder` and `AccumulatingDecoder` share, and it lets us (cleanly) introduce a new `PerfectDecoder` type class that represents decoders that can't fail, which makes some changes I'm working on for the `*Cursor` tests a little nicer.

I've introduced a new `internal` package to signal that these aren't generally user-facing types. It's possible that `GenericCursor` should go here as well (and that it should be named `AbstractCursor` for consistency—I went with "abstract" here instead of "generic" in order to avoid confusion with the `generic` module).
