### PR TITLE
Fix inappropriately failing test in circe-shapes

### DIFF
--- a/modules/tests/shared/src/test/scala/io/circe/shapes/ShapelessSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/shapes/ShapelessSuite.scala
@@ -39,7 +39,7 @@ class ShapelessSuite extends CirceSuite {
     assert(result === Right(expected))
   }
 
-  it should "accumulated errors" in forAll { (foo: String, bar: Int, baz: List[Char]) =>
+  it should "accumulate errors" in forAll { (foo: String, bar: Int, baz: List[Char]) =>
     val result = hlistDecoder.accumulating(json"""[ $foo, $baz, $bar ]""".hcursor)
 
     assert(result.swap.exists(_.size == 2))
@@ -54,7 +54,7 @@ class ShapelessSuite extends CirceSuite {
     assert(result === Right(expected))
   }
 
-  it should "accumulated errors" in forAll { (foo: String, bar: Int) =>
+  it should "accumulate errors" in forAll { (foo: String, bar: Int) =>
     val result = recordDecoder.accumulating(json"""{ "foo": $bar, "bar": $foo }""".hcursor)
 
     assert(result.swap.exists(_.size == 2))
@@ -69,8 +69,10 @@ class ShapelessSuite extends CirceSuite {
     assert(result.isLeft)
   }
 
-  it should "accumulated errors" in forAll { (a: Int, b: String, c: Int, d: String) =>
-    val result = sizedDecoder.accumulating(json"""[ $a, $b, $c, $d ]""".hcursor)
+  it should "accumulate errors" in forAll { (a: Int, b: String, c: Int, d: String) =>
+    val notIntB = b + "z"
+    val notIntD = "a" + d
+    val result = sizedDecoder.accumulating(json"""[ $a, $notIntB, $c, $notIntD ]""".hcursor)
 
     assert(result.swap.exists(_.size == 2))
   }


### PR DESCRIPTION
The `Sized` test here was failing in CI in a case where one of the strings happened to be a valid integer. I've also thrown in some typo fixes.