### PR TITLE
Some adjustments to #595 to accommodate Scala.js

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -145,6 +145,10 @@ object Encoder extends TupleEncoders with ProductEncoders with MidPriorityEncode
   }
 
   /**
+   * Note that on Scala.js the encoding of `Float` values is subject to the
+   * usual limitations of `Float#toString` on that platform (e.g. `1.1f` will be
+   * encoded as a [[Json]] value that will be printed as `"1.100000023841858"`).
+   *
    * @group Encoding
    */
   implicit final val encodeFloat: Encoder[Float] = new Encoder[Float] {

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -375,7 +375,7 @@ final object Json {
    *
    * The result is empty if the argument cannot be represented as a JSON number.
    */
-  final def fromFloat(value: Float): Option[Json] = if (isReal(value)) Some(JNumber(jsonFloat(value))) else None
+  final def fromFloat(value: Float): Option[Json] = if (isReal(value)) Some(JNumber(floatToJsonDouble(value))) else None
 
   /**
    * Create a `Json` value representing a JSON number or null from a `Double`.
@@ -391,7 +391,7 @@ final object Json {
    * The result is a JSON null if the argument cannot be represented as a JSON
    * number.
    */
-  final def fromFloatOrNull(value: Float): Json = if (isReal(value)) JNumber(jsonFloat(value)) else Null
+  final def fromFloatOrNull(value: Float): Json = if (isReal(value)) JNumber(floatToJsonDouble(value)) else Null
 
   /**
    * Create a `Json` value representing a JSON number or string from a `Double`.
@@ -400,7 +400,7 @@ final object Json {
    * number.
    */
   final def fromDoubleOrString(value: Double): Json =
-    if (isReal(value)) JNumber(JsonDouble(value)) else fromString(value.toString)
+    if (isReal(value)) JNumber(JsonDouble(value)) else fromString(java.lang.Double.toString(value))
 
   /**
    * Create a `Json` value representing a JSON number or string from a `Float`.
@@ -409,7 +409,7 @@ final object Json {
    * number.
    */
   final def fromFloatOrString(value: Float): Json =
-    if (isReal(value)) JNumber(jsonFloat(value)) else fromString(value.toString)
+    if (isReal(value)) JNumber(floatToJsonDouble(value)) else fromString(java.lang.Float.toString(value))
 
   /**
    * Create a `Json` value representing a JSON number from a `BigInt`.
@@ -422,17 +422,24 @@ final object Json {
   final def fromBigDecimal(value: BigDecimal): Json = JNumber(JsonBigDecimal(value))
 
   /**
-   * Convert a Float to a JsonDouble whilst avoiding float point errors.
-   * e.g. 1.1f.toDouble == 1.100000023841858
+   * Convert a `Float` to a [[JsonDouble]] while avoiding errors resulting from
+   * the difference in the precision (e.g. 1.1f.toDouble == 1.100000023841858).
    */
-  private[this] def jsonFloat(value: Float) = JsonDouble(java.lang.Double.parseDouble(java.lang.Float.toString(value)))
+  private[this] def floatToJsonDouble(value: Float) =
+    JsonDouble(java.lang.Double.parseDouble(java.lang.Float.toString(value)))
 
+  /**
+   * Calling `.isNaN` and `.isInfinity` directly on the value boxes; we
+   * explicitly avoid that here.
+   */
   private[this] def isReal(value: Double): Boolean =
-    // .isNaN and .isInfinity box, we explicitly avoid that here
     (!java.lang.Double.isNaN(value)) && (!java.lang.Double.isInfinite(value))
 
+  /**
+   * Calling `.isNaN` and `.isInfinity` directly on the value boxes; we
+   * explicitly avoid that here.
+   */
   private[this] def isReal(value: Float): Boolean =
-    // .isNaN and .isInfinity box, we explicitly avoid that here
     (!java.lang.Float.isNaN(value)) && (!java.lang.Float.isInfinite(value))
 
   private[this] final def arrayEq(x: Seq[Json], y: Seq[Json]): Boolean = {

--- a/modules/tests/js/src/test/scala/io/circe/FloatJsonTests.scala
+++ b/modules/tests/js/src/test/scala/io/circe/FloatJsonTests.scala
@@ -1,0 +1,9 @@
+package io.circe
+
+import io.circe.tests.CirceSuite
+
+/**
+ * On the JVM this trait contains tests that fail because of limitations on
+ * Scala.js.
+ */
+trait FloatJsonTests { this: CirceSuite => }

--- a/modules/tests/jvm/src/test/scala/io/circe/FloatJsonTests.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/FloatJsonTests.scala
@@ -1,0 +1,13 @@
+package io.circe
+
+import io.circe.tests.CirceSuite
+
+/**
+ * Tests that fail because of limitations on Scala.js.
+ */
+trait FloatJsonTests { this: CirceSuite =>
+  "fromFloatOrString" should "return JNumber for valid Floats" in {
+    assert(Json.fromFloatOrString(1.1f) === Json.JNumber(JsonNumber.fromDecimalStringUnsafe("1.1")))
+    assert(Json.fromFloatOrString(-1.2f) === Json.JNumber(JsonNumber.fromDecimalStringUnsafe("-1.2")))
+  }
+}

--- a/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
@@ -10,11 +10,15 @@ class JsonNumberSuite extends CirceSuite {
   }
 
   it should "match Json.fromDouble" in forAll { (d: Double) =>
-    assert(Json.fromDouble(d).flatMap(_.asNumber) === JsonNumber.fromString(d.toString))
+    val expected = Json.fromDouble(d).flatMap(_.asNumber)
+
+    assert(JsonNumber.fromString(d.toString) === expected)
   }
 
   it should "match Json.fromFloat" in forAll { (f: Float) =>
-    assert(Json.fromFloat(f).flatMap(_.asNumber) === JsonNumber.fromString(f.toString))
+    val expected = Json.fromFloat(f).flatMap(_.asNumber)
+
+    assert(JsonNumber.fromString(f.toString) === expected)
   }
 
   it should "round-trip Byte" in forAll { (b: Byte) =>
@@ -86,58 +90,5 @@ class JsonNumberSuite extends CirceSuite {
 
   it should "distinguishes negative and positive zeros with fractional parts" in {
     assert(JsonNumber.fromDecimalStringUnsafe("-0.0") =!= JsonNumber.fromDecimalStringUnsafe("0.0"))
-  }
-
-  "fromDouble" should "fail on Double.NaN" in {
-    assert(Json.fromDouble(Double.NaN) === None)
-  }
-
-  it should "fail on Double.PositiveInfinity" in {
-    assert(Json.fromDouble(Double.PositiveInfinity) === None)
-  }
-
-  it should "fail on Double.NegativeInfinity" in {
-    assert(Json.fromDouble(Double.NegativeInfinity) === None)
-  }
-
-  "fromFloat" should "fail on Float.NaN" in {
-    assert(Json.fromFloat(Float.NaN) === None)
-  }
-
-  it should "fail on Float.PositiveInfinity" in {
-    assert(Json.fromFloat(Float.PositiveInfinity) === None)
-  }
-
-  it should "fail on Float.NegativeInfinity" in {
-    assert(Json.fromFloat(Float.NegativeInfinity) === None)
-  }
-
-  "fromFloatOrNull" should "return Null on Float.NaN" in {
-    assert(Json.fromFloatOrNull(Float.NaN) === Json.Null)
-  }
-
-  it should "return Null on Float.PositiveInfinity" in {
-    assert(Json.fromFloatOrNull(Float.PositiveInfinity) === Json.Null)
-  }
-
-  it should "return NUll on Float.NegativeInfinity" in {
-    assert(Json.fromFloatOrNull(Float.NegativeInfinity) === Json.Null)
-  }
-
-  "fromFloatOrString" should "return String on Float.NaN" in {
-    assert(Json.fromFloatOrString(Float.NaN) === Json.JString("NaN"))
-  }
-
-  it should "return String on Float.PositiveInfinity" in {
-    assert(Json.fromFloatOrString(Float.PositiveInfinity) === Json.JString("Infinity"))
-  }
-
-  it should "return String on Float.NegativeInfinity" in {
-    assert(Json.fromFloatOrString(Float.NegativeInfinity) === Json.JString("-Infinity"))
-  }
-
-  it should "return JNumber for valid Floats" in {
-    assert(Json.fromFloatOrString(1.1f) === Json.JNumber(JsonNumber.fromDecimalStringUnsafe("1.1")))
-    assert(Json.fromFloatOrString(-1.2f) === Json.JNumber(JsonNumber.fromDecimalStringUnsafe("-1.2")))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -3,7 +3,7 @@ package io.circe
 import io.circe.Json.{JString, JArray, JNumber, JBoolean, JObject, JNull}
 import io.circe.tests.CirceSuite
 
-class JsonSuite extends CirceSuite {
+class JsonSuite extends CirceSuite with FloatJsonTests {
   "deepMerge" should "preserve argument order" in forAll { (js: List[Json]) =>
     val fields = js.zipWithIndex.map {
       case (j, i) => i.toString -> j
@@ -65,5 +65,82 @@ class JsonSuite extends CirceSuite {
     val resultAlias = json \\ key
 
     assert(result === expected && resultAlias === expected)
+  }
+
+  "fromDouble" should "fail on Double.NaN" in {
+    assert(Json.fromDouble(Double.NaN) === None)
+  }
+
+  it should "fail on Double.PositiveInfinity" in {
+    assert(Json.fromDouble(Double.PositiveInfinity) === None)
+  }
+
+  it should "fail on Double.NegativeInfinity" in {
+    assert(Json.fromDouble(Double.NegativeInfinity) === None)
+  }
+
+  "fromDoubleOrNull" should "return Null on Double.NaN" in {
+    assert(Json.fromDoubleOrNull(Double.NaN) === Json.Null)
+  }
+
+  it should "return Null on Double.PositiveInfinity" in {
+    assert(Json.fromDoubleOrNull(Double.PositiveInfinity) === Json.Null)
+  }
+
+  it should "return Null on Double.NegativeInfinity" in {
+    assert(Json.fromDoubleOrNull(Double.NegativeInfinity) === Json.Null)
+  }
+
+  "fromDoubleOrString" should "return String on Double.NaN" in {
+    assert(Json.fromDoubleOrString(Double.NaN) === Json.JString("NaN"))
+  }
+
+  it should "return String on Double.PositiveInfinity" in {
+    assert(Json.fromDoubleOrString(Double.PositiveInfinity) === Json.JString("Infinity"))
+  }
+
+  it should "return String on Double.NegativeInfinity" in {
+    assert(Json.fromDoubleOrString(Double.NegativeInfinity) === Json.JString("-Infinity"))
+  }
+
+  it should "return JNumber for valid Doubles" in {
+    assert(Json.fromDoubleOrString(1.1) === Json.JNumber(JsonNumber.fromDecimalStringUnsafe("1.1")))
+    assert(Json.fromDoubleOrString(-1.2) === Json.JNumber(JsonNumber.fromDecimalStringUnsafe("-1.2")))
+  }
+
+  "fromFloat" should "fail on Float.NaN" in {
+    assert(Json.fromFloat(Float.NaN) === None)
+  }
+
+  it should "fail on Float.PositiveInfinity" in {
+    assert(Json.fromFloat(Float.PositiveInfinity) === None)
+  }
+
+  it should "fail on Float.NegativeInfinity" in {
+    assert(Json.fromFloat(Float.NegativeInfinity) === None)
+  }
+
+  "fromFloatOrNull" should "return Null on Float.NaN" in {
+    assert(Json.fromFloatOrNull(Float.NaN) === Json.Null)
+  }
+
+  it should "return Null on Float.PositiveInfinity" in {
+    assert(Json.fromFloatOrNull(Float.PositiveInfinity) === Json.Null)
+  }
+
+  it should "return Null on Float.NegativeInfinity" in {
+    assert(Json.fromFloatOrNull(Float.NegativeInfinity) === Json.Null)
+  }
+
+  "fromFloatOrString" should "return String on Float.NaN" in {
+    assert(Json.fromFloatOrString(Float.NaN) === Json.JString("NaN"))
+  }
+
+  it should "return String on Float.PositiveInfinity" in {
+    assert(Json.fromFloatOrString(Float.PositiveInfinity) === Json.JString("Infinity"))
+  }
+
+  it should "return String on Float.NegativeInfinity" in {
+    assert(Json.fromFloatOrString(Float.NegativeInfinity) === Json.JString("-Infinity"))
   }
 }


### PR DESCRIPTION
Some miscellaneous clean-up. The important change is that a test that's failing on Scala.js after #595 has been made JVM-only. I thought about trying to make the handling of `Float` values behave correctly on Scala.js, but it's non-trivial, so I'm following Scala.js itself in just saying "floats are messed up". Specifically [this warning](https://www.scala-js.org/doc/semantics.html) holds for circe's encoding of floats on Scala.js:

> Floats print in a weird way because they are printed as if they were Doubles, which means their lack of precision shows up.

If someone wants to try to fix this, that'd be fantastic, but it's a very, very low priority for me personally.