### PR TITLE
Decoder ops

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.{ MonadError, SemigroupK }
 import cats.data.{ Kleisli, NonEmptyList, NonEmptyVector, OneAnd, StateT, Validated }
 import cats.instances.either.{ catsDataSemigroupKForEither, catsStdInstancesForEither }
+import cats.syntax.either._
 import io.circe.export.Exported
 import java.util.UUID
 import scala.annotation.tailrec
@@ -210,6 +211,13 @@ trait Decoder[A] extends Serializable { self =>
         case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
       }
   }
+
+  /**
+    * Widen this decoder to a supertype
+    * @tparam B The supertype of [[A]]
+    * @return This decoder, widened to the supertype [[B]]
+    */
+  final def widen[B >: A]: Decoder[B] = map(a => a:B)
 }
 
 /**
@@ -335,6 +343,27 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    * @group Utilities
    */
   final def failedWithMessage[A](message: String): Decoder[A] = failed(DecodingFailure(message, Nil))
+
+  /**
+    * Given a [[PartialFunction]] from String => Decoder[A], construct a Decoder[A] over singleton objects
+    * of the given keys which delegates to the specified decoder for each key.
+    *
+    * @param pf A [[PartialFunction]] which defines a Decoder for each singleton key
+    * @tparam A The type to which all cases should decode
+    * @return A decoder over singleton objects which decodes to [[A]]
+    */
+  final def singletonCases[A](pf: PartialFunction[String, Decoder[A]]): Decoder[A] = Decoder.instance {
+    cursor =>
+      def fail(err: String) = DecodingFailure(err, cursor.history)
+      for {
+        focus        <- cursor.focus.toRight(fail("Attempt to decode on empty focus"))
+        obj          <- focus.asObject.toRight(fail("Not an object"))
+        singleton    <- if (obj.size == 1) Right(obj) else Left(fail("Not a singleton"))
+        (key, inner) = singleton.toList.head
+        decoder      <- pf.lift.apply(key).toRight(fail(s"$key is not a valid case"))
+        decoded      <- decoder.decodeJson(inner)
+      } yield decoded
+  }
 
   /**
    * @group Decoding

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -314,4 +314,24 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
     assert(history.size === size + 1)
   }
+
+  "singletonCases" should "choose a decoder using the given PartialFunction" in {
+    sealed trait A
+    case class B(b: Int) extends A
+    case class C(c: String) extends A
+
+    val decodeB = Decoder.decodeInt.map(B.apply)
+    val decodeC = Decoder.decodeString.map(C.apply)
+
+    val decodeA = Decoder.singletonCases {
+      case "b" => decodeB.widen[A]
+      case "c" => decodeC.widen[A]
+    }
+
+    assert(decodeA.decodeJson(Json.obj("b" -> Json.fromInt(22))) === Right(B(22)))
+    assert(decodeA.decodeJson(Json.obj("c" -> Json.fromString("twenty two"))) === Right(C("twenty two")))
+    assert(decodeA.decodeJson(Json.obj("b" -> Json.fromString("twenty two"))).isLeft)
+    assert(decodeA.decodeJson(Json.obj("c" -> Json.fromInt(22))).isLeft)
+
+  }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -328,8 +328,10 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
       case "c" => decodeC.widen[A]
     }
 
-    assert(decodeA.decodeJson(Json.obj("b" -> Json.fromInt(22))) === Right(B(22)))
-    assert(decodeA.decodeJson(Json.obj("c" -> Json.fromString("twenty two"))) === Right(C("twenty two")))
+    implicit val eqA = cats.Eq.instance[A](_ == _)
+
+    assert(decodeA.decodeJson(Json.obj("b" -> Json.fromInt(22))) === Right(B(22):A))
+    assert(decodeA.decodeJson(Json.obj("c" -> Json.fromString("twenty two"))) === Right(C("twenty two"):A))
     assert(decodeA.decodeJson(Json.obj("b" -> Json.fromString("twenty two"))).isLeft)
     assert(decodeA.decodeJson(Json.obj("c" -> Json.fromInt(22))).isLeft)
 


### PR DESCRIPTION
This PR adds two operations that I found useful:

* `Decoder#widen[B]` is just a nicer syntax for `decoder.map(a => a:B)`, to ease the fact that `Decoder` is not covariant.
* `Decoder.singletonCases` is a convenience function for constructing a `Decoder[A]` similar to how a sealed trait is encoded, except that the  descriminator strings are explicit. For example:

  ```scala
  sealed trait A
  case class B(b: String) extends A
  case class C(c: Int) extends A

  object A {
    implicit val decoder: Decoder[A] = Decoder.singletonCases {
      case "b" | "B" | "foob" => Decoder.decodeString.map(B.apply).widen[A]
      case "c" | "C" | "fooc" => Decoder.decodeInt.map(C.apply).widen[A]
    }
  }
  ```

  It just provides an easier way of defining decoders of this variety.