### PR TITLE
Add durban/seals to the list of related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following open source projects are either built on circe or provide circe su
   implementation.
 * [scalist][scalist]: A [Todoist][todoist] API client.
 * [scala-jsonapi][scala-jsonapi]:  Scala support library for integrating the JSON API spec with Spray, Play! or Circe
+* [seals][seals]: Tools for schema evolution and language-integrated schemata (derives circe encoders and decoders).
 * [Slick-pg][slick-pg]: [Slick][slick] extensions for PostgreSQL.
 * [telepooz][telepooz]: A Scala wrapper for the [Telegram Bot API][telegram-bot-api] built on circe.
 * [Zenith][zenith]: Functional HTTP library built on circe.
@@ -162,6 +163,7 @@ limitations under the License.
 [scala-js]: http://www.scala-js.org/
 [scala-jsonapi]: https://github.com/zalando/scala-jsonapi
 [scalist]: https://github.com/vpavkin/scalist
+[seals]: https://github.com/durban/seals/
 [slick]: http://slick.lightbend.com/
 [slick-pg]: https://github.com/tminglei/slick-pg
 [snakeyaml]: https://bitbucket.org/asomov/snakeyaml


### PR DESCRIPTION
As discussed in https://github.com/durban/seals/issues/41, this commit adds the project to the list of related projects in `README.md`.