### PR TITLE
Move AST and other core types to new circe-ast module [do not merge]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,7 @@ def noDocProjects(sv: String): Seq[ProjectReference] = Seq[ProjectReference](
   genericExtrasJS,
   shapesJS,
   numbersJS,
+  astJS,
   opticsJS,
   parserJS,
   refinedJS,
@@ -128,6 +129,7 @@ lazy val docs = project.dependsOn(core, generic, parser, optics)
 
 lazy val aggregatedProjects: Seq[ProjectReference] = Seq[ProjectReference](
   numbers, numbersJS,
+  ast, astJS,
   core, coreJS,
   generic, genericJS,
   genericExtras, genericExtrasJS,
@@ -209,6 +211,28 @@ lazy val numbersBase = crossProject.in(file("modules/numbers"))
 lazy val numbers = numbersBase.jvm
 lazy val numbersJS = numbersBase.js
 
+lazy val astBase = crossProject.crossType(CrossType.Pure).in(file("modules/ast"))
+  .settings(
+    description := "circe abstract syntax tree",
+    moduleName := "circe-ast",
+    name := "Circe AST",
+    crossScalaVersions := scalaVersions
+  )
+  .settings(allSettings: _*)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test",
+      "org.scalatest" %%% "scalatest" % scalaTestVersion % "test",
+      "org.typelevel" %%% "cats-core" % catsVersion
+    )
+  )
+  .jvmConfigure(_.copy(id = "ast"))
+  .jsConfigure(_.copy(id = "astJS"))
+  .dependsOn(numbersBase)
+
+lazy val ast = astBase.jvm
+lazy val astJS = astBase.js
+
 lazy val coreBase = crossProject.in(file("modules/core"))
   .settings(
     description := "circe core",
@@ -218,9 +242,6 @@ lazy val coreBase = crossProject.in(file("modules/core"))
   )
   .settings(allSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core" % catsVersion
-    ),
     sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.gen).taskValue
   )
   .jvmSettings(
@@ -228,7 +249,7 @@ lazy val coreBase = crossProject.in(file("modules/core"))
   )
   .jvmConfigure(_.copy(id = "core"))
   .jsConfigure(_.copy(id = "coreJS"))
-  .dependsOn(numbersBase)
+  .dependsOn(astBase)
 
 lazy val core = coreBase.jvm
 lazy val coreJS = coreBase.js
@@ -700,6 +721,7 @@ credentials ++= (
 
 val jvmProjects = Seq(
   "numbers",
+  "ast",
   "core",
   "generic",
   "genericExtras",
@@ -716,6 +738,7 @@ val jvmProjects = Seq(
 
 val jvmTestProjects = Seq(
   "numbers",
+  "ast",
   "tests"
 ) ++ (
   if (sys.props("java.specification.version") == "1.8") Seq("java8", "optics") else Nil
@@ -723,6 +746,7 @@ val jvmTestProjects = Seq(
 
 val jsProjects = Seq(
   "numbersJS",
+  "astJS",
   "coreJS",
   "genericJS",
   "genericExtrasJS",

--- a/modules/ast/src/main/scala/io/circe/ast/Json.scala
+++ b/modules/ast/src/main/scala/io/circe/ast/Json.scala
@@ -1,4 +1,4 @@
-package io.circe
+package io.circe.ast
 
 import cats.{ Eq, Show }
 import io.circe.numbers.BiggerDecimal
@@ -48,16 +48,6 @@ sealed abstract class Json extends Product with Serializable {
     case JObject(o)  => jsonObject(o)
   }
 
-  /**
-   * Construct a cursor from this JSON value.
-   */
-  final def cursor: Cursor = Cursor(this)
-
-  /**
-   * Construct a cursor with history from this JSON value.
-   */
-  final def hcursor: HCursor = HCursor.fromCursor(Cursor(this))
-
   def isNull: Boolean
   def isBoolean: Boolean
   def isNumber: Boolean
@@ -95,11 +85,6 @@ sealed abstract class Json extends Product with Serializable {
       case JArray(_)   => "Array"
       case JObject(_)  => "Object"
     }
-
-  /**
-   * Attempts to decode this JSON value to another data type.
-   */
-  final def as[A](implicit d: Decoder[A]): Decoder.Result[A] = d(HCursor.fromCursor(cursor))
 
   /**
    * Pretty-print this JSON value to a string using the given pretty-printer.

--- a/modules/ast/src/main/scala/io/circe/ast/JsonNumber.scala
+++ b/modules/ast/src/main/scala/io/circe/ast/JsonNumber.scala
@@ -1,4 +1,4 @@
-package io.circe
+package io.circe.ast
 
 import cats.Eq
 import io.circe.numbers.BiggerDecimal

--- a/modules/ast/src/main/scala/io/circe/ast/JsonObject.scala
+++ b/modules/ast/src/main/scala/io/circe/ast/JsonObject.scala
@@ -1,4 +1,4 @@
-package io.circe
+package io.circe.ast
 
 import cats.{ Applicative, Eq, Foldable, Show }
 import cats.data.Kleisli

--- a/modules/ast/src/main/scala/io/circe/ast/Printer.scala
+++ b/modules/ast/src/main/scala/io/circe/ast/Printer.scala
@@ -1,4 +1,4 @@
-package io.circe
+package io.circe.ast
 
 import scala.annotation.{ switch, tailrec }
 

--- a/modules/core/shared/src/main/scala/io/circe/ACursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ACursor.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.{ Applicative, Eq }
 import cats.data.Validated
 import cats.instances.either._
+import io.circe.ast.Json
 
 /**
  * A cursor that tracks history and represents the possibility of failure.

--- a/modules/core/shared/src/main/scala/io/circe/ArrayEncoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ArrayEncoder.scala
@@ -1,5 +1,7 @@
 package io.circe
 
+import io.circe.ast.Json
+
 /**
  * A type class that provides a conversion from a value of type `A` to a JSON
  * array.

--- a/modules/core/shared/src/main/scala/io/circe/Context.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Context.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.{ Eq, Show }
+import io.circe.ast.Json
 
 sealed abstract class Context extends Serializable {
   def json: Json

--- a/modules/core/shared/src/main/scala/io/circe/Cursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Cursor.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.{ Eq, Functor, Id, Show }
 import cats.instances.list._
+import io.circe.ast.{ Json, JsonObject }
 import io.circe.cursor.{ CArray, CJson, CObject }
 import scala.annotation.tailrec
 

--- a/modules/core/shared/src/main/scala/io/circe/CursorOp.scala
+++ b/modules/core/shared/src/main/scala/io/circe/CursorOp.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.{ Eq, Show }
+import io.circe.ast.Json
 
 sealed abstract class CursorOp extends Product with Serializable {
   /**

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.{ MonadError, SemigroupK }
 import cats.data.{ Kleisli, NonEmptyList, NonEmptyVector, OneAnd, StateT, Validated }
 import cats.instances.either.{ catsDataSemigroupKForEither, catsStdInstancesForEither }
+import io.circe.ast.{ Json, JsonNumber, JsonObject }
 import io.circe.export.Exported
 import java.util.UUID
 import scala.annotation.tailrec
@@ -37,9 +38,9 @@ trait Decoder[A] extends Serializable { self =>
     )
 
   /**
-   * Decode the given [[Json]] value.
+   * Decode the given [[io.circe.ast.Json]] value.
    */
-  final def decodeJson(j: Json): Decoder.Result[A] = apply(HCursor.fromCursor(j.cursor))
+  final def decodeJson(j: Json): Decoder.Result[A] = apply(HCursor.fromJson(j))
 
   final def accumulating: AccumulatingDecoder[A] = AccumulatingDecoder.fromDecoder(self)
 

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -3,13 +3,15 @@ package io.circe
 import cats.data.{ NonEmptyList, NonEmptyVector, OneAnd, Validated }
 import cats.functor.Contravariant
 import cats.Foldable
+import io.circe.ast.{ Json, JsonNumber, JsonObject }
 import io.circe.export.Exported
 import java.util.UUID
 import scala.collection.GenSeq
 import scala.collection.generic.IsTraversableOnce
 
 /**
- * A type class that provides a conversion from a value of type `A` to a [[Json]] value.
+ * A type class that provides a conversion from a value of type `A` to a [[io.circe.ast.Json]]
+ * value.
  *
  * @author Travis Brown
  */

--- a/modules/core/shared/src/main/scala/io/circe/GenericCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/GenericCursor.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.Functor
+import io.circe.ast.Json
 
 /**
  * A zipper that represents a position in a JSON document and supports navigation and modification.

--- a/modules/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.{ Eq, Functor, Id }
+import io.circe.ast.Json
 
 /**
  * A cursor that tracks the history of operations performed with it.
@@ -127,6 +128,8 @@ sealed abstract class HCursor(final val cursor: Cursor) extends GenericCursor[HC
 }
 
 final object HCursor {
+  def fromJson(json: Json): HCursor = fromCursor(Cursor(json))
+
   /**
    * Create an [[HCursor]] from a [[Cursor]] in order to track history.
    */

--- a/modules/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
@@ -1,10 +1,11 @@
 package io.circe
 
+import io.circe.ast.{ Json, JsonObject }
 import io.circe.export.Exported
 
 /**
  * A type class that provides a conversion from a value of type `A` to a
- * [[JsonObject]].
+ * [[io.circe.ast.JsonObject]].
  *
  * @author Travis Brown
  */

--- a/modules/core/shared/src/main/scala/io/circe/Parser.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Parser.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.data.{ NonEmptyList, Validated, ValidatedNel }
+import io.circe.ast.Json
 
 trait Parser extends Serializable {
   def parse(input: String): Either[ParsingFailure, Json]
@@ -15,7 +16,7 @@ trait Parser extends Serializable {
   protected[this] final def finishDecodeAccumulating[A](input: Either[ParsingFailure, Json])(implicit
     decoder: Decoder[A]
   ): ValidatedNel[Error, A] = input match {
-    case Right(json) => decoder.accumulating(json.hcursor).leftMap {
+    case Right(json) => decoder.accumulating(HCursor.fromJson(json)).leftMap {
       case NonEmptyList(h, t) => NonEmptyList(h, t)
     }
     case Left(error) => Validated.invalidNel(error)

--- a/modules/core/shared/src/main/scala/io/circe/cursor/CArray.scala
+++ b/modules/core/shared/src/main/scala/io/circe/cursor/CArray.scala
@@ -1,7 +1,8 @@
 package io.circe.cursor
 
 import cats.Functor
-import io.circe.{ Context, Cursor, Json }
+import io.circe.{ Context, Cursor }
+import io.circe.ast.Json
 
 private[circe] final case class CArray(
   focus: Json,

--- a/modules/core/shared/src/main/scala/io/circe/cursor/CJson.scala
+++ b/modules/core/shared/src/main/scala/io/circe/cursor/CJson.scala
@@ -1,7 +1,8 @@
 package io.circe.cursor
 
 import cats.Functor
-import io.circe.{ Context, Cursor, Json }
+import io.circe.{ Context, Cursor }
+import io.circe.ast.Json
 
 private[circe] final case class CJson(focus: Json) extends Cursor {
   def context: List[Context] = Nil

--- a/modules/core/shared/src/main/scala/io/circe/cursor/CObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/cursor/CObject.scala
@@ -1,7 +1,8 @@
 package io.circe.cursor
 
 import cats.Functor
-import io.circe.{ Context, Cursor, Json, JsonObject }
+import io.circe.{ Context, Cursor }
+import io.circe.ast.{ Json, JsonObject }
 
 private[circe] final case class CObject(
   focus: Json,

--- a/modules/core/shared/src/main/scala/io/circe/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/io/circe/syntax/package.scala
@@ -1,5 +1,7 @@
 package io.circe
 
+import io.circe.ast.{ Json, JsonObject }
+
 /**
  * This package provides syntax via enrichment classes.
  */

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredObjectEncoder.scala
@@ -1,6 +1,6 @@
 package io.circe.generic.extras.encoding
 
-import io.circe.JsonObject
+import io.circe.ast.JsonObject
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.extras.Configuration
 import shapeless.{ Coproduct, HList, LabelledGeneric, Lazy }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
@@ -1,6 +1,7 @@
 package io.circe.generic.extras.encoding
 
-import io.circe.{ Encoder, Json }
+import io.circe.Encoder
+import io.circe.ast.Json
 import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness }
 import shapeless.labelled.FieldType
 

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprObjectEncoder.scala
@@ -1,6 +1,7 @@
 package io.circe.generic.extras.encoding
 
-import io.circe.{ Encoder, Json, JsonObject, ObjectEncoder }
+import io.circe.{ Encoder, ObjectEncoder }
+import io.circe.ast.{ Json, JsonObject }
 import io.circe.generic.extras.ConfigurableDeriver
 import scala.language.experimental.macros
 

--- a/modules/generic/shared/src/main/scala/io/circe/generic/Deriver.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/Deriver.scala
@@ -51,5 +51,5 @@ class Deriver(val c: whitebox.Context)
     q"($name, $encode($value))"
 
   protected[this] def encodeSubtype(name: String, encode: TermName, value: TermName): Tree =
-    q"_root_.io.circe.JsonObject.singleton($name, $encode($value))"
+    q"_root_.io.circe.ast.JsonObject.singleton($name, $encode($value))"
 }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
@@ -1,6 +1,7 @@
 package io.circe.generic.encoding
 
-import io.circe.{ JsonObject, ObjectEncoder }
+import io.circe.ObjectEncoder
+import io.circe.ast.JsonObject
 import shapeless.{ LabelledGeneric, Lazy }
 
 abstract class DerivedObjectEncoder[A] extends ObjectEncoder[A]

--- a/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/DerivationMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/DerivationMacros.scala
@@ -261,7 +261,7 @@ abstract class DerivationMacros[RD[_], RE[_], DD[_], DE[_]] {
       q"""
         a match {
           case $pattern =>
-            _root_.io.circe.JsonObject.fromIterable(_root_.scala.collection.immutable.Vector(..$fields))
+            _root_.io.circe.ast.JsonObject.fromIterable(_root_.scala.collection.immutable.Vector(..$fields))
         }
       """
     )
@@ -305,7 +305,8 @@ abstract class DerivationMacros[RD[_], RE[_], DD[_], DE[_]] {
         new $instanceType {
           ..$instanceDefs
 
-          final def $encodeMethodName(...${ fullEncodeMethodArgs(R.tpe) }): _root_.io.circe.JsonObject = $instanceImpl
+          final def $encodeMethodName(...${ fullEncodeMethodArgs(R.tpe) }): _root_.io.circe.ast.JsonObject =
+            $instanceImpl
         }: $instanceType
       """
     }

--- a/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
@@ -3,7 +3,7 @@ package io.circe.jackson
 import com.fasterxml.jackson.core.{ JsonParser, JsonTokenId }
 import com.fasterxml.jackson.databind.{ DeserializationContext, JsonDeserializer }
 import com.fasterxml.jackson.databind.`type`.TypeFactory
-import io.circe.{ Json, JsonBigDecimal }
+import io.circe.ast.{ Json, JsonBigDecimal }
 import java.util.ArrayList
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._

--- a/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonModule.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonModule.scala
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.Module.SetupContext
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.Serializers
-import io.circe.Json
+import io.circe.ast.Json
 
 final object CirceJsonModule extends SimpleModule("CirceJson", Version.unknownVersion()) {
   override final def setupModule(context: SetupContext): Unit = {

--- a/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonSerializer.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonSerializer.scala
@@ -2,7 +2,7 @@ package io.circe.jackson
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{ JsonSerializer, SerializerProvider }
-import io.circe.{ Json, JsonBigDecimal, JsonBiggerDecimal, JsonDecimal, JsonDouble, JsonLong }
+import io.circe.ast.{ Json, JsonBigDecimal, JsonBiggerDecimal, JsonDecimal, JsonDouble, JsonLong }
 
 private[jackson] final object CirceJsonSerializer extends JsonSerializer[Json] {
   import java.math.{ BigDecimal => JBigDecimal, BigInteger }

--- a/modules/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
@@ -1,7 +1,8 @@
 package io.circe.jackson
 
 import cats.data.ValidatedNel
-import io.circe.{ Decoder, Error, Json, Parser, ParsingFailure }
+import io.circe.{ Decoder, Error, Parser, ParsingFailure }
+import io.circe.ast.Json
 import java.io.File
 import scala.util.control.NonFatal
 

--- a/modules/jackson/src/main/scala/io/circe/jackson/package.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/package.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.ObjectWriter
+import io.circe.ast.Json
 
 /**
  * Support for Jackson-powered parsing and printing for circe.

--- a/modules/jackson/src/main/scala/io/circe/jackson/syntax/package.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/syntax/package.scala
@@ -1,6 +1,6 @@
 package io.circe.jackson
 
-import io.circe.Json
+import io.circe.ast.Json
 
 /**
  * This package provides syntax for Jackson printing via enrichment classes.

--- a/modules/java8/src/main/scala/io/circe/java8/time/package.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/package.scala
@@ -1,6 +1,7 @@
 package io.circe.java8
 
-import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
+import io.circe.{ Decoder, DecodingFailure, Encoder }
+import io.circe.ast.Json
 import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, ZonedDateTime }
 import java.time.format.{ DateTimeFormatter, DateTimeParseException }
 import java.time.format.DateTimeFormatter.{

--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -1,6 +1,6 @@
 package io.circe.jawn
 
-import io.circe.{ Json, JsonNumber, JsonObject }
+import io.circe.ast.{ Json, JsonNumber, JsonObject }
 import jawn.{ Facade, FContext, SupportParser }
 
 final object CirceSupportParser extends SupportParser[Json] {

--- a/modules/jawn/src/main/scala/io/circe/jawn/JawnParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/JawnParser.scala
@@ -1,7 +1,8 @@
 package io.circe.jawn
 
 import cats.data.ValidatedNel
-import io.circe.{ Decoder, Error, Json, Parser, ParsingFailure }
+import io.circe.{ Decoder, Error, Parser, ParsingFailure }
+import io.circe.ast.Json
 import java.io.File
 import java.nio.ByteBuffer
 import scala.util.{ Failure, Success, Try }

--- a/modules/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
+++ b/modules/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
@@ -1,6 +1,6 @@
 package io.circe.literal
 
-import io.circe.Json
+import io.circe.ast.Json
 import java.lang.reflect.{ InvocationHandler, Method, Proxy }
 import java.util.UUID
 import macrocompat.bundle
@@ -25,7 +25,7 @@ class LiteralMacros(val c: whitebox.Context) {
     def toJsonKey(s: String): Tree = placeHolders.get(s).flatMap(_._2).getOrElse(q"$s")
 
     def toJsonString(s: String): Tree =
-      placeHolders.get(s).map(_._1).getOrElse(q"_root_.io.circe.Json.fromString($s)")
+      placeHolders.get(s).map(_._1).getOrElse(q"_root_.io.circe.ast.Json.fromString($s)")
 
     def asProxy(cls: Class[_]): Object =
       Proxy.newProxyInstance(getClass.getClassLoader, Array(cls), this)
@@ -55,7 +55,7 @@ class LiteralMacros(val c: whitebox.Context) {
     var values: List[Tree] = Nil
 
     val invokeWithoutArg: String => Object = {
-      case "finish" => q"_root_.io.circe.Json.arr(..$values)"
+      case "finish" => q"_root_.io.circe.ast.Json.arr(..$values)"
       case "isObj" => false: java.lang.Boolean
     }
 
@@ -75,7 +75,7 @@ class LiteralMacros(val c: whitebox.Context) {
     var fields: List[Tree] = Nil
 
     val invokeWithoutArg: String => Object = {
-      case "finish" => q"_root_.io.circe.Json.obj(..$fields)"
+      case "finish" => q"_root_.io.circe.ast.Json.obj(..$fields)"
       case "isObj" => true: java.lang.Boolean
     }
 
@@ -98,9 +98,9 @@ class LiteralMacros(val c: whitebox.Context) {
   private[this] class TreeFacadeHandler(placeHolders: Map[String, (Tree, Option[Tree])])
     extends HandlerHelpers(placeHolders) {
     val invokeWithoutArg: String => Object = {
-      case "jnull" => q"_root_.io.circe.Json.Null"
-      case "jfalse" => q"_root_.io.circe.Json.False"
-      case "jtrue" => q"_root_.io.circe.Json.True"
+      case "jnull" => q"_root_.io.circe.ast.Json.Null"
+      case "jfalse" => q"_root_.io.circe.ast.Json.False"
+      case "jtrue" => q"_root_.io.circe.ast.Json.True"
       case "singleContext" =>
         new SingleContextHandler(placeHolders).asProxy(Class.forName("jawn.FContext"))
       case "arrayContext" =>
@@ -111,13 +111,13 @@ class LiteralMacros(val c: whitebox.Context) {
 
     val invokeWithArg: (String, Class[_], Object) => Object = {
       case ("jnum", cls, arg: String) if cls == classOf[String] => q"""
-        _root_.io.circe.Json.fromJsonNumber(
-          _root_.io.circe.JsonNumber.fromDecimalStringUnsafe($arg)
+        _root_.io.circe.ast.Json.fromJsonNumber(
+          _root_.io.circe.ast.JsonNumber.fromDecimalStringUnsafe($arg)
         )
       """
       case ("jint", cls, arg: String) if cls == classOf[String] => q"""
-        _root_.io.circe.Json.fromJsonNumber(
-          _root_.io.circe.JsonNumber.fromIntegralStringUnsafe($arg)
+        _root_.io.circe.ast.Json.fromJsonNumber(
+          _root_.io.circe.ast.JsonNumber.fromIntegralStringUnsafe($arg)
         )
       """
       case ("jstring", cls, arg: String) if cls == classOf[String] => toJsonString(arg)

--- a/modules/literal/src/main/scala/io/circe/literal/package.scala
+++ b/modules/literal/src/main/scala/io/circe/literal/package.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.ast.Json
 import scala.language.experimental.macros
 
 package object literal {

--- a/modules/optics/src/main/scala/io/circe/optics/JsonNumberOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonNumberOptics.scala
@@ -1,14 +1,14 @@
 package io.circe.optics
 
-import io.circe.{ JsonBigDecimal, JsonLong, JsonNumber }
+import io.circe.ast.{ JsonBigDecimal, JsonLong, JsonNumber }
 import java.math.MathContext
 import monocle.Prism
 
 /**
- * Optics instances for [[io.circe.JsonObject]].
+ * Optics instances for [[io.circe.ast.JsonObject]].
  *
- * Note that the prisms for integral types will fail on [[io.circe.JsonNumber]] values representing
- * negative zero, since this would make them unlawful.
+ * Note that the prisms for integral types will fail on [[io.circe.ast.JsonNumber]] values
+ * representing negative zero, since this would make them unlawful.
  *
  * @author Sean Parsons
  * @author Travis Brown

--- a/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
@@ -1,14 +1,14 @@
 package io.circe.optics
 
 import cats.instances.list.catsStdInstancesForList
-import io.circe.{ Json, JsonObject }
+import io.circe.ast.{ Json, JsonObject }
 import monocle.{ Lens, Traversal }
 import monocle.function.{ At, Each, FilterIndex, Index }
 import scalaz.{ Applicative, Traverse }
 import scalaz.std.ListInstances
 
 /**
- * Optics instances for [[io.circe.JsonObject]].
+ * Optics instances for [[io.circe.ast.JsonObject]].
  *
  * @author Sean Parsons
  * @author Travis Brown

--- a/modules/optics/src/main/scala/io/circe/optics/JsonOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonOptics.scala
@@ -3,7 +3,7 @@ package io.circe.optics
 import cats.instances.list._
 import cats.syntax.functor._
 import cats.syntax.traverse._
-import io.circe.{ Json, JsonNumber, JsonObject }
+import io.circe.ast.{ Json, JsonNumber, JsonObject }
 import io.circe.optics.JsonNumberOptics._
 import io.circe.optics.JsonObjectOptics.objectEach
 import monocle.{ Prism, Traversal }
@@ -11,7 +11,7 @@ import monocle.function.{ Each, Plated }
 import monocle.std.list._
 
 /**
- * Optics instances for [[io.circe.Json]].
+ * Optics instances for [[io.circe.ast.Json]].
  *
  * @author Sean Parsons
  * @author Travis Brown

--- a/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
@@ -1,6 +1,7 @@
 package io.circe.optics
 
-import io.circe.{ Decoder, Encoder, Json, JsonNumber, JsonObject }
+import io.circe.{ Decoder, Encoder }
+import io.circe.ast.{ Json, JsonNumber, JsonObject }
 import io.circe.optics.JsonObjectOptics._
 import io.circe.optics.JsonOptics._
 import monocle.{ Optional, Prism, Traversal }

--- a/modules/optics/src/test/scala/io/circe/optics/DeriveWithIsoSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/DeriveWithIsoSuite.scala
@@ -1,6 +1,7 @@
 package io.circe.optics
 
 import io.circe._
+import io.circe.ast.Json
 import io.circe.generic.semiauto._
 import io.circe.syntax._
 import io.circe.tests.CirceSuite

--- a/modules/optics/src/test/scala/io/circe/optics/JsonPathSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/JsonPathSuite.scala
@@ -2,6 +2,7 @@ package io.circe.optics
 
 import cats.Eq
 import io.circe._
+import io.circe.ast.Json
 import io.circe.generic.semiauto._
 import io.circe.syntax._
 import io.circe.tests.CirceSuite

--- a/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
@@ -3,7 +3,7 @@ package io.circe.optics
 import cats.Eq
 import io.circe.optics.all._
 import io.circe.tests.CirceSuite
-import io.circe.{ Json, JsonNumber, JsonObject }
+import io.circe.ast.{ Json, JsonNumber, JsonObject }
 import monocle.function.Plated.plate
 import monocle.law.discipline.function.{ AtTests, EachTests, FilterIndexTests, IndexTests }
 import monocle.law.discipline.{ PrismTests, TraversalTests }

--- a/modules/parser/js/src/main/scala/io/circe/parser/package.scala
+++ b/modules/parser/js/src/main/scala/io/circe/parser/package.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.ast.Json
 import io.circe.scalajs.convertJsToJson
 import scala.scalajs.js.JSON
 import scala.util.control.NonFatal

--- a/modules/parser/jvm/src/main/scala/io/circe/parser/package.scala
+++ b/modules/parser/jvm/src/main/scala/io/circe/parser/package.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.ast.Json
 import io.circe.jawn.JawnParser
 
 package object parser extends Parser {

--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -1,13 +1,14 @@
 package io.circe
 
-import io.circe.Json._
+import io.circe.ast.Json
+import io.circe.ast.Json._
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.{ JSRichGenMap, JSRichGenTraversableOnce }
 import scala.util.control.NonFatal
 
 package object scalajs {
   /**
-   * Attempt to convert a value to [[Json]].
+   * Attempt to convert a value to [[io.circe.ast.Json]].
    */
   private[this] def unsafeConvertAnyToJson(input: Any): Json = input match {
     case s: String => Json.fromString(s)
@@ -23,7 +24,7 @@ package object scalajs {
   }
 
   /**
-   * Convert [[scala.scalajs.js.Any]] to [[Json]].
+   * Convert [[scala.scalajs.js.Any]] to [[io.circe.ast.Json]].
    */
   final def convertJsToJson(input: js.Any): Either[Throwable, Json] =
     try Right(unsafeConvertAnyToJson(input)) catch {
@@ -40,7 +41,7 @@ package object scalajs {
     }
 
   /**
-   * Convert [[Json]] to [[scala.scalajs.js.Any]].
+   * Convert [[io.circe.ast.Json]] to [[scala.scalajs.js.Any]].
    */
   final def convertJsonToJs(input: Json): js.Any = input match {
     case JString(s) => s

--- a/modules/shapes/src/main/scala/io/circe/shapes/CoproductInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/CoproductInstances.scala
@@ -1,6 +1,7 @@
 package io.circe.shapes
 
-import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json }
+import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor }
+import io.circe.ast.Json
 import shapeless.{ :+:, CNil, Coproduct, Inl, Inr }
 
 trait CoproductInstances {

--- a/modules/shapes/src/main/scala/io/circe/shapes/HListInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/HListInstances.scala
@@ -1,6 +1,7 @@
 package io.circe.shapes
 
-import io.circe.{ AccumulatingDecoder, ArrayEncoder, Decoder, Encoder, HCursor, Json, JsonObject, ObjectEncoder }
+import io.circe.{ AccumulatingDecoder, ArrayEncoder, Decoder, Encoder, HCursor, ObjectEncoder }
+import io.circe.ast.{ Json, JsonObject }
 import shapeless.{ ::, HList, HNil }
 
 trait HListInstances extends LowPriorityHListInstances {

--- a/modules/shapes/src/main/scala/io/circe/shapes/LabelledCoproductInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/LabelledCoproductInstances.scala
@@ -1,7 +1,8 @@
 package io.circe.shapes
 
 import cats.Eq
-import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json, KeyDecoder, KeyEncoder }
+import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, KeyDecoder, KeyEncoder }
+import io.circe.ast.Json
 import shapeless.{ :+:, Coproduct, Inl, Inr, Widen, Witness }
 import shapeless.labelled.{ field, FieldType }
 

--- a/modules/shapes/src/main/scala/io/circe/shapes/LabelledHListInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/LabelledHListInstances.scala
@@ -8,11 +8,11 @@ import io.circe.{
   DecodingFailure,
   Encoder,
   HCursor,
-  JsonObject,
   KeyDecoder,
   KeyEncoder,
   ObjectEncoder
 }
+import io.circe.ast.JsonObject
 import shapeless.{ ::, HList, Widen, Witness }
 import shapeless.labelled.{ field, FieldType }
 

--- a/modules/spray/src/main/scala/io/circe/spray/JsonSupport.scala
+++ b/modules/spray/src/main/scala/io/circe/spray/JsonSupport.scala
@@ -1,7 +1,8 @@
 package io.circe.spray
 
 import cats.data.Validated
-import io.circe.{ Errors, Printer, RootEncoder }
+import io.circe.{ Errors, RootEncoder }
+import io.circe.ast.Printer
 import io.circe.jawn._
 import spray.http.{ ContentTypes, HttpCharsets, HttpEntity, MediaTypes }
 import spray.httpx.marshalling.Marshaller

--- a/modules/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
+++ b/modules/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
@@ -5,7 +5,8 @@ import cats.ApplicativeError
 import cats.instances.either._
 import cats.instances.list._
 import cats.syntax.traverse._
-import io.circe.{ Json, ParsingFailure }
+import io.circe.ParsingFailure
+import io.circe.ast.Json
 import io.circe.jawn.CirceSupportParser
 import io.iteratee.Enumeratee
 import io.iteratee.internal.Step

--- a/modules/streaming/src/main/scala/io/circe/streaming/package.scala
+++ b/modules/streaming/src/main/scala/io/circe/streaming/package.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import _root_.jawn.{ AsyncParser, ParseException }
 import cats.{ ApplicativeError, MonadError }
+import io.circe.ast.Json
 import io.circe.jawn.CirceSupportParser
 import io.iteratee.{ Enumeratee, Enumerator }
 
@@ -20,7 +21,7 @@ package object streaming {
 
   final def decoder[F[_], A](implicit F: MonadError[F, Throwable], decode: Decoder[A]): Enumeratee[F, Json, A] =
     Enumeratee.flatMap(json =>
-      decode(json.hcursor) match {
+      decode(HCursor.fromJson(json)) match {
         case Left(df) => Enumerator.liftM(F.raiseError(df))
         case Right(a) => Enumerator.enumOne(a)
       }

--- a/modules/testing/js/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
+++ b/modules/testing/js/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
@@ -1,6 +1,6 @@
 package io.circe.testing
 
-import io.circe.JsonNumber
+import io.circe.ast.JsonNumber
 import scala.scalajs.js.JSON
 import scala.util.Try
 

--- a/modules/testing/jvm/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
+++ b/modules/testing/jvm/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
@@ -1,6 +1,6 @@
 package io.circe.testing
 
-import io.circe.JsonNumber
+import io.circe.ast.JsonNumber
 
 private[testing] trait ArbitraryJsonNumberTransformer {
   def transformJsonNumber(n: JsonNumber): JsonNumber = n

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -2,7 +2,8 @@ package io.circe.testing
 
 import cats.data.ValidatedNel
 import cats.laws.discipline.arbitrary._
-import io.circe._
+import io.circe.{ AccumulatingDecoder, Decoder, DecodingFailure, Encoder }
+import io.circe.ast.{ Json, JsonBigDecimal, JsonBiggerDecimal, JsonDouble, JsonLong, JsonNumber, JsonObject }
 import io.circe.numbers.BiggerDecimal
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
 import org.scalacheck.Arbitrary.arbitrary

--- a/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
@@ -4,7 +4,8 @@ import cats.Eq
 import cats.instances.either._
 import cats.laws._
 import cats.laws.discipline._
-import io.circe.{ Decoder, Encoder, Json }
+import io.circe.{ Decoder, Encoder, HCursor }
+import io.circe.ast.Json
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
 import org.typelevel.discipline.Laws
@@ -14,10 +15,10 @@ trait CodecLaws[A] {
   def encode: Encoder[A]
 
   def codecRoundTrip(a: A): IsEq[Decoder.Result[A]] =
-    encode(a).as(decode) <-> Right(a)
+    decode.decodeJson(encode(a)) <-> Right(a)
 
   def codecAccumulatingConsistency(json: Json): IsEq[Decoder.Result[A]] =
-    decode(json.hcursor) <-> decode.accumulating(json.hcursor).leftMap(_.head).toEither
+    decode(HCursor.fromJson(json)) <-> decode.accumulating(HCursor.fromJson(json)).leftMap(_.head).toEither
 }
 
 object CodecLaws {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/CogenInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/CogenInstances.scala
@@ -1,6 +1,7 @@
 package io.circe.testing
 
-import io.circe.{ DecodingFailure, Json, JsonNumber, JsonObject }
+import io.circe.DecodingFailure
+import io.circe.ast.{ Json, JsonNumber, JsonObject }
 import org.scalacheck.Cogen
 
 private[testing] trait CogenInstances {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/EqInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/EqInstances.scala
@@ -3,7 +3,8 @@ package io.circe.testing
 import cats.Eq
 import cats.instances.either._
 import cats.syntax.eq._
-import io.circe.{ AccumulatingDecoder, Decoder, Encoder, Json }
+import io.circe.{ AccumulatingDecoder, Decoder, Encoder, HCursor }
+import io.circe.ast.Json
 import org.scalacheck.Arbitrary
 
 trait EqInstances { this: ArbitraryInstances =>
@@ -22,10 +23,14 @@ trait EqInstances { this: ArbitraryInstances =>
   }
 
   implicit def eqDecoder[A: Eq]: Eq[Decoder[A]] = Eq.instance { (d1, d2) =>
-    arbitraryValues[Json].take(codecEqualityCheckCount).forall(json => d1(json.hcursor) === d2(json.hcursor))
+    arbitraryValues[Json].take(codecEqualityCheckCount).forall(json =>
+      d1(HCursor.fromJson(json)) === d2(HCursor.fromJson(json))
+    )
   }
 
   implicit def eqAccumulatingDecoder[A: Eq]: Eq[AccumulatingDecoder[A]] = Eq.instance { (d1, d2) =>
-    arbitraryValues[Json].take(codecEqualityCheckCount).forall(json => d1(json.hcursor) === d2(json.hcursor))
+    arbitraryValues[Json].take(codecEqualityCheckCount).forall(json =>
+      d1(HCursor.fromJson(json)) === d2(HCursor.fromJson(json))
+    )
   }
 }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
@@ -4,7 +4,8 @@ import cats.data.{ Validated, ValidatedNel }
 import cats.instances.either._
 import cats.laws._
 import cats.laws.discipline._
-import io.circe.{ Error, Json, Parser, ParsingFailure }
+import io.circe.{ Error, Parser, ParsingFailure }
+import io.circe.ast.Json
 import org.scalacheck.{ Arbitrary, Prop }
 import org.typelevel.discipline.Laws
 

--- a/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
@@ -4,7 +4,8 @@ import cats.Eq
 import cats.instances.option._
 import cats.laws._
 import cats.laws.discipline._
-import io.circe.{ Decoder, Encoder, Parser, Printer }
+import io.circe.{ Decoder, Encoder, Parser }
+import io.circe.ast.Printer
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
 import org.typelevel.discipline.Laws

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ShrinkInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ShrinkInstances.scala
@@ -1,6 +1,6 @@
 package io.circe.testing
 
-import io.circe.{ Json, JsonBigDecimal, JsonNumber, JsonObject }
+import io.circe.ast.{ Json, JsonBigDecimal, JsonNumber, JsonObject }
 import org.scalacheck.Shrink
 
 private[testing] trait ShrinkInstances {

--- a/modules/tests/jvm/src/test/scala/io/circe/LargeNumberDecoderTests.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/LargeNumberDecoderTests.scala
@@ -11,13 +11,13 @@ trait LargeNumberDecoderTests { this: CirceSuite =>
     val zeros = "0" * (math.abs(n.toInt) + 1)
     val Right(json) = parse(s"$v.$zeros")
 
-    assert(Decoder[Long].apply(json.hcursor) === Right(v))
+    assert(Decoder[Long].decodeJson(json) === Right(v))
   }
 
   "Decoder[BigInt]" should "succeed on whole decimal values (#83)" in forAll { (v: BigInt, n: Byte) =>
     val zeros = "0" * (math.abs(n.toInt) + 1)
     val Right(json) = parse(s"$v.$zeros")
 
-    assert(Decoder[BigInt].apply(json.hcursor) === Right(v))
+    assert(Decoder[BigInt].decodeJson(json) === Right(v))
   }
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/MemoizedPiecesSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/MemoizedPiecesSuite.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.ast.Printer
 import io.circe.tests.CirceSuite
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest.concurrent.ScalaFutures

--- a/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.ast.{ Json, Printer }
 import scala.io.Source
 import scala.util.Random
 

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonInstances.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonInstances.scala
@@ -3,7 +3,7 @@ package io.circe.jackson
 import cats.Eq
 import cats.instances.list._
 import cats.instances.map._
-import io.circe.{
+import io.circe.ast.{
   Json,
   JsonBigDecimal,
   JsonBiggerDecimal,
@@ -12,7 +12,7 @@ import io.circe.{
   JsonLong,
   JsonNumber
 }
-import io.circe.Json.{ JArray, JNumber, JObject, JString }
+import io.circe.ast.Json.{ JArray, JNumber, JObject, JString }
 import io.circe.numbers.BiggerDecimal
 import io.circe.testing.ArbitraryInstances
 import org.scalacheck.Arbitrary

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
@@ -1,7 +1,7 @@
 package io.circe.jackson
 
 import cats.data.Validated
-import io.circe.Json
+import io.circe.ast.Json
 import io.circe.testing.ParserTests
 import io.circe.tests.CirceSuite
 import io.circe.tests.examples.glossary

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
@@ -1,6 +1,6 @@
 package io.circe.jackson
 
-import io.circe.Json
+import io.circe.ast.Json
 import io.circe.tests.CirceSuite
 
 class JacksonPrintingSuite extends CirceSuite with JacksonInstances {

--- a/modules/tests/jvm/src/test/scala/io/circe/jawn/JawnParserSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jawn/JawnParserSuite.scala
@@ -1,7 +1,7 @@
 package io.circe.jawn
 
 import cats.data.Validated
-import io.circe.Json
+import io.circe.ast.Json
 import io.circe.testing.ParserTests
 import io.circe.tests.CirceSuite
 import io.circe.tests.examples.glossary

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CursorSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CursorSuite.scala
@@ -1,7 +1,8 @@
 package io.circe.tests
 
 import cats.Eq
-import io.circe.{ GenericCursor, Json }
+import io.circe.{ Decoder, GenericCursor }
+import io.circe.ast.Json
 import io.circe.syntax._
 
 abstract class CursorSuite[C <: GenericCursor[C]](implicit
@@ -225,7 +226,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
     val result = for {
       c <- fromResult(cursor.downField("a"))
       a <- fromResult(c.downN(3))
-      l <- fromResult(a.leftAt(_.as[Int].right.exists(_ == 1)))
+      l <- fromResult(a.leftAt(Decoder[Int].decodeJson(_).right.exists(_ == 1)))
     } yield l
 
     assert(result.flatMap(focus) === Some(1.asJson))
@@ -234,7 +235,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
   it should "fail to select a value that doesn't exist" in {
     val result = for {
       c <- fromResult(cursor.downField("b"))
-      l <- fromResult(c.leftAt(_.as[Int].right.exists(_ == 1)))
+      l <- fromResult(c.leftAt(Decoder[Int].decodeJson(_).right.exists(_ == 1)))
     } yield l
 
     assert(result.flatMap(focus) === None)
@@ -244,7 +245,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
     val result = for {
       c <- fromResult(cursor.downField("a"))
       a <- fromResult(c.downN(3))
-      r <- fromResult(a.rightAt(_.as[Int].right.exists(_ == 5)))
+      r <- fromResult(a.rightAt(Decoder[Int].decodeJson(_).right.exists(_ == 5)))
     } yield r
 
     assert(result.flatMap(focus) === Some(5.asJson))
@@ -253,7 +254,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
   it should "fail to select a value that doesn't exist" in {
     val result = for {
       c <- fromResult(cursor.downField("b"))
-      r <- fromResult(c.rightAt(_.as[Int].right.exists(_ == 5)))
+      r <- fromResult(c.rightAt(Decoder[Int].decodeJson(_).right.exists(_ == 5)))
     } yield r
 
     assert(result.flatMap(focus) === None)

--- a/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -1,6 +1,7 @@
 package io.circe.tests
 
-import io.circe.{ Parser, Printer }
+import io.circe.Parser
+import io.circe.ast.Printer
 import io.circe.testing.PrinterTests
 
 class PrinterSuite(printer: Printer, parser: Parser) extends CirceSuite {

--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -2,7 +2,8 @@ package io.circe.tests
 
 import cats.Eq
 import cats.instances.AllInstances
-import io.circe.{ Decoder, Encoder, Json }
+import io.circe.{ Decoder, Encoder }
+import io.circe.ast.Json
 import io.circe.testing.ArbitraryInstances
 import org.scalacheck.{ Arbitrary, Gen }
 

--- a/modules/tests/shared/src/test/scala/io/circe/AccumulatingDecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/AccumulatingDecoderSuite.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.data.NonEmptyList
 import cats.laws.discipline.{ ApplicativeErrorTests, SemigroupKTests }
 import cats.laws.discipline.arbitrary._
+import io.circe.ast.{ Json, JsonObject }
 import io.circe.generic.semiauto._
 import io.circe.syntax._
 import io.circe.tests.CirceSuite
@@ -33,7 +34,7 @@ class AccumulatingDecoderSpec extends CirceSuite {
   "accumulating" should "return as many errors as invalid elements in a list" in {
     forAll { (xs: List[Either[Int, String]]) =>
       val json = xs.map(_.fold(Json.fromInt, Json.fromString)).asJson
-      val decoded = Decoder[List[String]].accumulating(json.hcursor)
+      val decoded = Decoder[List[String]].accumulating(HCursor.fromJson(json))
       val intElems = xs.collect { case Left(elem) => elem }
 
       assert(decoded.fold(_.tail.size + 1, _ => 0) === intElems.size)
@@ -42,7 +43,7 @@ class AccumulatingDecoderSpec extends CirceSuite {
 
   it should "return expected failures in a list" in {
     forAll { (xs: List[Either[Int, String]]) =>
-      val cursor = xs.map(_.fold(Json.fromInt, Json.fromString)).asJson.hcursor
+      val cursor = HCursor.fromJson(xs.map(_.fold(Json.fromInt, Json.fromString)).asJson)
       val invalidElems = xs.collect { case Left(e) => Some(e.asJson) }
       val errors = Decoder[List[String]].accumulating(cursor).fold(_.toList, _ => Nil)
 
@@ -52,7 +53,7 @@ class AccumulatingDecoderSpec extends CirceSuite {
 
   it should "return expected failures in a map" in {
     forAll { (xs: Map[String, Either[Int, String]]) =>
-      val cursor = xs.map { case (k, v) => (k, v.fold(Json.fromInt, Json.fromString)) }.asJson.hcursor
+      val cursor = HCursor.fromJson(xs.map { case (k, v) => (k, v.fold(Json.fromInt, Json.fromString)) }.asJson)
       val invalidElems = xs.values.collect { case Left(e) => e.asJson }.toSet
       val errors = Decoder[Map[String, String]].accumulating(cursor).fold(_.toList, _ => Nil)
 
@@ -62,7 +63,7 @@ class AccumulatingDecoderSpec extends CirceSuite {
 
   it should "return expected failures in a set" in {
     forAll { (xs: Set[Either[Int, String]]) =>
-      val cursor = xs.map(_.fold(Json.fromInt, Json.fromString)).asJson.asJson.hcursor
+      val cursor = HCursor.fromJson(xs.map(_.fold(Json.fromInt, Json.fromString)).asJson)
       val invalidElems = xs.collect { case Left(e) => Some(e.asJson): Option[Json] }
       val errors = Decoder[Set[String]].accumulating(cursor).fold(_.toList, _ => Nil)
 
@@ -72,7 +73,7 @@ class AccumulatingDecoderSpec extends CirceSuite {
 
   it should "return expected failures in a non-empty list" in {
     forAll { (xs: NonEmptyList[Either[Int, String]]) =>
-      val cursor = xs.map(_.fold(Json.fromInt, Json.fromString)).asJson.asJson.hcursor
+      val cursor = HCursor.fromJson(xs.map(_.fold(Json.fromInt, Json.fromString)).asJson)
       val invalidElems = xs.toList.collect { case Left(e) => Some(e.asJson) }
       val errors = Decoder[NonEmptyList[String]].accumulating(cursor).fold(_.toList, _ => Nil)
 
@@ -82,12 +83,14 @@ class AccumulatingDecoderSpec extends CirceSuite {
 
   it should "return expected failures in a tuple" in {
     forAll { (xs: (Either[Int, String], Either[Int, String], Either[Int, String])) =>
-      val cursor = (
-        xs._1.fold(Json.fromInt, Json.fromString),
-        xs._2.fold(Json.fromInt, Json.fromString),
-        xs._3.fold(Json.fromInt, Json.fromString)
-      ).asJson.hcursor
-      
+      val cursor = HCursor.fromJson(
+        (
+          xs._1.fold(Json.fromInt, Json.fromString),
+          xs._2.fold(Json.fromInt, Json.fromString),
+          xs._3.fold(Json.fromInt, Json.fromString)
+        ).asJson
+      )
+
       val invalidElems = xs.productIterator.toList.collect {
         case Left(e: Int) => Some(e.asJson)
       }
@@ -100,7 +103,7 @@ class AccumulatingDecoderSpec extends CirceSuite {
 
   it should "return expected failures in a case class" in {
     forAll { (a: Int, b: Boolean, c: Int) =>
-      val cursor = BadSample(a, b, c).asJson.hcursor
+      val cursor = HCursor.fromJson(BadSample(a, b, c).asJson)
       val invalidElems = List(Some(a.asJson), Some(b.asJson), Some(c.asJson))
       val errors = Decoder[Sample].accumulating(cursor).fold(_.toList, _ => Nil)
 
@@ -109,7 +112,9 @@ class AccumulatingDecoderSpec extends CirceSuite {
   }
 
   it should "return as many errors as invalid elements in a partial case class" in {
-    val decoded = deriveFor[Int => Qux[String]].incomplete.accumulating(Json.fromJsonObject(JsonObject.empty).hcursor)
+    val decoded = deriveFor[Int => Qux[String]].incomplete.accumulating(
+      HCursor.fromJson(Json.fromJsonObject(JsonObject.empty))
+    )
 
     assert(decoded.fold(_.tail.size + 1, _ => 0) === 2)
   }

--- a/modules/tests/shared/src/test/scala/io/circe/CursorSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CursorSuites.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.instances.list._
+import io.circe.ast.Json
 import io.circe.tests.CursorSuite
 
 class BasicCursorSuite extends CursorSuite[Cursor] {
@@ -11,7 +12,7 @@ class BasicCursorSuite extends CursorSuite[Cursor] {
 }
 
 class HCursorSuite extends CursorSuite[HCursor] {
-  def fromJson(j: Json): HCursor = j.hcursor
+  def fromJson(j: Json): HCursor = HCursor.fromJson(j)
   def top(c: HCursor): Option[Json] = Some(c.top)
   def focus(c: HCursor): Option[Json] = Some(c.focus)
   def fromResult(result: ACursor): Option[HCursor] = result.success
@@ -28,7 +29,7 @@ class HCursorSuite extends CursorSuite[HCursor] {
 }
 
 class ACursorSuite extends CursorSuite[ACursor] {
-  def fromJson(j: Json): ACursor = j.hcursor.acursor
+  def fromJson(j: Json): ACursor = HCursor.fromJson(j).acursor
   def top(c: ACursor): Option[Json] = c.top
   def focus(c: ACursor): Option[Json] = c.focus
   def fromResult(result: ACursor): Option[ACursor] = result.success.map(_.acursor)

--- a/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.laws.discipline.ContravariantTests
+import io.circe.ast.Json
 import io.circe.syntax._
 import io.circe.tests.CirceSuite
 
@@ -12,7 +13,7 @@ class EncoderSuite extends CirceSuite {
       _.withObject(obj => Json.fromJsonObject(obj.add(k, v.asJson)))
     )
 
-    assert(Decoder[Map[String, Int]].apply(newEncoder(m).hcursor) === Right(m.updated(k, v)))
+    assert(Decoder[Map[String, Int]].decodeJson(newEncoder(m)) === Right(m.updated(k, v)))
   }
 
   "Encoder[Enumeration]" should "write Scala Enumerations" in {
@@ -24,7 +25,7 @@ class EncoderSuite extends CirceSuite {
     implicit val encoder = Encoder.enumEncoder(WeekDay)
     val json = WeekDay.Fri.asJson
     val decoder = Decoder.enumDecoder(WeekDay)
-    assert(decoder.apply(json.hcursor) == Right(WeekDay.Fri))
+    assert(decoder.decodeJson(json) == Right(WeekDay.Fri))
   }
 
   "encodeSet" should "match sequence encoders" in forAll { (xs: Set[Int]) =>

--- a/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.ast.{ Json, JsonNumber }
 import io.circe.testing.JsonNumberString
 import io.circe.tests.CirceSuite
 import scala.math.{ min, max }

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.ast.{ Json, JsonObject }
 import io.circe.tests.CirceSuite
 import cats.data.Const
 

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -1,6 +1,7 @@
 package io.circe
 
-import io.circe.Json.{JString, JArray, JNumber, JBoolean, JObject, JNull}
+import io.circe.ast.{ Json, JsonLong, JsonObject }
+import io.circe.ast.Json.{ JString, JArray, JNumber, JBoolean, JObject, JNull }
 import io.circe.tests.CirceSuite
 
 class JsonSuite extends CirceSuite {

--- a/modules/tests/shared/src/test/scala/io/circe/ObjectEncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/ObjectEncoderSuite.scala
@@ -7,6 +7,6 @@ class ObjectEncoderSuite extends CirceSuite {
   "mapJsonObject" should "transform encoded output" in forAll { (m: Map[String, Int], k: String, v: Int) =>
     val newEncoder = ObjectEncoder[Map[String, Int]].mapJsonObject(_.add(k, v.asJson))
 
-    assert(Decoder[Map[String, Int]].apply(newEncoder(m).hcursor) === Right(m.updated(k, v)))
+    assert(Decoder[Map[String, Int]].decodeJson(newEncoder(m)) === Right(m.updated(k, v)))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.ast.Printer
 import io.circe.tests.PrinterSuite
 
 class Spaces2PrinterSuite extends PrinterSuite(Printer.spaces2, parser.`package`) with Spaces2PrinterExample

--- a/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.laws.SerializableLaws
 import cats.laws.discipline.SerializableTests
+import io.circe.ast.{ Json, Printer }
 import io.circe.tests.CirceSuite
 
 class SerializableSuite extends CirceSuite {
@@ -10,15 +11,15 @@ class SerializableSuite extends CirceSuite {
   }
 
   "Cursor" should "be serializable" in forAll { (j: Json) =>
-    SerializableLaws.serializable(j.cursor); ()
+    SerializableLaws.serializable(Cursor(j)); ()
   }
 
   "HCursor" should "be serializable" in forAll { (j: Json) =>
-    SerializableLaws.serializable(j.hcursor); ()
+    SerializableLaws.serializable(HCursor.fromJson(j)); ()
   }
 
   "ACursor" should "be serializable" in forAll { (j: Json) =>
-    SerializableLaws.serializable(ACursor.ok(j.hcursor)); ()
+    SerializableLaws.serializable(ACursor.ok(HCursor.fromJson(j))); ()
   }
 
   checkLaws("Decoder[Int]", SerializableTests.serializable(Decoder[Int]))

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -1,7 +1,8 @@
 package io.circe.generic.extras
 
 import cats.Eq
-import io.circe.{ Decoder, Encoder, Json }
+import io.circe.{ Decoder, Encoder }
+import io.circe.ast.Json
 import io.circe.generic.extras.auto._
 import io.circe.literal._
 import io.circe.testing.CodecTests
@@ -81,10 +82,12 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
   checkLaws("Codec[Foo]", CodecTests[Foo].codec)
 
   "Decoder[Int => Qux[String]]" should "decode partial JSON representations" in forAll { (i: Int, s: String, j: Int) =>
-    val result = Json.obj(
-      "a" -> Json.fromString(s),
-      "j" -> Json.fromInt(j)
-    ).as[Int => Qux[String]].map(_(i))
+    val result = Decoder[Int => Qux[String]].decodeJson(
+      Json.obj(
+        "a" -> Json.fromString(s),
+        "j" -> Json.fromInt(j)
+      )
+    ).map(_(i))
 
     assert(result === Right(Qux(i, s, j)))
   }

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
@@ -1,7 +1,8 @@
 package io.circe.generic.extras
 
 import cats.Eq
-import io.circe.{ Decoder, Encoder, Json, ObjectEncoder }
+import io.circe.{ Decoder, Encoder, ObjectEncoder }
+import io.circe.ast.Json
 import io.circe.generic.extras.semiauto._
 import io.circe.literal._
 import io.circe.tests.CirceSuite
@@ -53,22 +54,24 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite {
   }
 
   "Decoder[Int => Qux[String]]" should "decode partial JSON representations" in forAll { (i: Int, s: String, j: Int) =>
-    val result = Json.obj(
-      "a" -> Json.fromString(s),
-      "j" -> Json.fromInt(j)
-    ).as[Int => Qux[String]].map(_(i))
+    val result = Decoder[Int => Qux[String]].decodeJson(
+      Json.obj(
+        "a" -> Json.fromString(s),
+        "j" -> Json.fromInt(j)
+      )
+    ).map(_(i))
 
     assert(result === Right(Qux(i, s, j)))
   }
 
   "Decoder[FieldType[Witness.`'j`.T, Int] => Qux[String]]" should "decode partial JSON representations" in {
     forAll { (i: Int, s: String, j: Int) =>
-      val result = Json.obj(
-        "i" -> Json.fromInt(i),
-        "a" -> Json.fromString(s)
-      ).as[FieldType[Witness.`'j`.T, Int] => Qux[String]].map(
-         _(field(j))
-      )
+      val result = Decoder[FieldType[Witness.`'j`.T, Int] => Qux[String]].decodeJson(
+        Json.obj(
+          "i" -> Json.fromInt(i),
+          "a" -> Json.fromString(s)
+        )
+      ).map(_(field(j)))
 
       assert(result === Right(Qux(i, s, j)))
     }
@@ -84,7 +87,7 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite {
 
       val expected = Qux[String](i.getOrElse(q.i), a.getOrElse(q.a), j.getOrElse(q.j))
 
-      assert(json.as[Qux[String] => Qux[String]].map(_(q)) === Right(expected))
+      assert(Decoder[Qux[String] => Qux[String]].decodeJson(json).map(_(q)) === Right(expected))
     }
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/literal/LiteralInstancesSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/literal/LiteralInstancesSuite.scala
@@ -19,42 +19,42 @@ class LiteralInstancesSuite extends CirceSuite {
   "A literal String codec" should "round-trip values" in {
     val w = Witness("foo")
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
+    assert(Decoder[w.T].decodeJson(Encoder[w.T].apply(w.value)) === Right(w.value))
   }
 
   "A literal Boolean codec" should "round-trip values" in {
     val w = Witness(true)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
+    assert(Decoder[w.T].decodeJson(Encoder[w.T].apply(w.value)) === Right(w.value))
   }
 
   "A literal Float codec" should "round-trip values" in {
     val w = Witness(0.0F)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
+    assert(Decoder[w.T].decodeJson(Encoder[w.T].apply(w.value)) === Right(w.value))
   }
 
   "A literal Double codec" should "round-trip values" in {
     val w = Witness(0.0)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
+    assert(Decoder[w.T].decodeJson(Encoder[w.T].apply(w.value)) === Right(w.value))
   }
 
   "A literal Char codec" should "round-trip values" in {
     val w = Witness('a')
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
+    assert(Decoder[w.T].decodeJson(Encoder[w.T].apply(w.value)) === Right(w.value))
   }
 
   "A literal Int codec" should "round-trip values" in {
     val w = Witness(0)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
+    assert(Decoder[w.T].decodeJson(Encoder[w.T].apply(w.value)) === Right(w.value))
   }
 
   "A literal Long codec" should "round-trip values" in {
     val w = Witness(0L)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
+    assert(Decoder[w.T].decodeJson(Encoder[w.T].apply(w.value)) === Right(w.value))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
@@ -1,6 +1,6 @@
 package io.circe.parser
 
-import io.circe.Json
+import io.circe.ast.Json
 import io.circe.testing.ParserTests
 import io.circe.tests.CirceSuite
 

--- a/modules/tests/shared/src/test/scala/io/circe/refined/RefinedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/refined/RefinedSuite.scala
@@ -8,7 +8,8 @@ import eu.timepit.refined.numeric.{ Positive, Greater }
 import eu.timepit.refined.collection.{ NonEmpty, Size }
 import eu.timepit.refined.scalacheck.numeric.greaterArbitraryWit
 import eu.timepit.refined.scalacheck.string.startsWithArbitrary
-import io.circe.{ Decoder, Encoder, Json }
+import io.circe.{ Decoder, Encoder }
+import io.circe.ast.Json
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
 import io.circe.syntax._

--- a/modules/tests/shared/src/test/scala/io/circe/shapes/ShapelessSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/shapes/ShapelessSuite.scala
@@ -1,6 +1,6 @@
 package io.circe.shapes
 
-import io.circe.{ Decoder, Encoder }
+import io.circe.{ Decoder, Encoder, HCursor }
 import io.circe.literal._
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
@@ -40,7 +40,7 @@ class ShapelessSuite extends CirceSuite {
   }
 
   it should "accumulated errors" in forAll { (foo: String, bar: Int, baz: List[Char]) =>
-    val result = hlistDecoder.accumulating(json"""[ $foo, $baz, $bar ]""".hcursor)
+    val result = hlistDecoder.accumulating(HCursor.fromJson(json"""[ $foo, $baz, $bar ]"""))
 
     assert(result.swap.exists(_.size == 2))
   }
@@ -55,7 +55,7 @@ class ShapelessSuite extends CirceSuite {
   }
 
   it should "accumulated errors" in forAll { (foo: String, bar: Int) =>
-    val result = recordDecoder.accumulating(json"""{ "foo": $bar, "bar": $foo }""".hcursor)
+    val result = recordDecoder.accumulating(HCursor.fromJson(json"""{ "foo": $bar, "bar": $foo }"""))
 
     assert(result.swap.exists(_.size == 2))
   }
@@ -70,7 +70,7 @@ class ShapelessSuite extends CirceSuite {
   }
 
   it should "accumulated errors" in forAll { (a: Int, b: String, c: Int, d: String) =>
-    val result = sizedDecoder.accumulating(json"""[ $a, $b, $c, $d ]""".hcursor)
+    val result = sizedDecoder.accumulating(HCursor.fromJson(json"""[ $a, $b, $c, $d ]"""))
 
     assert(result.swap.exists(_.size == 2))
   }

--- a/modules/tests/shared/src/test/scala/io/circe/syntax/SyntaxSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/syntax/SyntaxSuite.scala
@@ -1,6 +1,7 @@
 package io.circe.syntax
 
-import io.circe.{ Encoder, Json }
+import io.circe.Encoder
+import io.circe.ast.Json
 import io.circe.tests.CirceSuite
 
 class SyntaxSuite extends CirceSuite {

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -167,6 +167,8 @@ object Boilerplate {
       block"""
         |package io.circe
         |
+        |import io.circe.ast.Json
+        |
         |private[circe] trait TupleEncoders {
         -  /**
         -   * @group Tuple
@@ -268,6 +270,8 @@ object Boilerplate {
 
       block"""
         |package io.circe
+        |
+        |import io.circe.ast.JsonObject
         |
         |private[circe] trait ProductEncoders {
         -  /**


### PR DESCRIPTION
As suggested by @adelbertc [on Gitter this evening](https://gitter.im/travisbrown/circe?at=583388cec0a2732923ffeca6).

I'm not 100% sold on this, but even apart from the fact that you can use the AST without bringing in the rest of the project, I like the fact that it gets rid of some of the circularity and multiple-ways-of-doing-things in the API.

The fact that we need to move core types to a new package is kind of a drag, but we could provide aliases in `io.circe` to make the transition less painful.

I'm interested in any feedback. If we want to move forward with this, the one additional thing that would need to be done for this PR is some test rearrangement.