### PR TITLE
Make truncation round toward zero

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -167,7 +167,7 @@ private[circe] final case class JsonBigDecimal(value: BigDecimal) extends JsonNu
   final def toBigInt: Option[BigInt] = toBiggerDecimal.toBigInteger.map(BigInt(_))
   final def toDouble: Double = value.toDouble
   final def toLong: Option[Long] = toBiggerDecimal.toLong
-  final def truncateToLong: Long = math.round(toDouble)
+  final def truncateToLong: Long = value.underlying.setScale(0, java.math.BigDecimal.ROUND_DOWN).longValue
   override final def toString: String = value.toString
 }
 
@@ -200,7 +200,7 @@ private[circe] final case class JsonDouble(value: Double) extends JsonNumber {
     if (asLong.toDouble == value) Some(asLong) else None
   }
 
-  final def truncateToLong: Long = java.lang.Math.round(value)
+  final def truncateToLong: Long = value.toLong
   override final def toString: String = java.lang.Double.toString(value)
 }
 

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -110,7 +110,7 @@ private[numbers] final class SigAndExp(
 
   def truncateToLong: Long = toLong.getOrElse {
     toBigDecimal.map { asBigDecimal =>
-      val rounded = asBigDecimal.setScale(0, BigDecimal.ROUND_HALF_UP)
+      val rounded = asBigDecimal.setScale(0, BigDecimal.ROUND_DOWN)
 
       if (rounded.compareTo(BiggerDecimal.MaxLong) >= 0) {
         Long.MaxValue

--- a/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
@@ -47,6 +47,15 @@ class JsonNumberSuite extends CirceSuite {
     assert(JsonNumber.fromString(l.toString).flatMap(_.toInt).isEmpty === invalid)
   }
 
+  "truncateToLong" should "round toward zero" in {
+    assert(JsonNumber.fromString("1.5").map(_.truncateToLong) === Some(1L))
+    assert(JsonNumber.fromString("-1.5").map(_.truncateToLong) === Some(-1L))
+    assert(Json.fromDouble(1.5).flatMap(_.asNumber).map(_.truncateToLong) === Some(1L))
+    assert(Json.fromDouble(-1.5).flatMap(_.asNumber).map(_.truncateToLong) === Some(-1L))
+    assert(Json.fromBigDecimal(BigDecimal(1.5)).asNumber.map(_.truncateToLong) === Some(1L))
+    assert(Json.fromBigDecimal(BigDecimal(-1.5)).asNumber.map(_.truncateToLong) === Some(-1L))
+  }
+
   "truncateToByte" should "return the truncated value" in forAll { (l: Long) =>
     val truncated: Byte = min(Byte.MaxValue, max(Byte.MinValue, l)).toByte
 


### PR DESCRIPTION
From the Scaladocs for `JsonNumber#truncateToLong`:

> Truncation means that we round toward zero to the closest valid `scala.Long`.

This isn't the current behavior, though:

```scala
scala> import io.circe.{ Json, JsonNumber }
import io.circe.{Json, JsonNumber}

scala> JsonNumber.fromString("1.5").map(_.truncateToLong)
res0: Option[Long] = Some(2)

scala> Json.fromDouble(1.5).flatMap(_.asNumber).map(_.truncateToLong)
res1: Option[Long] = Some(2)

scala> Json.fromBigDecimal(BigDecimal(1.5)).asNumber.map(_.truncateToLong)
res2: Option[Long] = Some(2)
```

This PR fixes the discrepancy by rounding toward zero (as specified in the docs) instead of to the nearest whole value.