### PR TITLE
Add JsonPatha.apply to allow terse index selection on the root

### DIFF
--- a/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
@@ -31,6 +31,8 @@ final case class JsonPath(json: Optional[Json, Json]) extends Dynamic {
 
   final def applyDynamic(field: String)(index: Int): JsonPath = selectDynamic(field).index(index)
 
+  final def apply(i: Int): JsonPath = index(i)
+
   final def index(i: Int): JsonPath =
     JsonPath(json.composePrism(jsonArray).composeOptional(Index.index(i)))
 
@@ -80,6 +82,8 @@ final case class JsonTraversalPath(json: Traversal[Json, Json]) extends Dynamic 
 
   final def applyDynamic(field: String)(index: Int): JsonTraversalPath = selectDynamic(field).index(index)
 
+  final def apply(i: Int): JsonTraversalPath = index(i)
+
   final def index(i: Int): JsonTraversalPath =
     JsonTraversalPath(json.composePrism(jsonArray).composeOptional(Index.index(i)))
 
@@ -124,6 +128,8 @@ final case class JsonFoldPath(json: Fold[Json, Json]) extends Dynamic {
     JsonFoldPath(json.composePrism(jsonObject).composeOptional(Index.index(field)))
 
   final def applyDynamic(field: String)(index: Int): JsonFoldPath = selectDynamic(field).index(index)
+
+  final def apply(i: Int): JsonFoldPath = index(i)
 
   final def index(i: Int): JsonFoldPath =
     JsonFoldPath(json.composePrism(jsonArray).composeOptional(Index.index(i)))

--- a/modules/optics/src/test/scala/io/circe/optics/JsonPathSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/JsonPathSuite.scala
@@ -42,6 +42,11 @@ class JsonPathSuite extends CirceSuite {
     assert(root.cars(1).model.string.getOption(john) === Some("suv"))
   }
 
+  it should "support traversal by array index using apply on the root" in {
+    val jsonArray = List("first".asJson, "second".asJson).asJson
+    assert(root(0).string.getOption(jsonArray) === Some("first"))
+  }
+
   it should "support insertion and deletion" in {
     assert(root.at("first_name").setOption(None)(john) === john.asObject.map(_.remove("first_name").asJson))
     assert(root.at("foo").set(Some(true.asJson))(john).asObject.flatMap(_.apply("foo")) === Some(Json.True))


### PR DESCRIPTION
* Allows root arrays to indexed using the `apply` method `root(5)` as well as using the `index` method: `root.index(5)`
* Consistent with the behaviour above the root using `applyDynamic` (e.g. `root.cars(5)`).