### PR TITLE
Update Jackson to 2.8.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -417,8 +417,8 @@ lazy val streaming = circeModule("streaming", mima = previousCirceVersion)
 lazy val jackson = circeModule("jackson", mima = previousCirceVersion)
   .settings(
     libraryDependencies ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % "2.5.3",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.3"
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.8.5",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.5"
     )
   )
   .dependsOn(core)

--- a/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
@@ -38,7 +38,7 @@ private[jackson] final class CirceJsonDeserializer(factory: TypeFactory, klass: 
 
   override final def deserialize(jp: JsonParser, ctxt: DeserializationContext): Json = {
     val value = deserialize(jp, ctxt, List())
-    if (!klass.isAssignableFrom(value.getClass)) throw ctxt.mappingException(klass)
+    if (!klass.isAssignableFrom(value.getClass)) ctxt.handleUnexpectedToken(klass, jp)
 
     value
   }

--- a/modules/jackson/src/main/scala/io/circe/jackson/package.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/package.scala
@@ -1,7 +1,6 @@
 package io.circe
 
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
-import com.fasterxml.jackson.databind.ObjectWriter
 
 /**
  * Support for Jackson-powered parsing and printing for circe.
@@ -20,7 +19,7 @@ package object jackson extends WithJacksonMapper with JacksonParser {
     val gen = stringJsonGenerator(sw).setPrettyPrinter(
       new DefaultPrettyPrinter()
     )
-    val writer: ObjectWriter = mapper.writerWithDefaultPrettyPrinter[ObjectWriter]()
+    val writer = mapper.writerWithDefaultPrettyPrinter()
     writer.writeValue(gen, json)
     sw.flush()
     sw.getBuffer.toString


### PR DESCRIPTION
There are 2 code changes:
- use non generic factory method 'writerWithPrettyPrinter'
- replace deprecated exception method