### PR TITLE
Add Codec type class (#133)

### DIFF
--- a/core/shared/src/main/scala/io/circe/Codec.scala
+++ b/core/shared/src/main/scala/io/circe/Codec.scala
@@ -1,0 +1,17 @@
+import io.circe._
+
+/**
+ * A type class that provides back and forth conversion between values of type `A`
+ * and the [[Json]] format. Must obey the laws defined in [[io.circe.tests.CodecLaws]].
+ */
+trait Codec[A] extends Encoder[A] with Decoder[A]
+
+object Codec {
+  def apply[A](implicit instance: Codec[A]): Codec[A] = instance
+
+  implicit def fromEncoderDecoder[A](implicit e: Encoder[A], d: Decoder[A]): Codec[A] =
+    new Codec[A] {
+      def apply(c: HCursor): Decoder.Result[A] = d(c)
+      def apply(a: A): Json = e(a)
+    }
+}

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -8,6 +8,9 @@ import java.util.UUID
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.Builder
 
+/**
+ * A type class that provides a way to materialize a value of type `A` from a [[Json]] value.
+ */
 trait Decoder[A] extends Serializable { self =>
   /**
    * Decode the given hcursor.


### PR DESCRIPTION
This implementation follows what is done in https://github.com/jto/validation with [`Format`](https://github.com/jto/validation/blob/master/validation-core/src/main/scala/play/api/data/mapping/Format.scala#L7). I think is fulfills the first 4 requirements listed in #133, 5. does not quite work unfortunately: 96a57230a903bc7778aed49e3bbaf32fc7ec78d0.

If you think that's still acceptable I would be happy to continue the PR with tests & co :)
