### PR TITLE
Make logo in header scale down

### DIFF
--- a/docs/src/main/resources/microsite/css/override.css
+++ b/docs/src/main/resources/microsite/css/override.css
@@ -9,3 +9,9 @@
 .sidebar-nav > .sidebar-brand a .brand-wrapper {
   background-size: 36px 36px !important;
 }
+
+#site-header .navbar-wrapper .brand .icon-wrapper {
+  width: 36px;
+  background-size: 100%;
+}
+


### PR DESCRIPTION
The background logo image isn't scaled in all the browsers I've tried on my Linux desktop. This seems to fix the issue, and looks the same on OS X. /cc @jonas