### PR TITLE
Provide Auto trait

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/AutoDerivation.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/AutoDerivation.scala
@@ -10,11 +10,11 @@ import scala.language.experimental.macros
 /**
  * Fully automatic configurable codec derivation.
  *
- * Importing the contents of this object provides [[io.circe.Decoder]] and [[io.circe.Encoder]]
+ * Extending this trait provides [[io.circe.Decoder]] and [[io.circe.Encoder]]
  * instances for case classes (if all members have instances), "incomplete" case classes, sealed
  * trait hierarchies, etc.
  */
-final object auto {
+trait AutoDerivation {
   implicit def exportDecoder[A]: Exported[Decoder[A]] =
     macro ExportMacros.exportDecoder[ConfiguredDecoder, A]
   implicit def exportEncoder[A]: Exported[ObjectEncoder[A]] =

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/auto/package.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/auto/package.scala
@@ -1,0 +1,10 @@
+package io.circe.generic.extras
+
+/**
+ * Fully automatic configurable codec derivation.
+ *
+ * Importing the contents of this package object provides [[io.circe.Decoder]] and [[io.circe.Encoder]]
+ * instances for case classes (if all members have instances), "incomplete" case classes, sealed
+ * trait hierarchies, etc.
+ */
+package object auto extends AutoDerivation

--- a/modules/generic/shared/src/main/scala/io/circe/generic/AutoDerivation.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/AutoDerivation.scala
@@ -10,11 +10,11 @@ import scala.language.experimental.macros
 /**
  * Fully automatic codec derivation.
  *
- * Importing the contents of this object provides [[io.circe.Decoder]] and [[io.circe.Encoder]]
+ * Extending this trait provides [[io.circe.Decoder]] and [[io.circe.Encoder]]
  * instances for case classes (if all members have instances), "incomplete" case classes, sealed
  * trait hierarchies, etc.
  */
-final object auto {
+trait AutoDerivation {
   implicit def exportDecoder[A]: Exported[Decoder[A]] = macro ExportMacros.exportDecoder[DerivedDecoder, A]
   implicit def exportEncoder[A]: Exported[ObjectEncoder[A]] = macro ExportMacros.exportEncoder[DerivedObjectEncoder, A]
 }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/auto/package.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/auto/package.scala
@@ -1,0 +1,10 @@
+package io.circe.generic
+
+/**
+ * Fully automatic codec derivation.
+ *
+ * Importing the contents of this package object provides [[io.circe.Decoder]] and [[io.circe.Encoder]]
+ * instances for case classes (if all members have instances), "incomplete" case classes, sealed
+ * trait hierarchies, etc.
+ */
+package object auto extends AutoDerivation


### PR DESCRIPTION
Sometimes it's more useful to bring `io.circe.generic.auto._` implicits into scope by not importing them but by extending package object, object or class from a trait.
For example:
```scala
package app

import io.circe.generic.Auto

package object api extends Auto {
}
```
makes implicits for automatic encoders and decoders generation visible for all code in package `app.api` and after that there is no need to import `io.circe.generic.auto._` in each source file in this package.