### PR TITLE
String concatenation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,8 +208,8 @@ lazy val aggregatedProjects: Seq[ProjectReference] =
 
 def macroSettings(scaladocFor210: Boolean): Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
-    "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
-    "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+    "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+    "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
     "org.typelevel" %%% "macro-compat" % "1.1.1",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   ),
@@ -249,8 +249,8 @@ lazy val circe = project.in(file("."))
 lazy val numbersBase = circeCrossModule("numbers", mima = previousCirceVersion)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test",
-      "org.scalatest" %%% "scalatest" % scalaTestVersion % "test"
+      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test,
+      "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
     )
   )
 
@@ -410,7 +410,7 @@ lazy val jawn = circeModule("jawn", mima = previousCirceVersion)
   .dependsOn(core)
 
 lazy val java8 = circeModule("java8", mima = previousCirceVersion)
-  .dependsOn(core, tests % "test")
+  .dependsOn(core, tests % Test)
 
 lazy val streaming = circeModule("streaming", mima = previousCirceVersion)
   .settings(
@@ -422,11 +422,11 @@ lazy val opticsBase = circeCrossModule("optics", mima = previousCirceVersion, Cr
   .settings(
     libraryDependencies ++= Seq(
       "com.github.julien-truffaut" %%% "monocle-core" % "1.4.0-M2",
-      "com.github.julien-truffaut" %%% "monocle-law"  % "1.4.0-M2" % "test",
+      "com.github.julien-truffaut" %%% "monocle-law"  % "1.4.0-M2" % Test,
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     )
   )
-  .dependsOn(coreBase, testsBase % "test")
+  .dependsOn(coreBase, testsBase % Test)
 
 lazy val optics = opticsBase.jvm
 lazy val opticsJS = opticsBase.js
@@ -439,7 +439,7 @@ lazy val benchmark = circeModule("benchmark", mima = None)
       _.filterNot(Set("-Yno-predef"))
     },
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     )
   )

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -211,12 +211,10 @@ final object JsonObject {
 
     final def size: Int = fieldMap.size
 
-    override final def toString: String = String.format(
-      "object[%s]",
+    override final def toString: String =
       fieldMap.map {
         case (k, v) => s"$k -> ${ Json.showJson.show(v) }"
-      }.mkString(",")
-    )
+      }.mkString("object[", ",", "]")
 
     /**
      * Universal equality derived from our type-safe equality.

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -70,52 +70,47 @@ final case class Printer(
     }
   }
 
+  private[this] final def concat(left: String, text: String, right: String): String =
+    left.concat(text).concat(right)
+
   private[this] final val pieces = new Printer.MemoizedPieces {
     final def compute(i: Int): Printer.Pieces = Printer.Pieces(
-      String.format(
-        "%s%s%s",
+      concat(
         addIndentation(lbraceLeft)(i),
         openBraceText,
         addIndentation(lbraceRight)(i + 1)
       ),
-      String.format(
-        "%s%s%s",
+      concat(
         addIndentation(rbraceLeft)(i),
         closeBraceText,
         addIndentation(rbraceRight)(i + 1)
       ),
-      String.format(
-        "%s%s%s",
+      concat(
         addIndentation(lbracketLeft)(i),
         openArrayText,
         addIndentation(lbracketRight)(i + 1)
       ),
-      String.format(
-        "%s%s%s",
+      concat(
         addIndentation(rbracketLeft)(i),
         closeArrayText,
         addIndentation(rbracketRight)(i + 1)
       ),
-      String.format(
-        "%s%s%s",
+      concat(
         openArrayText,
         addIndentation(lrbracketsEmpty)(i),
         closeArrayText
       ),
-      String.format(
-        "%s%s%s",
+      concat(
         addIndentation(arrayCommaLeft)(i + 1),
         commaText,
         addIndentation(arrayCommaRight)(i + 1)
       ),
-      String.format(
-        "%s%s%s",
+      concat(
         addIndentation(objectCommaLeft)(i + 1),
         commaText,
         addIndentation(objectCommaRight)(i + 1)
       ),
-      String.format(
-        "%s%s%s",
+      concat(
         addIndentation(colonLeft)(i + 1),
         colonText,
         addIndentation(colonRight)(i + 1)


### PR DESCRIPTION
Some minor cleanups based on the no-Predef PR removing use of `String.format` a couple of places. 

Even though `Printer.toString` is not performance critical I made [a small benchmark](https://gist.github.com/jonas/f45c2dce32297f442084d7ff60db3896) for fun and profit. If `String.concat` is not appropriate I suggest to at least switch to use `StringContext`.