### PR TITLE
Support printing to arbitrary Writers

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import java.io.{ BufferedWriter, ByteArrayOutputStream, OutputStreamWriter }
 import java.lang.StringBuilder
+import java.nio.ByteBuffer
 import scala.annotation.switch
 
 /**
@@ -209,14 +210,18 @@ final case class Printer(
     writer.toString
   }
 
-  final def prettyBytes(json: Json): Array[Byte] = {
-    val bytes = new ByteArrayOutputStream()
+  private[this] class EnhancedByteArrayOutputStream extends ByteArrayOutputStream {
+    def toByteBuffer: ByteBuffer = ByteBuffer.wrap(this.buf, 0, this.size)
+  }
+
+  final def prettyByteBuffer(json: Json): ByteBuffer = {
+    val bytes = new EnhancedByteArrayOutputStream
     val writer = new BufferedWriter(new OutputStreamWriter(bytes, "UTF-8"))
 
     printJsonAtDepth(writer)(json, 0)
 
     writer.close()
-    bytes.toByteArray
+    bytes.toByteBuffer
   }
 }
 

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -1,6 +1,8 @@
 package io.circe
 
-import scala.annotation.{ switch, tailrec }
+import java.io.{ BufferedWriter, ByteArrayOutputStream, OutputStreamWriter }
+import java.lang.StringBuilder
+import scala.annotation.switch
 
 /**
  * A pretty-printer for JSON values.
@@ -54,9 +56,6 @@ final case class Printer(
   private[this] final val commaText = ","
   private[this] final val colonText = ":"
   private[this] final val nullText = "null"
-  private[this] final val trueText = "true"
-  private[this] final val falseText = "false"
-  private[this] final val stringEnclosureText = "\""
 
   private[this] final def addIndentation(s: String): Int => String = {
     val lastNewLineIndex = s.lastIndexOf("\n")
@@ -118,89 +117,106 @@ final case class Printer(
     )
   }
 
+  private[this] final def printEscapedChar(writer: Appendable)(c: Char): Unit = {
+    writer.append('\\')
+    (c: @switch) match {
+      case '\\' => writer.append('\\')
+      case '"'  => writer.append('"')
+      case '\b' => writer.append('b')
+      case '\f' => writer.append('f')
+      case '\n' => writer.append('n')
+      case '\r' => writer.append('r')
+      case '\t' => writer.append('t')
+      case possibleUnicode =>
+        writer.append('u').append(String.format("%04x", Integer.valueOf(possibleUnicode.toInt)))
+    }
+  }
+
+  private[this] def printJsonString(writer: Appendable)(jsonString: String): Unit = {
+    writer.append('"')
+
+    var i = 0
+    var offset = 0
+
+    while (i < jsonString.length) {
+      val c = jsonString.charAt(i)
+      if (!Printer.isNormalChar(c)) {
+        writer.append(jsonString, offset, i)
+        printEscapedChar(writer)(c)
+        offset = i + 1
+      }
+
+      i += 1
+    }
+
+    if (offset < i) writer.append(jsonString, offset, i)
+    writer.append('"')
+  }
+
+  private[this] final def printJsonAtDepth(writer: Appendable)(json: Json, depth: Int): Unit = {
+    if (json.isNull) writer.append(nullText) else (json: @unchecked) match {
+      case Json.JString(s) => printJsonString(writer)(s)
+      case Json.JNumber(n) => writer.append(n.toString)
+      case Json.JBoolean(b) => if (b) writer.append("true") else writer.append("false")
+      case Json.JObject(o) =>
+        val p = pieces(depth)
+        writer.append(p.lBraces)
+        val items = if (preserveOrder) o.toList else o.toMap
+        var first = true
+
+        val fieldIterator = items.iterator
+
+        while (fieldIterator.hasNext) {
+          val (key, value) = fieldIterator.next()
+          if (!dropNullKeys || !value.isNull) {
+            if (!first) writer.append(p.objectCommas)
+            printJsonString(writer)(key)
+            writer.append(p.colons)
+            printJsonAtDepth(writer)(value, depth + 1)
+            first = false
+          }
+        }
+        writer.append(p.rBraces)
+      case Json.JArray(a) =>
+        val p = pieces(depth)
+        val len = a.length
+
+        if (len == 0) writer.append(p.lrEmptyBrackets) else {
+          writer.append(p.lBrackets)
+          printJsonAtDepth(writer)(a(0), depth + 1)
+
+          var i = 1
+
+          while (i < len) {
+            writer.append(p.arrayCommas)
+            printJsonAtDepth(writer)(a(i), depth + 1)
+            i += 1
+          }
+
+          writer.append(p.rBrackets)
+        }
+    }
+  }
+
   /**
    * Returns a string representation of a pretty-printed JSON value.
    */
-  final def pretty(j: Json): String = {
-    val builder = new java.lang.StringBuilder()
+  final def pretty(json: Json): String = {
+    val writer = new StringBuilder()
 
-    @tailrec
-    def appendJsonString(
-      jsonString: String,
-      normalChars: Boolean,
-      offset: Int
-    ): Unit = if (normalChars) {
-      var i = offset
+    printJsonAtDepth(writer)(json, 0)
 
-      while (i < jsonString.length && Printer.isNormalChar(jsonString.charAt(i))) {
-        i += 1
-      }
+    writer.toString
+  }
 
-      builder.append(jsonString, offset, i)
+  final def prettyBytes(json: Json): Array[Byte] = {
+    val bytes = new ByteArrayOutputStream()
+    val writer = new BufferedWriter(new OutputStreamWriter(bytes, "UTF-8"))
 
-      if (i < jsonString.length) appendJsonString(jsonString, false, i)
-    } else {
-      var i = offset
+    printJsonAtDepth(writer)(json, 0)
 
-      while (i < jsonString.length && !Printer.isNormalChar(jsonString.charAt(i))) {
-        builder.append(Printer.escape(jsonString.charAt(i)))
-        i += 1
-      }
-
-      if (i < jsonString.length) appendJsonString(jsonString, true, i)
-    }
-
-    def encloseJsonString(jsonString: String): Unit = {
-      builder.append(stringEnclosureText)
-      appendJsonString(jsonString, true, 0)
-      builder.append(stringEnclosureText)
-    }
-
-    def trav(depth: Int, k: Json): Unit = {
-      val p = pieces(depth)
-
-      k match {
-        case Json.JObject(o) =>
-          builder.append(p.lBraces)
-          val items = if (preserveOrder) o.toList else o.toMap
-          var first = true
-
-          val itemIterator = items.iterator
-
-          while (itemIterator.hasNext) {
-            val (key, value) = itemIterator.next()
-            if (!dropNullKeys || !value.isNull) {
-              if (!first) {
-                builder.append(p.objectCommas)
-              }
-              encloseJsonString(key)
-              builder.append(p.colons)
-              trav(depth + 1, value)
-              first = false
-            }
-          }
-          builder.append(p.rBraces)
-        case Json.JString(s) => encloseJsonString(s)
-        case Json.JNumber(n) => builder.append(n.toString)
-        case Json.JBoolean(b) => builder.append(if (b) trueText else falseText)
-        case Json.JArray(arr) =>
-          val arrIterator = arr.iterator
-          if (!arrIterator.hasNext) builder.append(p.lrEmptyBrackets) else {
-            builder.append(p.lBrackets)
-            trav(depth + 1, arrIterator.next)
-
-            while (arrIterator.hasNext) {
-              builder.append(p.arrayCommas)
-              trav(depth + 1, arrIterator.next())
-            }
-            builder.append(p.rBrackets)
-          }
-        case Json.JNull => builder.append(nullText)
-      }
-    }
-
-    trav(0, j)
-    builder.toString
+    writer.close()
+    bytes.toByteArray
   }
 }
 
@@ -243,22 +259,9 @@ final object Printer {
    */
   final val spaces4: Printer = indented("    ")
 
-  private[circe] final def escape(c: Char): String = (c: @switch) match {
-    case '\\' => "\\\\"
-    case '"' => "\\\""
-    case '\b' => "\\b"
-    case '\f' => "\\f"
-    case '\n' => "\\n"
-    case '\r' => "\\r"
-    case '\t' => "\\t"
-    case possibleUnicode => if (Character.isISOControl(possibleUnicode)) {
-      String.format("\\u%04x", Integer.valueOf(possibleUnicode.toInt))
-    } else possibleUnicode.toString
-  }
-
   private[circe] final def isNormalChar(c: Char): Boolean = (c: @switch) match {
     case '\\' => false
-    case '"' => false
+    case '"'  => false
     case '\b' => false
     case '\f' => false
     case '\n' => false

--- a/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -1,7 +1,8 @@
 package io.circe.tests
 
-import io.circe.{ Parser, Printer }
+import io.circe.{ Json, Parser, Printer }
 import io.circe.testing.PrinterTests
+import java.nio.charset.StandardCharsets.UTF_8
 
 class PrinterSuite(printer: Printer, parser: Parser) extends CirceSuite {
   checkLaws("Printing Unit", PrinterTests[Unit].printer(printer, parser))
@@ -14,4 +15,16 @@ class PrinterSuite(printer: Printer, parser: Parser) extends CirceSuite {
   // Temporarily disabling because of problems round-tripping in Scala.js.
   //checkLaws("Printing Long", PrinterTests[Long].printer(printer, parser))
   checkLaws("Printing Map", PrinterTests[Map[String, List[Int]]].printer(printer, parser))
+
+  "prettyByteBuffer" should "match pretty" in forAll { (json: Json) =>
+    val buffer = printer.prettyByteBuffer(json)
+
+    val bytes = new Array[Byte](buffer.limit)
+    buffer.get(bytes)
+
+    val asString = new String(bytes, UTF_8)
+    val expected = printer.pretty(json)
+
+    assert(asString === expected)
+  }
 }


### PR DESCRIPTION
Addresses #536. In addition to the new `prettyBytes` I've made a few other small changes that simplify things a bit and seem to give us a few percent more throughput in the benchmarks.

I'm not currently exposing the ability for users to print to their own `Appendable`s. I'm not totally opposed to the idea, but I'd prefer not to add methods that are fundamentally about mutation unless there's a really clear need.