### PR TITLE
Make integral number decoding consistent for strings

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -461,10 +461,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => try {
-        Right(string.toByte)
-      } catch {
-        case _: NumberFormatException => fail(c)
+      case JString(string) => JsonNumber.fromString(string).flatMap(_.toByte) match {
+        case Some(value) => Right(value)
+        case None => fail(c)
       }
       case _ => fail(c)
     }
@@ -483,10 +482,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => try {
-        Right(string.toShort)
-      } catch {
-        case _: NumberFormatException => fail(c)
+      case JString(string) => JsonNumber.fromString(string).flatMap(_.toShort) match {
+        case Some(value) => Right(value)
+        case None => fail(c)
       }
       case _ => fail(c)
     }
@@ -505,10 +503,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => try {
-        Right(string.toInt)
-      } catch {
-        case _: NumberFormatException => fail(c)
+      case JString(string) => JsonNumber.fromString(string).flatMap(_.toInt) match {
+        case Some(value) => Right(value)
+        case None => fail(c)
       }
       case _ => fail(c)
     }
@@ -530,10 +527,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => try {
-        Right(string.toLong)
-      } catch {
-        case _: NumberFormatException => fail(c)
+      case JString(string) => JsonNumber.fromString(string).flatMap(_.toLong) match {
+        case Some(value) => Right(value)
+        case None => fail(c)
       }
       case _ => fail(c)
     }
@@ -555,10 +551,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => try {
-        Right(BigInt(string))
-      } catch {
-        case _: NumberFormatException => fail(c)
+      case JString(string) => JsonNumber.fromString(string).flatMap(_.toBigInt) match {
+        case Some(value) => Right(value)
+        case None => fail(c)
       }
       case _ => fail(c)
     }
@@ -583,10 +578,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => try {
-        Right(BigDecimal(string))
-      } catch {
-        case _: NumberFormatException => fail(c)
+      case JString(string) => JsonNumber.fromString(string).flatMap(_.toBigDecimal) match {
+        case Some(value) => Right(value)
+        case None => fail(c)
       }
       case _ => fail(c)
     }


### PR DESCRIPTION
Fixes #476 and provides a kind of workaround for #93. This is a breaking change, but as far as I know nobody is relying on the previous behavior (which is still available by parsing into a `String` and then using `flatMap` or similar).