### PR TITLE
Rename unsafe methods for consistency

### DIFF
--- a/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
@@ -41,11 +41,11 @@ final case class JsonPath(json: Optional[Json, Json]) extends Dynamic {
   final def filterByField(p: String => Boolean): JsonTraversalPath =
     JsonTraversalPath(obj composeTraversal FilterIndex.filterIndex(p))
 
-  final def unsafeFilter(p: Json => Boolean): JsonPath =
+  final def filterUnsafe(p: Json => Boolean): JsonPath =
     JsonPath(json composePrism UnsafeOptics.select(p))
 
   final def filter(p: Json => Boolean): JsonFoldPath =
-    JsonFoldPath(unsafeFilter(p).json.asFold)
+    JsonFoldPath(filterUnsafe(p).json.asFold)
 
   final def as[A](implicit decode: Decoder[A], encode: Encoder[A]): Optional[Json, A] =
     json composePrism UnsafeOptics.parse
@@ -88,11 +88,11 @@ final case class JsonTraversalPath(json: Traversal[Json, Json]) extends Dynamic 
   final def filterByField(p: String => Boolean): JsonTraversalPath =
     JsonTraversalPath(obj composeTraversal FilterIndex.filterIndex(p))
 
-  final def unsafeFilter(p: Json => Boolean): JsonTraversalPath =
+  final def filterUnsafe(p: Json => Boolean): JsonTraversalPath =
     JsonTraversalPath(json composePrism UnsafeOptics.select(p))
 
   final def filter(p: Json => Boolean): JsonFoldPath =
-    JsonFoldPath(unsafeFilter(p).json.asFold)
+    JsonFoldPath(filterUnsafe(p).json.asFold)
 
   final def as[A](implicit decode: Decoder[A], encode: Encoder[A]): Traversal[Json, A] =
     json composePrism UnsafeOptics.parse

--- a/modules/optics/src/test/scala/io/circe/optics/JsonPathSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/JsonPathSuite.scala
@@ -71,7 +71,7 @@ class JsonPathSuite extends CirceSuite {
 
   it should "support an unsafe filtering by value" in {
     assert(
-      root.cars.each.unsafeFilter(root.maxSpeed.int.asFold.exist(_ > 100)(_)).model.string.set("new")(john) ===
+      root.cars.each.filterUnsafe(root.maxSpeed.int.asFold.exist(_ > 100)(_)).model.string.set("new")(john) ===
         Json.obj(
           "first_name" -> "John".asJson,
           "last_name"  -> "Doe".asJson,

--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -9,15 +9,15 @@ package object scalajs {
   /**
    * Attempt to convert a value to [[Json]].
    */
-  private[this] def unsafeConvertAnyToJson(input: Any): Json = input match {
+  private[this] def convertAnyToJsonUnsafe(input: Any): Json = input match {
     case s: String => Json.fromString(s)
     case n: Double => Json.fromDoubleOrNull(n)
     case true => Json.True
     case false => Json.False
     case null => Json.Null
-    case a: js.Array[_] => Json.fromValues(a.map(unsafeConvertAnyToJson(_: Any)))
+    case a: js.Array[_] => Json.fromValues(a.map(convertAnyToJsonUnsafe(_: Any)))
     case o: js.Object => Json.fromFields(
-      o.asInstanceOf[js.Dictionary[_]].mapValues(unsafeConvertAnyToJson).toSeq
+      o.asInstanceOf[js.Dictionary[_]].mapValues(convertAnyToJsonUnsafe).toSeq
     )
     case other if js.isUndefined(other) => Json.Null
   }
@@ -26,7 +26,7 @@ package object scalajs {
    * Convert [[scala.scalajs.js.Any]] to [[Json]].
    */
   final def convertJsToJson(input: js.Any): Either[Throwable, Json] =
-    try Right(unsafeConvertAnyToJson(input)) catch {
+    try Right(convertAnyToJsonUnsafe(input)) catch {
       case NonFatal(exception) => Left(exception)
     }
 


### PR DESCRIPTION
This PR changes the name of the new `unsafeFilter` method introduced in #473 to be consistent with other unsafe methods in circe (where the `unsafe` is a suffix).

I've also updated a pre-existing private method that was inconsistent.