### PR TITLE
Change CrossVersion.full to use CrossVersion.patch for Typelevel Scala compatibility.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -209,8 +209,8 @@ lazy val aggregatedProjects: Seq[ProjectReference] =
 
 def macroSettings(scaladocFor210: Boolean): Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
-    "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
-    "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
+    scalaOrganization.value % "scala-compiler" % scalaVersion.value % Provided,
+    scalaOrganization.value % "scala-reflect" % scalaVersion.value % Provided,
     "org.typelevel" %%% "macro-compat" % "1.1.1",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,7 @@ lazy val docs = project.dependsOn(core, generic, parser, optics)
   .settings(docSettings)
   .settings(noPublishSettings)
   .settings(
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
   )
   .enablePlugins(MicrositesPlugin)
   .enablePlugins(ScalaUnidocPlugin)
@@ -212,7 +212,7 @@ def macroSettings(scaladocFor210: Boolean): Seq[Setting[_]] = Seq(
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
     "org.typelevel" %%% "macro-compat" % "1.1.1",
-    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
   ),
   libraryDependencies ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
@@ -234,7 +234,7 @@ lazy val circe = project.in(file("."))
   .settings(allSettings)
   .settings(noPublishSettings)
   .settings(
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch),
     initialCommands in console :=
       """
         |import io.circe._
@@ -365,7 +365,7 @@ lazy val testsBase = circeCrossModule("tests", mima = None)
       "org.typelevel" %%% "cats-laws" % catsVersion,
       "org.typelevel" %%% "discipline" % disciplineVersion,
       "eu.timepit" %%% "refined-scalacheck" % refinedVersion,
-      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
     ),
     sourceGenerators in Test += (sourceManaged in Test).map(Boilerplate.genTests).taskValue,
     unmanagedResourceDirectories in Compile +=
@@ -424,7 +424,7 @@ lazy val opticsBase = circeCrossModule("optics", mima = previousCirceVersion, Cr
     libraryDependencies ++= Seq(
       "com.github.julien-truffaut" %%% "monocle-core" % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-law"  % monocleVersion % Test,
-      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
     )
   )
   .dependsOn(coreBase, testsBase % Test)
@@ -441,7 +441,7 @@ lazy val benchmark = circeModule("benchmark", mima = None)
     },
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
-      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
     )
   )
   .enablePlugins(JmhPlugin)


### PR DESCRIPTION
Including text from the issue at [typelevel/scala#135](https://github.com/typelevel/scala/issues/135): 

> To use Typelevel Scala versions which are not exactly aligned with the corresponding Lightbend Scala version (ie. because they include an additional -bin-patch-nnn suffix in their version) we need to modify project builds which use CrossVersion.full (which includes the suffix) to use CrossVersion.patch (which doesn't) where appropriate (eg. for macro-paradise and other compiler plugins).

Replaced the aforementioned, as well as updating the use of "org.scala-lang" to scalaOrganization.value in library dependencies.