### PR TITLE
Fix JsonNumber equality

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -265,19 +265,10 @@ final object JsonNumber {
   }
 
   implicit final val eqJsonNumber: Eq[JsonNumber] = Eq.instance {
-    case (JsonBiggerDecimal(a), b) => a == b.toBiggerDecimal
-    case (a, JsonBiggerDecimal(b)) => a.toBiggerDecimal == b
-    case (a @ JsonDecimal(_), b) => a.toBiggerDecimal == b.toBiggerDecimal
-    case (a, b @ JsonDecimal(_)) => a.toBiggerDecimal == b.toBiggerDecimal
     case (JsonLong(x), JsonLong(y)) => x == y
-    case (JsonFloat(x), JsonLong(y)) => x == y
-    case (JsonDouble(x), JsonLong(y)) => x == y
-    case (JsonLong(x), JsonDouble(y)) => y == x
-    case (JsonFloat(x), JsonDouble(y)) => y == x
     case (JsonDouble(x), JsonDouble(y)) => java.lang.Double.compare(x, y) == 0
-    case (JsonLong(x), JsonFloat(y)) => x == y
     case (JsonFloat(x), JsonFloat(y)) => java.lang.Float.compare(x, y) == 0
-    case (JsonDouble(x), JsonFloat(y)) => x == y
-    case (a, b) => a.toBigDecimal == b.toBigDecimal
+    case (JsonBigDecimal(x), JsonBigDecimal(y)) => x == y
+    case (a, b) => a.toBiggerDecimal == b.toBiggerDecimal
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
@@ -67,14 +67,6 @@ class JsonNumberSuite extends CirceSuite {
     }
   }
 
-  "JsonFloat.toLong" should "return None if it loses precision" in forAll { (f: Float) =>
-    if (f.toLong.toFloat == f) {
-      assert(JsonFloat(f).toLong === Some(f.toLong))
-    } else {
-      assert(JsonFloat(f).toLong === None)
-    }
-  }
-
   "JsonFloat.toBigInt" should "return None if it loses precision" in forAll { (f: Float) =>
     val j = JsonFloat(f)
     val expected = j.toBiggerDecimal match {

--- a/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
@@ -113,12 +113,45 @@ class JsonNumberSuite extends CirceSuite {
     assert(JsonNumber.fromString(l.toString).map(_.truncateToInt) === Some(truncated))
   }
 
+  val positiveZeros: List[JsonNumber] = List(
+    JsonNumber.fromIntegralStringUnsafe("0"),
+    JsonNumber.fromDecimalStringUnsafe("0.0"),
+    Json.fromDouble(0.0).flatMap(_.asNumber).get,
+    Json.fromFloat(0.0f).flatMap(_.asNumber).get,
+    Json.fromLong(0).asNumber.get,
+    Json.fromBigInt(BigInt(0)).asNumber.get,
+    Json.fromBigDecimal(BigDecimal(0)).asNumber.get
+  )
+
+  val negativeZeros: List[JsonNumber] = List(
+    JsonNumber.fromIntegralStringUnsafe("-0"),
+    JsonNumber.fromDecimalStringUnsafe("-0.0"),
+    Json.fromDouble(-0.0).flatMap(_.asNumber).get,
+    Json.fromFloat(-0.0f).flatMap(_.asNumber).get
+  )
+
   "Eq[JsonNumber]" should "distinguish negative and positive zeros" in {
-    assert(JsonNumber.fromIntegralStringUnsafe("-0") =!= JsonNumber.fromIntegralStringUnsafe("0"))
+    positiveZeros.foreach { pz =>
+      negativeZeros.foreach { nz =>
+        assert(pz =!= nz)
+      }
+    }
   }
 
-  it should "distinguishes negative and positive zeros with fractional parts" in {
-    assert(JsonNumber.fromDecimalStringUnsafe("-0.0") =!= JsonNumber.fromDecimalStringUnsafe("0.0"))
+  it should "not distinguish any positive zeros" in {
+    positiveZeros.foreach { pz1 =>
+      positiveZeros.foreach { pz2 =>
+        assert(pz1 === pz2)
+      }
+    }
+  }
+
+  it should "not distinguish any negative zeros" in {
+    negativeZeros.foreach { nz1 =>
+      negativeZeros.foreach { nz2 =>
+        assert(nz1 === nz2)
+      }
+    }
   }
 
   it should "compare Float and Long" in forAll { (f: Float, l: Long) =>


### PR DESCRIPTION
The tl;dr for this PR is that there's some weird behavior for `JsonNumber` in some unusual cases if you're doing unusual things. Most users should be unaffected by both these changes and the weirdnesses they're intended to smooth out.

There are currently a couple of ways that the `Eq` instance for `JsonNumber` isn't transitive. The first involves negative zero:

```scala
scala> import cats.syntax.eq._, io.circe.Json
import cats.syntax.eq._
import io.circe.{Json, JsonNumber}

scala> val Some(lz) = Json.fromLong(0L).asNumber
lz: io.circe.JsonNumber = 0

scala> val Some(dz) = Json.fromDouble(0.0).flatMap(_.asNumber)
dz: io.circe.JsonNumber = 0.0

scala> val Some(nz) = Json.fromDouble(-0.0).flatMap(_.asNumber)
nz: io.circe.JsonNumber = -0.0

scala> lz === dz
res0: Boolean = true

scala> lz === nz
res1: Boolean = true

scala> dz === nz
res2: Boolean = false
```

The other involves comparing instances created from `Double`s and `Long`s once you get past the point that `Double` can represent integral values exactly:

```scala
scala> val bigLong = Long.MaxValue
bigLong: Long = 9223372036854775807

scala> val prettyBigLong = Long.MaxValue - 1L
prettyBigLong: Long = 9223372036854775806

scala> val Some(bigLongJson) = Json.fromLong(bigLong).asNumber
bigLongJson: io.circe.JsonNumber = 9223372036854775807

scala> val Some(prettyBigLongJson) = Json.fromLong(prettyBigLong).asNumber
prettyBigLongJson: io.circe.JsonNumber = 9223372036854775806

scala> val Some(bigDoubleJson) = Json.fromDouble(bigLong.toDouble).flatMap(_.asNumber)
bigDoubleJson: io.circe.JsonNumber = 9.223372036854776E18

scala> bigLongJson === bigDoubleJson
res3: Boolean = true

scala> prettyBigLongJson === bigDoubleJson
res4: Boolean = true

scala> bigLongJson === prettyBigLongJson
res5: Boolean = false
```

In both cases the current equality checks simply delegate to `==` on the various combinations of primitive values, which have the same problems with transitivity.

The fix in this PR makes all equality checks go via the `BiggerDecimal` representation except for the cases where we're comparing the same kind of value. This simplifies things a lot, and gives us transitivity, and the only cost is that equality checks are more expensive in some cases. Checking equality on `JsonNumber` isn't a terribly common operation, though, so I don't care much about the expense.

Setting aside equality, these changes do mean that the behavior of `toLong` will be different than in previous circe versions in certain situations. For example, this is 0.7.1:

```scala
scala>  val value = (Long.MaxValue - 525).toDouble
value: Double = 9.2233720368547748E18

scala> Json.fromDouble(value).flatMap(_.asNumber).flatMap(_.toLong)
res6: Option[Long] = Some(9223372036854774784)
```

And here's the new behavior:

```scala
scala> val value = (Long.MaxValue - 525).toDouble
value: Double = 9.2233720368547748E18

scala> Json.fromDouble(value).flatMap(_.asNumber).flatMap(_.toLong)
res0: Option[Long] = Some(9223372036854774800)
```

This follows our new policy of having all conversions from floating point numbers (i.e. both `Double` and `Float`) go via the `toString` for those types.

/cc @carymrobbins