### PR TITLE
Each instance for key-value pairs of a Json object

### DIFF
--- a/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
@@ -22,6 +22,17 @@ trait JsonObjectOptics extends CatsConversions with ListInstances {
     }
   }
 
+  implicit final lazy val objectEachKV: Each[JsonObject, (String, Json)] = new Each[JsonObject, (String, Json)] {
+    final def each: Traversal[JsonObject, (String, Json)] = new Traversal[JsonObject, (String, Json)] {
+      final def modifyF[F[_]](f: ((String, Json)) => F[(String, Json)])(from: JsonObject)(implicit
+        F: Applicative[F]
+      ): F[JsonObject] =
+        F.map(from.toList.reverse.foldLeft(F.pure(List.empty[(String, Json)])) {
+          case (acc, kv) => F.apply2(acc, f(kv)){case (list, elem) => elem :: list}
+        })(JsonObject.from(_))
+    }
+  }
+
   implicit final lazy val objectAt: At[JsonObject, String, Option[Json]] =
     new At[JsonObject, String, Option[Json]] {
       final def at(field: String): Lens[JsonObject, Option[Json]] =

--- a/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
@@ -14,6 +14,7 @@ import scalaz.std.math.bigInt._
 import scalaz.std.option._
 import scalaz.std.string._
 import scalaz.std.vector._
+import scalaz.std.tuple._
 
 class OpticsSuite extends CirceSuite {
   implicit val equalJson: Equal[Json] = Equal.equal(Eq[Json].eqv)
@@ -52,6 +53,7 @@ class OpticsSuite extends CirceSuite {
   checkLaws("plated Json", TraversalTests(plate[Json]))
 
   checkLaws("objectEach", EachTests[JsonObject, Json])
+  checkLaws("objectEachKV", EachTests[JsonObject, (String, Json)])
   checkLaws("objectAt", AtTests[JsonObject, String, Option[Json]])
   checkLaws("objectIndex", IndexTests[JsonObject, String, Json])
   checkLaws("objectFilterIndex", FilterIndexTests[JsonObject, String, Json])


### PR DESCRIPTION
Replaces #587, re discussion in earlier PR. 

This instance doesnt seem lawful. My guess is, like in #587, its failing on the case of duplicate keys in a json object, which seems to clash with the principle that for an `Each[S, A]`, [`A` is supposed to be unique for a given `S`](https://github.com/julien-truffaut/Monocle/blob/master/core/shared/src/main/scala/monocle/function/Each.scala#L11).

Whats confusing me is that there's an exisiting [`Each` instance](https://github.com/circe/circe/blob/master/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala#L17) for the fields (without keys) of a json object. But if the fields are type `A` above, they are not guaranteed to be unique either. So why is the existing instance lawful I wonder?

