### PR TITLE
551 BitVector encoder/decoder fix

### DIFF
--- a/modules/scodec/shared/src/main/scala/io/circe/scodec/package.scala
+++ b/modules/scodec/shared/src/main/scala/io/circe/scodec/package.scala
@@ -1,23 +1,65 @@
 package io.circe
 
-import _root_.scodec.bits.{BitVector, ByteVector}
+import _root_.scodec.bits.{ BitVector, ByteVector }
 
-package object scodec {
+private[circe] trait BitVectorCodec {
   implicit final val decodeBitVector: Decoder[BitVector] =
     Decoder.instance { c =>
-      Decoder.decodeString(c) match {
-        case Right(str) =>
-          BitVector.fromBase64Descriptive(str) match {
-            case r @ Right(_) => r.asInstanceOf[Decoder.Result[BitVector]]
-            case Left(err) => Left(DecodingFailure(err, c.history))
+      Decoder.decodeJsonObject(c) match {
+        case Right(jsonObject) =>
+          val decoded = for {
+            bitsJ     <- jsonObject("bits")
+            bits      <- bitsJ.asString
+            lengthJ   <- jsonObject("length")
+            length    <- lengthJ.asNumber.flatMap(_.toLong)
+            bitVector <- BitVector.fromBase64Descriptive(bits).right.toOption
+          } yield bitVector.take(length)
+
+          decoded match {
+            case Some(bitVector)  => Right(bitVector)
+            case None             => Left(DecodingFailure("Incorrect format of BitVector field", c.history))
           }
         case l @ Left(_) => l.asInstanceOf[Decoder.Result[BitVector]]
       }
     }
 
+  /**
+    * For serialization of BitVector we use base64. scodec's implementation of `toBase64` adds padding to 8 bits.
+    * That's not desired in our case and to preserve original BitVector length we add field "length".
+    *
+    * Examples:
+    * encodeBitVector(bin"101")
+    * res: io.circe.Json =
+    * {
+    *   "bits" : "oA==",
+    *   "length" : 3
+    * }
+    *
+    *
+    * encodeBitVector(bin"")
+    * res: io.circe.Json =
+    * {
+    *   "bits" : "",
+    *   "length" : 0
+    * }
+    *
+    * encodeBitVector(bin"11001100")
+    * res: io.circe.Json =
+    * {
+    *   "bits" : "zA==",
+    *   "length" : 8
+    * }
+    *
+    */
   implicit final val encodeBitVector: Encoder[BitVector] =
-    Encoder.encodeString.contramap(_.toBase64)
+    Encoder.encodeJsonObject.contramap { bv =>
+      JsonObject.empty
+        .add("bits", Json.fromString(bv.toBase64))
+        .add("length", Json.fromLong(bv.size))
+    }
+}
 
+private[circe] trait ByteVectorCodec {
   implicit final val decodeByteVector: Decoder[ByteVector] =
     Decoder.instance { c =>
       Decoder.decodeString(c) match {
@@ -33,3 +75,5 @@ package object scodec {
   implicit final val encodeByteVector: Encoder[ByteVector] =
     Encoder.encodeString.contramap(_.toBase64)
 }
+
+package object scodec extends ByteVectorCodec with BitVectorCodec

--- a/modules/tests/shared/src/test/scala/io/circe/scodec/ScodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/scodec/ScodecSuite.scala
@@ -1,14 +1,18 @@
 package io.circe.scodec
 
-import _root_.scodec.bits.{ BitVector, ByteVector }
+import _root_.scodec.bits._
 import cats.Eq
+import io.circe.{Decoder, Json}
+import io.circe.parser.parse
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
 import org.scalacheck.Arbitrary
+import org.scalatest.Matchers
+import org.scalatest.matchers.{MatchResult, Matcher}
 
-class ScodecSuite extends CirceSuite {
+class ScodecSuite extends CirceSuite with Matchers with BitVectorMatchers {
   implicit val arbitraryBitVector: Arbitrary[BitVector] =
-    Arbitrary(Arbitrary.arbitrary[Array[Byte]].map(BitVector.view))
+    Arbitrary(Arbitrary.arbitrary[Iterable[Boolean]].map(BitVector.bits))
 
   implicit val arbitraryByteVector: Arbitrary[ByteVector] =
     Arbitrary(Arbitrary.arbitrary[Array[Byte]].map(ByteVector.view))
@@ -20,6 +24,51 @@ class ScodecSuite extends CirceSuite {
     Eq.fromUniversalEquals
 
   checkLaws("Codec[BitVector]", CodecTests[BitVector].codec)
-  
+
   checkLaws("Codec[ByteVector]", CodecTests[ByteVector].codec)
+
+  "Codec[ByteVector]" should "return failure for Json String" in {
+    val json = Json.fromString("mA==")
+    assert(decodeBitVector.decodeJson(json).isLeft)
+  }
+
+  "Codec[ByteVector]" should "return failure in case input is an incomplete object" in {
+    decodeBitVector should failFor("{}")
+    decodeBitVector should failFor("""{"bits": "mA=="}""")
+    decodeBitVector should failFor("""{"length": 6}""")
+  }
+
+  // this test shows that decoder is to some extend liberal
+  // even though such input could not have been produced by BitVector encoder it's getting decoded to BitVector
+  "Codec[ByteVector]" should "return empty BitVector in case contains only non-zero header" in {
+    decodeBitVector should decodeTo("""{"bits": "mA==", "length": 8}""", bin"10011000")
+    decodeBitVector should decodeTo("""{"bits": "mA==", "length": 16}""", bin"10011000")
+    decodeBitVector should decodeTo("""{"bits": "mA==", "length": 0}""", BitVector.empty)
+  }
 }
+
+trait BitVectorMatchers {
+  class FailFor(input: String) extends Matcher[Decoder[BitVector]] {
+    override def apply(decoder: Decoder[BitVector]): MatchResult = {
+      val json = parse(input).right.get
+      MatchResult(decoder.decodeJson(json).isLeft, s"Has not failed for $input", s"Failed for $input")
+    }
+  }
+
+  def failFor(input: String): FailFor = new FailFor(input)
+
+  class DecodeTo(input: String, expectedBitVector: BitVector) extends Matcher[Decoder[BitVector]] {
+    override def apply(decoder: Decoder[BitVector]): MatchResult = {
+      val json = parse(input).right.get
+
+      val decoded = decoder.decodeJson(json)
+      val expected = Right(expectedBitVector)
+      MatchResult(decoded.right.get == expectedBitVector,
+        s"Decoded to [$decoded], expected: [$expected]",
+        s"Decoded to [$expected]")
+    }
+  }
+
+  def decodeTo(input: String, expectedBitVector: BitVector): DecodeTo = new DecodeTo(input, expectedBitVector)
+}
+


### PR DESCRIPTION
refs #551 , the root of the problem was that base64 was used. It adds padding to 8 bits which leaded to not preserving length.

The solution is to add one byte header which contains number of bits of data in the last byte of base64 representation.

My first solution used `toBin` which has very simple implementation but such encoding is very inefficient in terms of resulting string size. That solution can be found here: https://github.com/note/circe/commit/c7bd54ad124f12afd5a3712fff5470ba38744beb.

@travisbrown This is my first contribution to circe and I may not be aware of some internal conventions, please be forgiving :)