### PR TITLE
Use applyDynamic in JsonPaths to allow more terse array indexing

### DIFF
--- a/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
@@ -29,6 +29,8 @@ final case class JsonPath(json: Optional[Json, Json]) extends Dynamic {
   final def selectDynamic(field: String): JsonPath =
     JsonPath(json.composePrism(jsonObject).composeOptional(Index.index(field)))
 
+  final def applyDynamic(field: String)(index: Int): JsonPath = selectDynamic(field).index(index)
+
   final def index(i: Int): JsonPath =
     JsonPath(json.composePrism(jsonArray).composeOptional(Index.index(i)))
 
@@ -76,6 +78,8 @@ final case class JsonTraversalPath(json: Traversal[Json, Json]) extends Dynamic 
   final def selectDynamic(field: String): JsonTraversalPath =
     JsonTraversalPath(json.composePrism(jsonObject).composeOptional(Index.index(field)))
 
+  final def applyDynamic(field: String)(index: Int): JsonTraversalPath = selectDynamic(field).index(index)
+
   final def index(i: Int): JsonTraversalPath =
     JsonTraversalPath(json.composePrism(jsonArray).composeOptional(Index.index(i)))
 
@@ -118,6 +122,8 @@ final case class JsonFoldPath(json: Fold[Json, Json]) extends Dynamic {
 
   final def selectDynamic(field: String): JsonFoldPath =
     JsonFoldPath(json.composePrism(jsonObject).composeOptional(Index.index(field)))
+
+  final def applyDynamic(field: String)(index: Int): JsonFoldPath = selectDynamic(field).index(index)
 
   final def index(i: Int): JsonFoldPath =
     JsonFoldPath(json.composePrism(jsonArray).composeOptional(Index.index(i)))

--- a/modules/optics/src/test/scala/io/circe/optics/JsonPathSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/JsonPathSuite.scala
@@ -38,6 +38,10 @@ class JsonPathSuite extends CirceSuite {
     assert(root.cars.index(1).model.string.getOption(john) === Some("suv"))
   }
 
+  it should "support traversal by array index using apply" in {
+    assert(root.cars(1).model.string.getOption(john) === Some("suv"))
+  }
+
   it should "support insertion and deletion" in {
     assert(root.at("first_name").setOption(None)(john) === john.asObject.map(_.remove("first_name").asJson))
     assert(root.at("foo").set(Some(true.asJson))(john).asObject.flatMap(_.apply("foo")) === Some(Json.True))


### PR DESCRIPTION
We can use `applyDynamic` to allow simple array indexing. Given the following JSON

```json
{
  "array": [0, 1, 2, 3, 4]
}
```

this change allows us to access an element of `array` like this: `root.array(1)` rather than like this: `root.array.index(1)`

I could only find a relevant test for `JsonPath` and not for `JsonFoldPath` and `JsonTraversalPath` which I found a little worrying. Have I missed something somewhere?