### PR TITLE
First attempt to fix #604

### DIFF
--- a/modules/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
@@ -147,11 +147,11 @@ class AutoDerivedSuite extends CirceSuite {
 
   trait Tag1
   trait Tag2
-  case class WithTaggedMembers(i: Int @@ Tag1, s: String @@ Tag2)
+  case class WithTaggedMembers(i: List[Int] @@ Tag1, s: String @@ Tag2)
 
-  implicit val encodeIntTag1: Encoder[Int @@ Tag1] = Encoder[Int].narrow
+  implicit val encodeIntTag1: Encoder[List[Int] @@ Tag1] = Encoder[List[Int]].narrow
   implicit val encodeStringTag2: Encoder[String @@ Tag2] = Encoder[String].narrow
-  implicit val decodeIntTag1: Decoder[Int @@ Tag1] = Decoder[Int].map(tag[Tag1](_))
+  implicit val decodeIntTag1: Decoder[List[Int] @@ Tag1] = Decoder[List[Int]].map(tag[Tag1](_))
   implicit val decodeStringTag2: Decoder[String @@ Tag2] = Decoder[String].map(tag[Tag2](_))
 
   object WithTaggedMembers {
@@ -159,7 +159,7 @@ class AutoDerivedSuite extends CirceSuite {
 
     implicit val arbitraryWithTaggedMembers: Arbitrary[WithTaggedMembers] = Arbitrary(
       for {
-        i <- Arbitrary.arbitrary[Int]
+        i <- Arbitrary.arbitrary[List[Int]]
         s <- Arbitrary.arbitrary[String]
       } yield WithTaggedMembers(tag[Tag1](i), tag[Tag2](s))
     )


### PR DESCRIPTION
This is a quick sketch of an attempt to fix #604. The following code (adapted from an example by @javierarrieta) previously compiled on 2.10 and 2.11 but failed on 2.12:

```scala
import cats.syntax.contravariant._
import io.circe.Encoder
import io.circe.generic.semiauto.deriveEncoder
import shapeless.tag.@@

sealed trait EmailAddressTag
sealed trait PasswordTag
type EmailAddress = String @@ EmailAddressTag
type Password = String @@ PasswordTag

case class CustomerRegistrationEntity(email: EmailAddress, password: Password)

implicit val emailEncoder: Encoder[EmailAddress] = Encoder[String].narrow
implicit val passwordEncoder: Encoder[Password] = Encoder[String].narrow

deriveEncoder[CustomerRegistrationEntity]
```

This was because of a change in the behavior of `RefinedType` in the Scala reflection API in 2.12. This PR makes the code above compile on all three versions.

/cc @Tvaroh