### PR TITLE
Don't count the negative sign against digit budget for toBigInteger

### DIFF
--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -87,7 +87,7 @@ private[numbers] final class SigAndExp(
 
   def toBigIntegerWithMaxDigits(maxDigits: BigInteger): Option[BigInteger] =
     if (!isWhole) None else {
-      val digits = BigInteger.valueOf(unscaled.toString.length.toLong).subtract(scale)
+      val digits = BigInteger.valueOf(unscaled.abs.toString.length.toLong).subtract(scale)
 
       if (digits.compareTo(BiggerDecimal.MaxBigIntegerDigits) > 0) None else Some(
         new BigDecimal(unscaled, scale.intValue).toBigInteger

--- a/modules/tests/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -1,7 +1,7 @@
 package io.circe.numbers
 
 import io.circe.testing.{ IntegralString, JsonNumberString }
-import java.math.BigDecimal
+import java.math.{ BigDecimal, BigInteger }
 import org.scalatest.FlatSpec
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import scala.math.{ BigDecimal => SBigDecimal }
@@ -107,6 +107,18 @@ class BiggerDecimalSuite extends FlatSpec with GeneratorDrivenPropertyChecks {
     val Some(d) = BiggerDecimal.parseBiggerDecimal("-9223372036854775809")
 
     assert(d.truncateToLong === Long.MinValue)
+  }
+
+  "toBigInteger" should "fail on very large values" in {
+    val Some(d) = BiggerDecimal.parseBiggerDecimal("1e262144")
+
+    assert(d.toBigInteger === None)
+  }
+
+  it should "not count the sign against the digit length" in {
+    val Some(d) = BiggerDecimal.parseBiggerDecimal("-1e262143")
+
+    assert(d.toBigInteger === Some(new BigDecimal("-1e262143").toBigInteger))
   }
 
   "fromLong and fromDouble" should "agree on Int-sized integral values" in forAll { (value: Int) =>


### PR DESCRIPTION
This adds some tests and makes one small change to behavior—when you try to convert a `BiggerDecimal` into a `BigInteger`, the sign no longer counts as one of the `2 ^ 18` allowed characters.