### PR TITLE
No Predef

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ lazy val compilerOptions = Seq(
   "-Yno-adapted-args",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen",
-  "-Xfuture"
+  "-Xfuture",
+  "-Yno-predef"
 )
 
 lazy val catsVersion = "0.7.2"
@@ -40,10 +41,13 @@ lazy val baseSettings = Seq(
     }
   ),
   scalacOptions in (Compile, console) ~= {
-    _.filterNot(Set("-Ywarn-unused-import"))
+    _.filterNot(Set("-Ywarn-unused-import", "-Yno-predef"))
   },
   scalacOptions in (Test, console) ~= {
-    _.filterNot(Set("-Ywarn-unused-import"))
+    _.filterNot(Set("-Ywarn-unused-import", "-Yno-predef"))
+  },
+  scalacOptions in Test ~= {
+    _.filterNot(Set("-Yno-predef"))
   },
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),

--- a/build.sbt
+++ b/build.sbt
@@ -335,6 +335,9 @@ lazy val testsBase = crossProject.in(file("modules/tests"))
   .settings(allSettings: _*)
   .settings(noPublishSettings: _*)
   .settings(
+    scalacOptions ~= {
+      _.filterNot(Set("-Yno-predef"))
+    },
     libraryDependencies ++= Seq(
       "com.chuusai" %%% "shapeless" % shapelessVersion,
       "org.scalacheck" %%% "scalacheck" % scalaCheckVersion,
@@ -477,6 +480,9 @@ lazy val benchmark = project.in(file("modules/benchmark"))
   .settings(allSettings)
   .settings(noPublishSettings)
   .settings(
+    scalacOptions ~= {
+      _.filterNot(Set("-Yno-predef"))
+    },
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % "2.3.10",
       "io.argonaut" %% "argonaut" % "6.1",

--- a/modules/core/shared/src/main/scala/io/circe/ACursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ACursor.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.{ Applicative, Eq }
 import cats.data.Validated
 import cats.instances.either._
+import scala.collection.immutable.Set
 
 /**
  * A cursor that tracks history and represents the possibility of failure.

--- a/modules/core/shared/src/main/scala/io/circe/Cursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Cursor.scala
@@ -4,6 +4,7 @@ import cats.{ Eq, Functor, Id, Show }
 import cats.instances.list._
 import io.circe.cursor.{ CArray, CJson, CObject }
 import scala.annotation.tailrec
+import scala.collection.immutable.Set
 
 /**
  * A zipper that represents a position in a JSON value and supports navigation around the JSON

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -7,6 +7,7 @@ import io.circe.export.Exported
 import java.util.UUID
 import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
+import scala.collection.immutable.{ Map, Set }
 import scala.util.{ Failure, Success, Try }
 
 trait Decoder[A] extends Serializable { self =>
@@ -441,7 +442,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case None => fail(c)
       }
       case JString(string) => try {
-        Right(string.toByte)
+        Right(java.lang.Byte.parseByte(string))
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -463,7 +464,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case None => fail(c)
       }
       case JString(string) => try {
-        Right(string.toShort)
+        Right(java.lang.Short.parseShort(string))
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -485,7 +486,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case None => fail(c)
       }
       case JString(string) => try {
-        Right(string.toInt)
+        Right(java.lang.Integer.parseInt(string))
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -510,7 +511,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case None => fail(c)
       }
       case JString(string) => try {
-        Right(string.toLong)
+        Right(java.lang.Long.parseLong(string))
       } catch {
         case _: NumberFormatException => fail(c)
       }

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -7,6 +7,8 @@ import io.circe.export.Exported
 import java.util.UUID
 import scala.collection.GenSeq
 import scala.collection.generic.IsTraversableOnce
+import scala.collection.immutable.Map
+import scala.Predef._
 
 /**
  * A type class that provides a conversion from a value of type `A` to a [[Json]] value.

--- a/modules/core/shared/src/main/scala/io/circe/GenericCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/GenericCursor.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.Functor
+import scala.collection.immutable.Set
 
 /**
  * A zipper that represents a position in a JSON document and supports navigation and modification.

--- a/modules/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.{ Eq, Functor, Id }
+import scala.collection.immutable.Set
 
 /**
  * A cursor that tracks the history of operations performed with it.

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -158,7 +158,7 @@ private[circe] final case class JsonBigDecimal(value: BigDecimal) extends JsonNu
   final def toBigInt: Option[BigInt] = toBiggerDecimal.toBigInteger.map(BigInt(_))
   final def toDouble: Double = value.toDouble
   final def toLong: Option[Long] = toBiggerDecimal.toLong
-  final def truncateToLong: Long = toDouble.round
+  final def truncateToLong: Long = math.round(toDouble)
   override final def toString: String = value.toString
 }
 
@@ -191,7 +191,7 @@ private[circe] final case class JsonDouble(value: Double) extends JsonNumber {
     if (asLong.toDouble == value) Some(asLong) else None
   }
 
-  final def truncateToLong: Long = value.round
+  final def truncateToLong: Long = math.round(value)
   override final def toString: String = java.lang.Double.toString(value)
 }
 
@@ -219,9 +219,9 @@ final object JsonNumber {
    */
   final def unsafeIntegral(value: String): JsonNumber =
     if (!NumberParsing.integralIsValidLong(value)) JsonDecimal(value) else {
-      val longValue = value.toLong
+      val longValue = java.lang.Long.parseLong(value)
 
-      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else JsonLong(value.toLong)
+      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else JsonLong(longValue)
     }
 
   final def fromString(value: String): Option[JsonNumber] =

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -4,6 +4,7 @@ import cats.{ Applicative, Eq, Foldable, Show }
 import cats.data.Kleisli
 import cats.instances.map._
 import scala.collection.breakOut
+import scala.collection.immutable.{ Map, Set }
 
 /**
  * A mapping from keys to JSON values that maintains insertion order.
@@ -150,7 +151,7 @@ final object JsonObject {
    * Construct a [[JsonObject]] with a single field.
    */
   final def singleton(k: String, j: Json): JsonObject =
-    MapAndVectorJsonObject(Map(k -> j), Vector(k))
+    MapAndVectorJsonObject(Map((k, j)), Vector(k))
 
   implicit final val showJsonObject: Show[JsonObject] = Show.fromToString
   implicit final val eqJsonObject: Eq[JsonObject] = Eq.by(_.toMap)
@@ -187,7 +188,7 @@ final object JsonObject {
     final def withJsons(f: Json => Json): JsonObject = copy(fieldMap = fieldMap.mapValues(f).view.force)
     final def isEmpty: Boolean = fieldMap.isEmpty
     final def contains(k: String): Boolean = fieldMap.contains(k)
-    final def toList: List[(String, Json)] = orderedFields.map(k => k -> fieldMap(k))(breakOut)
+    final def toList: List[(String, Json)] = orderedFields.map(k => (k, fieldMap(k)))(breakOut)
     final def values: List[Json] = orderedFields.map(k => fieldMap(k))(breakOut)
     final def kleisli: Kleisli[Option, String, Json] = Kleisli(fieldMap.get)
     final def fields: List[String] = orderedFields.toList
@@ -201,12 +202,12 @@ final object JsonObject {
 
     final def size: Int = fieldMap.size
 
-    override final def toString: String =
-      "object[%s]".format(
-        fieldMap.map {
-          case (k, v) => s"$k -> ${ Json.showJson.show(v) }"
-        }.mkString(",")
-      )
+    override final def toString: String = String.format(
+      "object[%s]",
+      fieldMap.map {
+        case (k, v) => s"$k -> ${ Json.showJson.show(v) }"
+      }.mkString(",")
+    )
 
     /**
      * Universal equality derived from our type-safe equality.

--- a/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
@@ -59,10 +59,10 @@ final object KeyDecoder {
     } else None
   }
 
-  implicit val decodeKeyByte: KeyDecoder[Byte] = numberInstance(_.toByte)
-  implicit val decodeKeyShort: KeyDecoder[Short] = numberInstance(_.toShort)
-  implicit val decodeKeyInt: KeyDecoder[Int] = numberInstance(_.toInt)
-  implicit val decodeKeyLong: KeyDecoder[Long] = numberInstance(_.toLong)
+  implicit val decodeKeyByte: KeyDecoder[Byte] = numberInstance(java.lang.Byte.parseByte)
+  implicit val decodeKeyShort: KeyDecoder[Short] = numberInstance(java.lang.Short.parseShort)
+  implicit val decodeKeyInt: KeyDecoder[Int] = numberInstance(java.lang.Integer.parseInt)
+  implicit val decodeKeyLong: KeyDecoder[Long] = numberInstance(java.lang.Long.parseLong)
 
   implicit val keyDecoderInstances: MonadError[KeyDecoder, Unit] = new MonadError[KeyDecoder, Unit] {
     final def pure[A](a: A): KeyDecoder[A] = new KeyDecoder[A] {

--- a/modules/core/shared/src/main/scala/io/circe/MapDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/MapDecoder.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.data.{ NonEmptyList, Validated }
 import scala.collection.generic.CanBuildFrom
+import scala.collection.immutable.Map
 
 private[circe] final class MapDecoder[M[K, +V] <: Map[K, V], K, V](implicit
   dk: KeyDecoder[K],

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -66,48 +66,56 @@ final case class Printer(
       val afterLastNewLineIndex = lastNewLineIndex + 1
       val start = s.substring(0, afterLastNewLineIndex)
       val end = s.substring(afterLastNewLineIndex)
-      n => start + indent * n + end
+      n => start + Predef.augmentString(indent) * n + end
     }
   }
 
   private[this] final val pieces = new Printer.MemoizedPieces {
     final def compute(i: Int): Printer.Pieces = Printer.Pieces(
-      "%s%s%s".format(
+      String.format(
+        "%s%s%s",
         addIndentation(lbraceLeft)(i),
         openBraceText,
         addIndentation(lbraceRight)(i + 1)
       ),
-      "%s%s%s".format(
+      String.format(
+        "%s%s%s",
         addIndentation(rbraceLeft)(i),
         closeBraceText,
         addIndentation(rbraceRight)(i + 1)
       ),
-      "%s%s%s".format(
+      String.format(
+        "%s%s%s",
         addIndentation(lbracketLeft)(i),
         openArrayText,
         addIndentation(lbracketRight)(i + 1)
       ),
-      "%s%s%s".format(
+      String.format(
+        "%s%s%s",
         addIndentation(rbracketLeft)(i),
         closeArrayText,
         addIndentation(rbracketRight)(i + 1)
       ),
-      "%s%s%s".format(
+      String.format(
+        "%s%s%s",
         openArrayText,
         addIndentation(lrbracketsEmpty)(i),
         closeArrayText
       ),
-      "%s%s%s".format(
+      String.format(
+        "%s%s%s",
         addIndentation(arrayCommaLeft)(i + 1),
         commaText,
         addIndentation(arrayCommaRight)(i + 1)
       ),
-      "%s%s%s".format(
+      String.format(
+        "%s%s%s",
         addIndentation(objectCommaLeft)(i + 1),
         commaText,
         addIndentation(objectCommaRight)(i + 1)
       ),
-      "%s%s%s".format(
+      String.format(
+        "%s%s%s",
         addIndentation(colonLeft)(i + 1),
         colonText,
         addIndentation(colonRight)(i + 1)
@@ -249,7 +257,7 @@ final object Printer {
     case '\r' => "\\r"
     case '\t' => "\\t"
     case possibleUnicode => if (Character.isISOControl(possibleUnicode)) {
-      "\\u%04x".format(possibleUnicode.toInt)
+      String.format("\\u%04x", Integer.valueOf(possibleUnicode.toInt))
     } else possibleUnicode.toString
   }
 

--- a/modules/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
@@ -4,6 +4,7 @@ import io.circe.{ Decoder, Encoder }
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
 import macrocompat.bundle
+import scala.collection.immutable.Map
 import scala.reflect.macros.whitebox
 import shapeless.{ CNil, Coproduct, HList, HNil, Lazy }
 import shapeless.labelled.KeyTag

--- a/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
@@ -20,7 +20,7 @@ private[jackson] final case class ReadingList(content: ArrayList[Json])
 private[jackson] final case class KeyRead(content: ArrayList[(String, Json)], fieldName: String)
   extends DeserializerContext {
   def addValue(value: Json): DeserializerContext = ReadingMap {
-    content.add(fieldName -> value)
+    content.add((fieldName, value))
     content
   }
 }

--- a/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonModule.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonModule.scala
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.Serializers
 import io.circe.Json
+import scala.Predef.classOf
 
 final object CirceJsonModule extends SimpleModule("CirceJson", Version.unknownVersion()) {
   override final def setupModule(context: SetupContext): Unit = {

--- a/modules/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
@@ -2,6 +2,7 @@ package io.circe.jackson
 
 import io.circe.{ Json, Parser, ParsingFailure }
 import java.io.File
+import scala.Predef.classOf
 import scala.util.control.NonFatal
 
 trait JacksonParser extends Parser { this: WithJacksonMapper =>

--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -33,8 +33,8 @@ final object CirceSupportParser extends SupportParser[Json] {
       private[this] final var key: String = null
       private[this] final val vs = ArrayBuffer.empty[(String, Json)]
       final def add(s: String): Unit =
-        if (key == null) { key = s } else { vs += (key -> jstring(s)); key = null }
-      final def add(v: Json): Unit = { vs += (key -> v); key = null }
+        if (key == null) { key = s } else { vs += ((key, jstring(s))); key = null }
+      final def add(v: Json): Unit = { vs += ((key, v)); key = null }
       final def finish: Json = Json.fromFields(vs)
       final def isObj: Boolean = true
     }

--- a/modules/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
+++ b/modules/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
@@ -4,6 +4,8 @@ import io.circe.Json
 import java.lang.reflect.{ InvocationHandler, Method, Proxy }
 import java.util.UUID
 import macrocompat.bundle
+import scala.Predef.classOf
+import scala.collection.immutable.Map
 import scala.reflect.macros.whitebox
 import scala.util.control.NonFatal
 
@@ -37,7 +39,7 @@ class LiteralMacros(val c: whitebox.Context) {
 
     val invokeWithoutArg: String => Object = {
       case "finish" => value
-      case "isObj" => false: java.lang.Boolean
+      case "isObj" => java.lang.Boolean.FALSE
     }
 
     val invokeWithArg: (String, Class[_], Object) => Object = {
@@ -56,7 +58,7 @@ class LiteralMacros(val c: whitebox.Context) {
 
     val invokeWithoutArg: String => Object = {
       case "finish" => q"_root_.io.circe.Json.arr(..$values)"
-      case "isObj" => false: java.lang.Boolean
+      case "isObj" => java.lang.Boolean.FALSE
     }
 
     val invokeWithArg: (String, Class[_], Object) => Object = {
@@ -76,7 +78,7 @@ class LiteralMacros(val c: whitebox.Context) {
 
     val invokeWithoutArg: String => Object = {
       case "finish" => q"_root_.io.circe.Json.obj(..$fields)"
-      case "isObj" => true: java.lang.Boolean
+      case "isObj" => java.lang.Boolean.TRUE
     }
 
     val invokeWithArg: (String, Class[_], Object) => Object = {

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -99,7 +99,7 @@ private[numbers] final class SigAndExp(
     }
   }
 
-  def truncateToLong: Long = toDouble.round
+  def truncateToLong: Long = math.round(toDouble)
 
   override def equals(that: Any): Boolean = that match {
     case other: SigAndExp =>

--- a/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
@@ -39,7 +39,7 @@ trait JsonObjectOptics extends CatsConversions with ListInstances {
           F.map(
             Traverse[List].traverse(from.toList) {
               case (field, json) =>
-                F.map(if (p(field)) f(json) else F.point(json))(field -> _)
+                F.map(if (p(field)) f(json) else F.point(json))((field, _))
             }
           )(JsonObject.from(_)(catsStdInstancesForList))
     }

--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -2,7 +2,6 @@ package io.circe
 
 import io.circe.Json._
 import scala.scalajs.js
-import scala.scalajs.js.undefined
 import scala.scalajs.js.JSConverters.{ JSRichGenMap, JSRichGenTraversableOnce }
 import scala.util.control.NonFatal
 

--- a/modules/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
+++ b/modules/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
@@ -35,7 +35,7 @@ private[streaming] abstract class ParsingEnumeratee[F[_], S](implicit F: Applica
     final def onChunk(h1: S, h2: S, t: Vector[S]): F[Step[F, S, Step[F, Json, A]]] =
       (h1 +: h2 +: t).traverseU(parseWith(p)) match {
         case Left(error) => F.raiseError(ParsingFailure(error.getMessage, error))
-        case Right(js) => F.map(feedStep(step, js.flatten))(doneOrLoop[A](p))
+        case Right(js) => F.map(feedStep(step, js.flatten(Predef.identity)))(doneOrLoop[A](p))
       }
     }
 


### PR DESCRIPTION
These changes address #320. In all cases except `round` I'm pretty sure the syntax provided by `Predef` doesn't involve extra allocations, but I'm tempted to make this change anyway, for the sake of explicitness and future safety.
