### PR TITLE
Define Iso[JsonObject, List[(String, Json)]]

### DIFF
--- a/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
@@ -2,7 +2,7 @@ package io.circe.optics
 
 import cats.instances.list.catsStdInstancesForList
 import io.circe.{ Json, JsonObject }
-import monocle.{ Lens, Traversal }
+import monocle.{ Iso, Lens, Traversal }
 import monocle.function.{ At, Each, FilterIndex, Index }
 import scalaz.{ Applicative, Traverse }
 import scalaz.std.ListInstances
@@ -46,6 +46,15 @@ trait JsonObjectOptics extends CatsConversions with ListInstances {
   }
 
   implicit final lazy val objectIndex: Index[JsonObject, String, Json] = Index.fromAt
+
+  final lazy val jsonObjectIso: Iso[JsonObject, List[(String, Json)]] =
+    Iso((_: JsonObject).toList)(JsonObject.fromIterable)
+
+  final lazy val jsonObjectFields: Traversal[JsonObject, (String, Json)] =
+    jsonObjectIso.composeTraversal(Traversal.fromTraverse[List, (String, Json)])
+
+  final lazy val jsonFields: Traversal[Json, (String, Json)] =
+    JsonOptics.jsonObject.composeTraversal(jsonObjectFields)
 }
 
 final object JsonObjectOptics extends JsonObjectOptics

--- a/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
@@ -6,7 +6,7 @@ import io.circe.tests.CirceSuite
 import io.circe.{ Json, JsonNumber, JsonObject }
 import monocle.function.Plated.plate
 import monocle.law.discipline.function.{ AtTests, EachTests, FilterIndexTests, IndexTests }
-import monocle.law.discipline.{ PrismTests, TraversalTests }
+import monocle.law.discipline.{ IsoTests, PrismTests, TraversalTests }
 import scalaz.Equal
 import scalaz.std.anyVal._
 import scalaz.std.math.bigDecimal._
@@ -14,6 +14,8 @@ import scalaz.std.math.bigInt._
 import scalaz.std.option._
 import scalaz.std.string._
 import scalaz.std.vector._
+import scalaz.std.list.listEqual
+import scalaz.std.tuple._
 
 class OpticsSuite extends CirceSuite {
   implicit val equalJson: Equal[Json] = Equal.equal(Eq[Json].eqv)
@@ -27,6 +29,8 @@ class OpticsSuite extends CirceSuite {
   implicit val doubleInstance: Equal[Double] = Equal.equal { (a, b) =>
     (a.isNaN && b.isNaN) || scalaz.std.anyVal.doubleInstance.equal(a, b)
   }
+
+  checkLaws("JsonObject Iso List[(String, Json)]", IsoTests(jsonObjectIso))
 
   checkLaws("Json to Unit", PrismTests(jsonNull))
   checkLaws("Json to Boolean", PrismTests(jsonBoolean))


### PR DESCRIPTION
Based on gitter discussion with @travisbrown: https://gitter.im/circe/circe?at=58bc792221d548df2c94ea01

Currently there is a failing test which generates over [1000 lines of output when it fails](https://gist.github.com/benhutchison/5e096c5725dcd5b581b7c4c2261b77a3#file-propertybasedtestingisawesome-log); I cant make head or tail of what's wrong, except to suggest that pruning the test data generation somehow will probably fix it.