### PR TITLE
Add printing benchmarks and rearrange some things

### DIFF
--- a/modules/benchmark/src/main/scala/io/circe/benchmark/ExampleData.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/ExampleData.scala
@@ -1,0 +1,17 @@
+package io.circe.benchmark
+
+import io.circe.Json
+import io.circe.syntax._
+
+class ExampleData {
+  val ints: List[Int] = (0 to 1000).toList
+  val booleans: List[Boolean] = ints.map(_ % 2 == 0)
+
+  val foos: Map[String, Foo] = List.tabulate(100) { i =>
+    ("b" * i) -> Foo("a" * i, (i + 2.0) / (i + 1.0), i, i * 1000L, (0 to i).map(_ % 2 == 0).toList)
+  }.toMap
+
+  val intsJson: Json = ints.asJson
+  val booleansJson: Json = booleans.asJson
+  val foosJson: Json = foos.asJson
+}

--- a/modules/benchmark/src/main/scala/io/circe/benchmark/Foo.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/Foo.scala
@@ -1,0 +1,14 @@
+package io.circe.benchmark
+
+import cats.Eq
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto._
+
+case class Foo(s: String, d: Double, i: Int, l: Long, bs: List[Boolean])
+
+object Foo {
+  implicit val decodeFoo: Decoder[Foo] = deriveDecoder
+  implicit val encodeFoo: Encoder[Foo] = deriveEncoder
+
+  implicit val eqFoo: Eq[Foo] = Eq.fromUniversalEquals[Foo]
+}

--- a/modules/benchmark/src/main/scala/io/circe/benchmark/GenericDerivationBenchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/GenericDerivationBenchmark.scala
@@ -1,63 +1,21 @@
 package io.circe.benchmark
 
-import cats.Eq
-import cats.data.NonEmptyList
-import io.circe.{ Decoder, Encoder, Json }
+import io.circe.{ Decoder, Encoder, HCursor, Json }
 import io.circe.generic.semiauto._
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
-
-case class Foo(s: String, d: Double, i: Int, l: Long, bs: List[Boolean])
-
-object Foo {
-  implicit val decodeFoo: Decoder[Foo] = deriveDecoder
-  implicit val encodeFoo: Encoder[Foo] = deriveEncoder
-
-  implicit val eqFoo: Eq[Foo] = Eq.fromUniversalEquals[Foo]
-}
-
-case class FooNel(s: String, d: Double, i: Int, l: Long, bs: NonEmptyList[Boolean])
-
-object FooNel {
-  implicit val encodeFooNel: Encoder[FooNel] = deriveEncoder
-}
-
-class ExampleData {
-  val ints: List[Int] = (0 to 1000).toList
-
-  val foos: Map[String, Foo] = List.tabulate(100) { i =>
-    ("b" * i) -> Foo("a" * i, (i + 2.0) / (i + 1.0), i, i * 1000L, (0 to i).map(_ % 2 == 0).toList)
-  }.toMap
-
-  val fooNels: Map[String, FooNel] = foos.mapValues {
-    foo => FooNel(foo.s, foo.d, foo.i, foo.l, NonEmptyList(true, foo.bs))
-  }
-
-  @inline def encodeC[A](a: A)(implicit encode: Encoder[A]): Json = encode(a)
-
-  val intsC: Json = encodeC(ints)
-
-  val foosC: Json = encodeC(foos)
-  val fooNelsC: Json = encodeC(fooNels)
-
-  val intsJson: String = intsC.noSpaces
-  val foosJson: String = foosC.noSpaces
-}
-
 
 /**
  * Compare the performance of derived and non-derived codecs.
  *
  * The following command will run the benchmarks with reasonable settings:
  *
- * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.CirceDerivationBenchmark"
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.GenericDerivationBenchmark"
  */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-class CirceDerivationBenchmark {
-  import io.circe._
-
+class GenericDerivationBenchmark {
   private[this] val derivedDecoder: Decoder[Foo] = deriveDecoder
   private[this] val derivedEncoder: Encoder[Foo] = deriveEncoder
 

--- a/modules/benchmark/src/main/scala/io/circe/benchmark/PrintingBenchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/PrintingBenchmark.scala
@@ -1,0 +1,36 @@
+package io.circe.benchmark
+
+import io.circe.Printer
+import java.nio.ByteBuffer
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+/**
+ * Compare the performance of string and byte buffer printers.
+ *
+ * The following command will run the benchmarks with reasonable settings:
+ *
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.PrintingBenchmark"
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class PrintingBenchmark extends ExampleData {
+  @Benchmark
+  def printFoosToString: String = Printer.noSpaces.pretty(foosJson)
+
+  @Benchmark
+  def printFoosToByteBuffer: ByteBuffer = Printer.noSpaces.prettyByteBuffer(foosJson)
+
+  @Benchmark
+  def printBooleansToString: String = Printer.noSpaces.pretty(booleansJson)
+
+  @Benchmark
+  def printBooleansToByteBuffer: ByteBuffer = Printer.noSpaces.prettyByteBuffer(booleansJson)
+
+  @Benchmark
+  def printIntsToString: String = Printer.noSpaces.pretty(intsJson)
+
+  @Benchmark
+  def printIntsToByteBuffer: ByteBuffer = Printer.noSpaces.prettyByteBuffer(intsJson)
+}

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/GenericDerivationBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/GenericDerivationBenchmarkSpec.scala
@@ -2,8 +2,8 @@ package io.circe.benchmark
 
 import org.scalatest.FlatSpec
 
-class CirceDerivationBenchmarkSpec extends FlatSpec {
-  val benchmark: CirceDerivationBenchmark = new CirceDerivationBenchmark
+class GenericDerivationBenchmarkSpec extends FlatSpec {
+  val benchmark: GenericDerivationBenchmark = new GenericDerivationBenchmark
 
   import benchmark._
 

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
@@ -1,0 +1,43 @@
+package io.circe.benchmark
+
+import io.circe.jawn.decode
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.UTF_8
+import org.scalatest.FlatSpec
+
+class PrintingBenchmarkSpec extends FlatSpec {
+  val benchmark: PrintingBenchmark = new PrintingBenchmark
+
+  import benchmark._
+
+  def byteBufferToString(buffer: ByteBuffer): String = {
+    val bytes = new Array[Byte](buffer.limit)
+    buffer.get(bytes)
+
+    new String(bytes, UTF_8)
+  }
+
+  "The string printer" should "correctly decode Foos" in {
+    assert(decode[Map[String, Foo]](printFoosToString) === Right(foos))
+  }
+
+  it should "correctly encode Ints" in {
+    assert(decode[List[Int]](printIntsToString) === Right(ints))
+  }
+
+  it should "correctly encode Booleans" in {
+    assert(decode[List[Boolean]](printBooleansToString) === Right(booleans))
+  }
+
+  "The byte buffer printer" should "correctly decode Foos" in {
+    assert(decode[Map[String, Foo]](byteBufferToString(printFoosToByteBuffer)) === Right(foos))
+  }
+
+  it should "correctly encode Ints" in {
+    assert(decode[List[Int]](byteBufferToString(printIntsToByteBuffer)) === Right(ints))
+  }
+
+  it should "correctly encode Booleans" in {
+    assert(decode[List[Boolean]](byteBufferToString(printBooleansToByteBuffer)) === Right(booleans))
+  }
+}

--- a/modules/core/js/src/main/scala/io/circe/PlatformSpecificPrinting.scala
+++ b/modules/core/js/src/main/scala/io/circe/PlatformSpecificPrinting.scala
@@ -1,3 +1,7 @@
 package io.circe
 
-abstract class PlatformSpecificPrinting
+import java.io.Writer
+
+abstract class PlatformSpecificPrinting {
+  def bufferWriter(writer: Writer): Writer = writer
+}

--- a/modules/core/js/src/main/scala/io/circe/PlatformSpecificPrinting.scala
+++ b/modules/core/js/src/main/scala/io/circe/PlatformSpecificPrinting.scala
@@ -1,7 +1,12 @@
 package io.circe
 
-import java.io.Writer
+import java.io.{ ByteArrayOutputStream, Writer }
+import java.nio.ByteBuffer
 
 abstract class PlatformSpecificPrinting {
+  protected[this] class EnhancedByteArrayOutputStream extends ByteArrayOutputStream {
+    def toByteBuffer: ByteBuffer = ByteBuffer.wrap(this.toByteArray)
+  }
+
   def bufferWriter(writer: Writer): Writer = writer
 }

--- a/modules/core/jvm/src/main/scala/io/circe/PlatformSpecificPrinting.scala
+++ b/modules/core/jvm/src/main/scala/io/circe/PlatformSpecificPrinting.scala
@@ -1,22 +1,7 @@
 package io.circe
 
-import java.io.{ BufferedWriter, ByteArrayOutputStream, OutputStreamWriter }
-import java.nio.ByteBuffer
+import java.io.{ BufferedWriter, Writer }
 
-abstract class PlatformSpecificPrinting { Printer =>
-  protected[this] def printJsonAtDepth(writer: Appendable)(json: Json, depth: Int): Unit
-
-  private[this] class EnhancedByteArrayOutputStream extends ByteArrayOutputStream {
-    def toByteBuffer: ByteBuffer = ByteBuffer.wrap(this.buf, 0, this.size)
-  }
-
-  final def prettyByteBuffer(json: Json): ByteBuffer = {
-    val bytes = new EnhancedByteArrayOutputStream
-    val writer = new BufferedWriter(new OutputStreamWriter(bytes, "UTF-8"))
-
-    printJsonAtDepth(writer)(json, 0)
-
-    writer.close()
-    bytes.toByteBuffer
-  }
+abstract class PlatformSpecificPrinting {
+  def bufferWriter(writer: Writer): Writer = new BufferedWriter(writer)
 }

--- a/modules/core/jvm/src/main/scala/io/circe/PlatformSpecificPrinting.scala
+++ b/modules/core/jvm/src/main/scala/io/circe/PlatformSpecificPrinting.scala
@@ -1,7 +1,12 @@
 package io.circe
 
-import java.io.{ BufferedWriter, Writer }
+import java.io.{ BufferedWriter, ByteArrayOutputStream, Writer }
+import java.nio.ByteBuffer
 
 abstract class PlatformSpecificPrinting {
+  protected[this] class EnhancedByteArrayOutputStream extends ByteArrayOutputStream {
+    def toByteBuffer: ByteBuffer = ByteBuffer.wrap(this.buf, 0, this.size)
+  }
+
   def bufferWriter(writer: Writer): Writer = new BufferedWriter(writer)
 }

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -159,14 +159,16 @@ final case class Printer(
       case Json.JBoolean(b) => if (b) writer.append("true") else writer.append("false")
       case Json.JObject(o) =>
         val p = pieces(depth)
+        val m = o.toMap
         writer.append(p.lBraces)
-        val items = if (preserveOrder) o.toList else o.toMap
+        val fields = if (preserveOrder) o.fields else o.fieldSet
         var first = true
 
-        val fieldIterator = items.iterator
+        val fieldIterator = fields.iterator
 
         while (fieldIterator.hasNext) {
-          val (key, value) = fieldIterator.next()
+          val key = fieldIterator.next()
+          val value = m(key)
           if (!dropNullKeys || !value.isNull) {
             if (!first) writer.append(p.objectCommas)
             printJsonString(writer)(key)

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -178,18 +178,16 @@ final case class Printer(
         writer.append(p.rBraces)
       case Json.JArray(a) =>
         val p = pieces(depth)
-        val len = a.length
 
-        if (len == 0) writer.append(p.lrEmptyBrackets) else {
+        if (a.isEmpty) writer.append(p.lrEmptyBrackets) else {
+          val iterator = a.iterator
+
           writer.append(p.lBrackets)
-          printJsonAtDepth(writer)(a(0), depth + 1)
+          printJsonAtDepth(writer)(iterator.next(), depth + 1)
 
-          var i = 1
-
-          while (i < len) {
+          while (iterator.hasNext) {
             writer.append(p.arrayCommas)
-            printJsonAtDepth(writer)(a(i), depth + 1)
-            i += 1
+            printJsonAtDepth(writer)(iterator.next(), depth + 1)
           }
 
           writer.append(p.rBrackets)

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import java.io.{ ByteArrayOutputStream, OutputStreamWriter }
+import java.io.OutputStreamWriter
 import java.lang.StringBuilder
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
@@ -244,10 +244,6 @@ final case class Printer(
     printJsonAtDepth(writer)(json, 0)
 
     writer.toString
-  }
-
-  private[this] class EnhancedByteArrayOutputStream extends ByteArrayOutputStream {
-    def toByteBuffer: ByteBuffer = ByteBuffer.wrap(this.buf, 0, this.size)
   }
 
   final def prettyByteBuffer(json: Json): ByteBuffer = {

--- a/modules/tests/jvm/src/main/scala/io/circe/tests/PlatformSpecificPrinterTests.scala
+++ b/modules/tests/jvm/src/main/scala/io/circe/tests/PlatformSpecificPrinterTests.scala
@@ -1,22 +1,8 @@
 package io.circe.tests
 
-import io.circe.Json
 import io.circe.testing.PrinterTests
-import java.nio.charset.StandardCharsets.UTF_8
 
 trait PlatformSpecificPrinterTests { self: PrinterSuite =>
   // Temporarily JVM-only because of problems round-tripping in Scala.js.
   checkLaws("Printing Long", PrinterTests[Long].printer(printer, parser))
-
-  "prettyByteBuffer" should "match pretty" in forAll { (json: Json) =>
-    val buffer = printer.prettyByteBuffer(json)
-
-    val bytes = new Array[Byte](buffer.limit)
-    buffer.get(bytes)
-
-    val asString = new String(bytes, UTF_8)
-    val expected = printer.pretty(json)
-
-    assert(asString === expected)
-  }
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/MemoizedPiecesSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/MemoizedPiecesSuite.scala
@@ -19,7 +19,7 @@ class MemoizedPiecesSuite extends CirceSuite with ScalaFutures {
   }
 
   def makePieces: Printer.MemoizedPieces = new Printer.MemoizedPieces {
-    def compute(i: Int): Printer.Pieces = Printer.Pieces(
+    def compute(i: Int): Printer.Pieces = new Printer.Pieces(
       "%s%s%s".format(" " * i, "a", " " * (i + 1)),
       "%s%s%s".format(" " * i, "b", " " * (i + 1)),
       "%s%s%s".format(" " * i, "c", " " * (i + 1)),

--- a/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -1,7 +1,8 @@
 package io.circe.tests
 
-import io.circe.{ Parser, Printer }
+import io.circe.{ Json, Parser, Printer }
 import io.circe.testing.PrinterTests
+import java.nio.charset.StandardCharsets.UTF_8
 
 class PrinterSuite(val printer: Printer, val parser: Parser) extends CirceSuite with PlatformSpecificPrinterTests {
   checkLaws("Printing Unit", PrinterTests[Unit].printer(printer, parser))
@@ -12,4 +13,16 @@ class PrinterSuite(val printer: Printer, val parser: Parser) extends CirceSuite 
   checkLaws("Printing Short", PrinterTests[Short].printer(printer, parser))
   checkLaws("Printing Int", PrinterTests[Int].printer(printer, parser))
   checkLaws("Printing Map", PrinterTests[Map[String, List[Int]]].printer(printer, parser))
+
+  "prettyByteBuffer" should "match pretty" in forAll { (json: Json) =>
+    val buffer = printer.prettyByteBuffer(json)
+
+    val bytes = new Array[Byte](buffer.limit)
+    buffer.get(bytes)
+
+    val asString = new String(bytes, UTF_8)
+    val expected = printer.pretty(json)
+
+    assert(asString === expected)
+  }
 }


### PR DESCRIPTION
First stab at investigating #542, but the results aren't very surprising / helpful:

```
Benchmark                                     Mode  Cnt      Score      Error  Units
PrintingBenchmark.printBooleansToByteBuffer  thrpt   20  31892.871 ± 2119.524  ops/s
PrintingBenchmark.printBooleansToString      thrpt   20  37532.772 ± 3550.116  ops/s
PrintingBenchmark.printFoosToByteBuffer      thrpt   20   2839.652 ±  221.515  ops/s
PrintingBenchmark.printFoosToString          thrpt   20   3496.935 ±   39.529  ops/s
PrintingBenchmark.printIntsToByteBuffer      thrpt   20  17816.349 ± 1988.353  ops/s
PrintingBenchmark.printIntsToString          thrpt   20  17039.468 ± 4612.298  ops/s
```