### PR TITLE
No default configuration for @ConfiguredJsonCodec

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -17,3 +17,7 @@ final object Configuration {
     "$1_$2"
   ).replaceAll("([a-z\\d])([A-Z])", "$1_$2").toLowerCase
 }
+
+final object DefaultConfiguration {
+  implicit val default: Configuration = Configuration.default
+}

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -18,6 +18,6 @@ final object Configuration {
   ).replaceAll("([a-z\\d])([A-Z])", "$1_$2").toLowerCase
 }
 
-final object DefaultConfiguration {
-  implicit val default: Configuration = Configuration.default
+final object defaults {
+  implicit val defaults: Configuration = Configuration.default
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -10,7 +10,7 @@ final case class Configuration(transformKeys: String => String, useDefaults: Boo
 }
 
 final object Configuration {
-  implicit val default: Configuration = Configuration(Predef.identity, false, None)
+  val default: Configuration = Configuration(Predef.identity, false, None)
 
   val snakeCaseTransformation: String => String = _.replaceAll(
     "([A-Z]+)([A-Z][a-z])",

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -76,7 +76,7 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
   }
 
   {
-    import DefaultConfiguration._
+    import defaults._
     checkLaws("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
     checkLaws("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
     checkLaws("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -76,7 +76,7 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
   }
 
   {
-    implicit val configuration = Configuration.default
+    import DefaultConfiguration._
     checkLaws("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
     checkLaws("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
     checkLaws("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -75,17 +75,20 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
     assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
   }
 
-  checkLaws("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
-  checkLaws("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
-  checkLaws("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
-  checkLaws("Codec[Foo]", CodecTests[Foo].codec)
+  {
+    implicit val configuration = Configuration.default
+    checkLaws("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
+    checkLaws("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
+    checkLaws("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
+    checkLaws("Codec[Foo]", CodecTests[Foo].codec)
 
-  "Decoder[Int => Qux[String]]" should "decode partial JSON representations" in forAll { (i: Int, s: String, j: Int) =>
-    val result = Json.obj(
-      "a" -> Json.fromString(s),
-      "j" -> Json.fromInt(j)
-    ).as[Int => Qux[String]].map(_(i))
+    "Decoder[Int => Qux[String]]" should "decode partial JSON representations" in forAll { (i: Int, s: String, j: Int) =>
+      val result = Json.obj(
+        "a" -> Json.fromString(s),
+        "j" -> Json.fromInt(j)
+      ).as[Int => Qux[String]].map(_(i))
 
-    assert(result === Right(Qux(i, s, j)))
+      assert(result === Right(Qux(i, s, j)))
+    }
   }
 }


### PR DESCRIPTION
There should be no default configuration for `@ConfiguredJsonCodec`. When you choose the use that instead of `@JsonCodec`, you always want to specify your own configuration.

This is mainly a problem with intellij, that tells you importing the config from somewhere is an unused import statement. And cleans it up, which means your code breaks without any warning.