### PR TITLE
Make the benchmark module work against Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -423,11 +423,9 @@ lazy val benchmark = circeModule("benchmark", mima = None)
   .settings(
     crossScalaVersions := crossScalaVersions.value.init,
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-json" % "2.3.10",
-      "io.argonaut" %% "argonaut" % "6.1",
+      "com.typesafe.play" %% "play-json" % "2.6.0-M1",
+      "io.argonaut" %% "argonaut" % "6.2-RC2",
       "io.spray" %% "spray-json" % "1.3.2",
-      "io.github.netvl.picopickle" %% "picopickle-core" % "0.2.1",
-      "io.github.netvl.picopickle" %% "picopickle-backend-jawn" % "0.2.1",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     )

--- a/modules/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
@@ -6,8 +6,6 @@ import cats.data.NonEmptyList
 import io.circe.{ Decoder, Encoder, Json => JsonC }
 import io.circe.generic.semiauto._
 import io.circe.jawn._
-import io.github.netvl.picopickle.backends.jawn.JsonPickler
-import io.github.netvl.picopickle.backends.jawn.JsonPickler._
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import play.api.libs.json.{ Format, Json => JsonP, JsValue => JsValueP, Writes }
@@ -47,20 +45,17 @@ class ExampleData {
   @inline def encodeC[A](a: A)(implicit encode: Encoder[A]): JsonC = encode(a)
   @inline def encodeP[A](a: A)(implicit encode: Writes[A]): JsValueP = encode.writes(a)
   @inline def encodeS[A](a: A)(implicit encode: JsonWriter[A]): JsValueS = encode.write(a)
-  @inline def encodePico[A](a: A)(implicit encode: JsonPickler.Writer[A]): backend.BValue = write(a)(encode)
 
   val intsC: JsonC = encodeC(ints)
   val intsA: JsonA = encodeA(ints)
   val intsP: JsValueP = encodeP(ints)
   val intsS: JsValueS = encodeS(ints)
-  val intsPico: backend.BValue = encodePico(ints)
 
   val foosC: JsonC = encodeC(foos)
   val fooNelsC: JsonC = encodeC(fooNels)
   val foosA: JsonA = encodeA(foos)
   val foosP: JsValueP = encodeP(foos)
   val foosS: JsValueS = encodeS(foos)
-  val foosPico: backend.BValue = encodePico(foos)
 
   val intsJson: String = intsC.noSpaces
   val foosJson: String = foosC.noSpaces
@@ -90,9 +85,6 @@ class EncodingBenchmark extends ExampleData {
   def encodeIntsS: JsValueS = encodeS(ints)
 
   @Benchmark
-  def encodeIntsPico: backend.BValue = encodePico(ints)
-
-  @Benchmark
   def encodeFoosC: JsonC = encodeC(foos)
 
   @Benchmark
@@ -105,9 +97,6 @@ class EncodingBenchmark extends ExampleData {
   def encodeFoosS: JsValueS = encodeS(foos)
 
   def encodeFooNelsC: JsonC = encodeC(fooNels)
-
-  @Benchmark
-  def encodeFoosPico: backend.BValue = encodePico(foos)
 }
 
 /**
@@ -134,9 +123,6 @@ class DecodingBenchmark extends ExampleData {
   def decodeIntsS: List[Int] = intsS.convertTo[List[Int]]
 
   @Benchmark
-  def decodeIntsPico: List[Int] = read[List[Int]](intsPico)
-
-  @Benchmark
   def decodeFoosC: Map[String, Foo] =
     foosC.as[Map[String, Foo]].right.getOrElse(throw new Exception)
 
@@ -149,9 +135,6 @@ class DecodingBenchmark extends ExampleData {
 
   @Benchmark
   def decodeFoosS: Map[String, Foo] = foosS.convertTo[Map[String, Foo]]
-
-  @Benchmark
-  def decodeFoosPico: Map[String, Foo] = read[Map[String, Foo]](foosPico)
 }
 
 /**
@@ -178,9 +161,6 @@ class ParsingBenchmark extends ExampleData {
   def parseIntsS: JsValueS = JsonParserS(intsJson)
 
   @Benchmark
-  def parseIntsPico: backend.BValue = readAst(intsJson)
-
-  @Benchmark
   def parseFoosC: JsonC = parse(foosJson).right.getOrElse(throw new Exception)
 
   @Benchmark
@@ -191,9 +171,6 @@ class ParsingBenchmark extends ExampleData {
 
   @Benchmark
   def parseFoosS: JsValueS = JsonParserS(foosJson)
-
-  @Benchmark
-  def parseFoosPico: backend.BValue = readAst(foosJson)
 }
 
 /**
@@ -220,9 +197,6 @@ class PrintingBenchmark extends ExampleData {
   def printIntsS: String = intsS.compactPrint
 
   @Benchmark
-  def printIntsPico: String = writeAst(intsPico)
-
-  @Benchmark
   def printFoosC: String = foosC.noSpaces
 
   @Benchmark
@@ -233,9 +207,6 @@ class PrintingBenchmark extends ExampleData {
 
   @Benchmark
   def printFoosS: String = foosS.compactPrint
-
-  @Benchmark
-  def printFoosPico: String = writeAst(foosPico)
 }
 
 /**

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/DecodingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/DecodingBenchmarkSpec.scala
@@ -23,10 +23,6 @@ class DecodingBenchmarkSpec extends FlatSpec {
     assert(decodeIntsS === ints)
   }
 
-  it should "correctly decode integers using Picopickle" in {
-    assert(decodeIntsPico === ints)
-  }
-
   it should "correctly decode case classes using Circe" in {
     assert(decodeFoosC === foos)
   }
@@ -41,9 +37,5 @@ class DecodingBenchmarkSpec extends FlatSpec {
 
   it should "correctly decode case classes using Spray JSON" in {
     assert(decodeFoosS === foos)
-  }
-
-  it should "correctly decode case classes using Picopickle" in {
-    assert(decodeFoosPico === foos)
   }
 }

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/EncodingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/EncodingBenchmarkSpec.scala
@@ -3,7 +3,6 @@ package io.circe.benchmark
 import argonaut.Parse, argonaut.Argonaut._
 import org.scalatest.FlatSpec
 import play.api.libs.json.{ Json => JsonP }
-import io.github.netvl.picopickle.backends.jawn.JsonPickler._
 
 class EncodingBenchmarkSpec extends FlatSpec {
   val benchmark: EncodingBenchmark = new EncodingBenchmark
@@ -32,10 +31,6 @@ class EncodingBenchmarkSpec extends FlatSpec {
     assert(decodeInts(encodeIntsS.compactPrint) === Some(ints))
   }
 
-  it should "correctly encode integers using Picopickle" in {
-    assert(decodeInts(writeAst(encodeIntsPico)) === Some(ints))
-  }
-
   it should "correctly encode case classes using Circe" in {
     assert(decodeFoos(encodeFoosC.noSpaces) === Some(foos))
   }
@@ -50,9 +45,5 @@ class EncodingBenchmarkSpec extends FlatSpec {
 
   it should "correctly encode case classes using Spray JSON" in {
     assert(decodeFoos(encodeFoosS.compactPrint) === Some(foos))
-  }
-
-  it should "correctly encode case classes using Picopickle" in {
-    assert(decodeFoos(writeAst(encodeFoosPico)) === Some(foos))
   }
 }

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/ParsingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/ParsingBenchmarkSpec.scala
@@ -23,10 +23,6 @@ class ParsingBenchmarkSpec extends FlatSpec {
     assert(parseIntsS === intsS)
   }
 
-  it should "correctly parse integers using Picopickle" in {
-    assert(parseIntsPico === intsPico)
-  }
-
   it should "correctly parse case classes using Circe" in {
     assert(parseFoosC === foosC)
   }
@@ -41,9 +37,5 @@ class ParsingBenchmarkSpec extends FlatSpec {
 
   it should "correctly parse case classes using Spray JSON" in {
     assert(parseFoosS === foosS)
-  }
-
-  it should "correctly parse case classes using Picopickle" in {
-    assert(parseFoosPico === foosPico)
   }
 }

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
@@ -30,10 +30,6 @@ class PrintingBenchmarkSpec extends FlatSpec {
     assert(decodeInts(printIntsS) === Some(ints))
   }
 
-  it should "correctly print integers using Picopickle" in {
-    assert(decodeInts(printIntsPico) === Some(ints))
-  }
-
   it should "correctly print case classes using Circe" in {
     assert(decodeFoos(printFoosC) === Some(foos))
   }
@@ -48,9 +44,5 @@ class PrintingBenchmarkSpec extends FlatSpec {
 
   it should "correctly print case classes using Spray JSON" in {
     assert(decodeFoos(printFoosS) === Some(foos))
-  }
-
-  it should "correctly print case classes using Picopickle" in {
-    assert(decodeFoos(printFoosPico) === Some(foos))
   }
 }


### PR DESCRIPTION
This change removes picopickle as a dependency for the benchmark module, as it is not published for Scala 2.12.

At the same time, Play JSON and Argonaut have been updated to the latest Scala 2.12 published releases.

This change resolves the IntelliJ issue with importing mentioned in https://github.com/circe/circe/issues/503

It also allows running `sbt benchmark/test` locally out of the box (i.e. with Scala 2.12).