### PR TITLE
Avoid using return

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -404,10 +404,7 @@ final object Json {
   private[this] final def arrayEq(x: Seq[Json], y: Seq[Json]): Boolean = {
     val it0 = x.iterator
     val it1 = y.iterator
-    while (it0.hasNext && it1.hasNext) {
-      if (Json.eqJson.neqv(it0.next, it1.next)) return false
-    }
-    it0.hasNext == it1.hasNext
+    it0.zip(it1).forall((Json.eqJson.eqv _).tupled) && !it0.hasNext && !it1.hasNext
   }
 
   implicit final val eqJson: Eq[Json] = Eq.instance {


### PR DESCRIPTION
For reducing the warnings.
`.../circe/modules/core/shared/src/main/scala/io/circe/Json.scala:408:48: Avoid using return`

```scala
def time(f: => Boolean): Boolean = {
  val start = System.nanoTime()
  val r = f
  println(System.nanoTime() - start)
  r
}

val json1 = parse(scala.io.Source.fromURL("https://netfile.com/Sunlight/Api/Lobbyist/Sf/v11/Filers/2015").mkString).right.get

val json2 = parse(scala.io.Source.fromURL("https://netfile.com/Sunlight/Api/Lobbyist/Sf/v11/Filers/2016").mkString).right.get
```

|   | before | after |
| - | ------- | ------ |
| time(json1 == json1) | 433980 | 532888 |
|                      | 465075 | 515176 |
|                      | 353991 | 148322 |
|                      | 180967 | 138756 |
|                      | 122145 | 170806 |
| time(json1 == json2) | 98063  | 116100 |
|                      | 149007 | 107977 |
|                      | 76080  | 101400 |
|                      | 73067  | 71044 |
|                      | 115644 | 79425 |
| time(json2 == json2) | 121846 | 165234 |
|                      | 135392 | 138271 |
|                      | 111382 | 141838 |
|                      | 120160 | 124833 |
|                      | 149265 | 133229 |