### PR TITLE
[RFC] generic derivation dsl allowing to override individual case class field decoders

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,10 @@ lazy val generic = genericBase.jvm
 lazy val genericJS = genericBase.js
 
 lazy val genericExtrasBase = circeCrossModule("generic-extras", mima = previousCirceVersion, CrossType.Pure)
-  .settings(macroSettings(scaladocFor210 = false))
+  .settings(
+    macroSettings(scaladocFor210 = false),
+    libraryDependencies += "org.typelevel" %% "kittens" % "1.0.0-M9"
+  )
   .dependsOn(genericBase)
 
 lazy val genericExtras = genericExtrasBase.jvm

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/flex/data.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/flex/data.scala
@@ -1,0 +1,61 @@
+package io.circe
+package generic.extras.flex
+
+case class Chain[A, B](pre: A, post: B)
+
+object Chain
+{
+  implicit def Retrieve_Chain[A, B]
+  (implicit ra: Retrieve[A], rb: Retrieve[B])
+  : Retrieve[Chain[A, B]] =
+    new Retrieve[Chain[A, B]] {
+      def apply(a: Chain[A, B])(cursor: ACursor) = {
+        val pre = ra(a.pre)(cursor)
+        rb(a.post)(pre)
+      }
+      def innermostKey(a: Chain[A, B]): Option[String] = rb.innermostKey(a.post)
+    }
+}
+
+case class Path(keys: List[String])
+{
+  def descend(key: String) = Path(keys :+ key)
+}
+
+object Path
+{
+  implicit val Retrieve_Path: Retrieve[Path] =
+    new Retrieve[Path] {
+      def apply(a: Path)(cursor: ACursor) = a.keys.foldLeft(cursor: ACursor)((c, b) => c.downField(b))
+      def innermostKey(a: Path): Option[String] = a.keys.lastOption
+    }
+}
+
+case class Manual(f: ACursor => ACursor)
+
+object Manual
+{
+  implicit val Retrieve_Manual: Retrieve[Manual] =
+    new Retrieve[Manual] {
+      def apply(a: Manual)(cursor: ACursor) = a.f(cursor)
+      def innermostKey(a: Manual): Option[String] = None
+    }
+}
+
+case class Ap[A, B, C](pre: A, f: B => C)
+{
+  def retrieve(implicit retr: Retrieve[A]) = retr.apply(pre) _
+}
+
+case class Fmap[A, B, C](pre: A, f: B => C)
+{
+  def retrieve(implicit retr: Retrieve[A]) = retr.apply(pre) _
+}
+
+case class Auto[A]()
+
+case class DefaultValue[A, B](pre: A, value: B)
+
+case class Value[A, V](pre: A)
+
+case class Extraction[A, B](data: B)

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/flex/derive.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/flex/derive.scala
@@ -1,0 +1,325 @@
+package io.circe
+package generic.extras.flex
+
+import scala.reflect.macros.whitebox
+
+import cats.Functor
+import cats.sequence._
+
+import shapeless.{HList, HNil, Poly2, ::, Witness, LabelledGeneric, =:!=, Default}
+import shapeless.labelled.{FieldType, field}
+import shapeless.ops.hlist.{LeftFolder, Zip}
+
+import syntax.mapWith._
+
+trait DefaultFields[A]
+{
+  type Out <: HList
+
+  def create: Out
+}
+
+object DefaultFields
+{
+  type Aux[A, O <: HList] = DefaultFields[A] { type Out = O }
+
+  implicit def hnil: DefaultFields.Aux[HNil, HNil] =
+    new DefaultFields[HNil] {
+      type Out = HNil
+      def create: Out = HNil
+    }
+
+  implicit def hcons[K, V, L0 <: HList, OutH, OutT <: HList]
+  (implicit tdf: DefaultFields.Aux[L0, OutT], key: Witness.Aux[K])
+  : DefaultFields.Aux[FieldType[K, V] :: L0, FieldType[K, Auto[V]] :: OutT] =
+    new DefaultFields[FieldType[K, V] :: L0] {
+      type Out = FieldType[K, Auto[V]] :: OutT
+      def create: Out = field[K](Auto[V]()) :: tdf.create
+    }
+}
+
+object extractJson
+extends Poly2
+{
+  implicit def extract[K <: Symbol: Witness.Aux, A, B](implicit E: Extract.Aux[A, B])
+  : Case.Aux[FieldType[K, Extraction[B, A]], HCursor, Decoder.Result[FieldType[K, B]]]
+  = at((f, cursor) => E[K](f.data)(cursor).map(field[K](_)))
+}
+
+trait replaceByKey
+extends Poly2
+{
+  implicit def keep[K0, V0, K, V]
+  (implicit ev: K0 =:!= K)
+  : Case.Aux[FieldType[K0, V0], FieldType[K, V], FieldType[K0, V0]]
+  = at((pre, post) => pre)
+}
+
+object replaceByKey
+extends replaceByKey
+{
+  implicit def replace[K <: Symbol, A, V]
+  (implicit ex: Extract.Aux[V, A])
+  : Case.Aux[FieldType[K, Auto[A]], FieldType[K, V], FieldType[K, V]]
+  = at((pre, post) => post)
+}
+
+object merge
+extends Poly2
+{
+  implicit def withoutDefault[Rules <: HList, K, V0, V1]
+  (implicit updater: LeftFolder.Aux[Rules, FieldType[K, Auto[V0]], replaceByKey.type, FieldType[K, V1]])
+  : Case.Aux[(FieldType[K, Auto[V0]], None.type), Rules, FieldType[K, Extraction[V0, V1]]]
+  = at { case ((df, dv), rules) =>
+    field[K](Extraction[V0, V1](updater(rules, df)))
+  }
+
+  implicit def withDefault[Rules <: HList, K, V0, V1, D]
+  (implicit updater: LeftFolder.Aux[Rules, FieldType[K, Auto[V0]], replaceByKey.type, FieldType[K, V1]])
+  : Case.Aux[(FieldType[K, Auto[V0]], Some[D]), Rules, FieldType[K, Extraction[V0, DefaultValue[V1, D]]]]
+  = at {
+    case ((df, Some(dv)), rules) =>
+      field[K](Extraction[V0, DefaultValue[V1, D]](DefaultValue(updater(rules, df), dv)))
+  }
+}
+
+class DeriveDecoder[A]
+{
+  def apply[Repr <: HList, Rules <: HList, DF <: HList, DV <: HList, DD <: HList, Merged <: HList, Parsed <: HList]
+  (custom: Rules)
+    (implicit
+      gen: LabelledGeneric.Aux[A, Repr],
+      defaultFields: DefaultFields.Aux[Repr, DF],
+      defaultValues: Default.Aux[A, DV],
+      zipper: Zip.Aux[DF :: DV :: HNil, DD],
+      merger: MapWith.Aux[merge.type, DD, Rules, Merged],
+      extractor: MapWith.Aux[extractJson.type, Merged, HCursor, Parsed],
+      seq: Sequencer.Aux[Parsed, Decoder.Result[Repr]]
+      )
+    : Decoder[A]
+    = {
+      val rules = defaultFields.create
+        .zip(defaultValues())
+        .mapWith(merge)(custom)
+      Decoder.instance { cursor =>
+        rules
+          .mapWith(extractJson)(cursor)
+          .sequence
+          .map(LabelledGeneric[A].from)
+      }
+    }
+}
+
+trait ErrorHints
+{
+  val c: whitebox.Context
+
+  import c.universe._
+
+  object syms
+  {
+    val lgen = symbolOf[LabelledGeneric[_]].companion
+    val decoder = symbolOf[Decoder[_]]
+    val extract = symbolOf[Extract.Aux[_, _]]
+    val fieldType = symbolOf[FieldType[_, _]]
+    val path = symbolOf[Path]
+    val ap = symbolOf[Ap[_, _, _]]
+    val fmap = symbolOf[Fmap[_, _, _]]
+    val value = symbolOf[Value[_, _]]
+    val manual = symbolOf[Manual]
+    val functor = symbolOf[Functor[X] forSome { type X[_] }]
+  }
+
+  def keyTagName = "shapeless.labelled.KeyTag"
+
+  def taggedName = "shapeless.tag.Tagged"
+
+  def isKeyTag(tpe: Type) = tpe.typeSymbol.fullName == keyTagName
+
+  def isTagged(tpe: Type) = tpe.typeSymbol.fullName == taggedName
+
+  object tag
+  {
+    def unapply(args: Type) = args match {
+      case RefinedType(parents, _) => parents.find(isTagged)
+      case _ => None
+    }
+  }
+
+  object keyTag
+  {
+    def unapply(tpe: Type) = tpe.typeArgs match {
+      case List(tag(args), _) if isKeyTag(tpe) => args.find(isTagged)
+      case _ => None
+    }
+  }
+
+  object extractRecord
+  {
+    def unapply(tpe: Type) = Some(tpe) collect {
+      case RefinedType(List(actual, keyTag(key)), _) =>
+        (actual, key)
+      case TypeRef(pre, sym, List(tag(key), actual)) if sym == syms.fieldType =>
+        (actual, key)
+    }
+  }
+
+  object extractStringConstant
+  {
+    def unapply(tpe: Type) = tpe.typeArgs match {
+      case List(RefinedType(parents, _), _) =>
+        parents.find(isTagged)
+          .flatMap(_.typeArgs.headOption)
+          .collect { case ConstantType(Constant(a: String)) => Symbol(a) }
+      case List(ConstantType(Constant(a: String))) =>
+        Some(Symbol(a))
+      case _ => None
+    }
+  }
+
+  type SSymbol = scala.Symbol
+
+  sealed trait KV
+  {
+    def key: SSymbol
+  }
+
+  case class Rule(key: SSymbol, tpe: Type)
+  extends KV
+
+  case class CCField(key: SSymbol, tpe: Type)
+  extends KV
+
+  def analyzeKV[A](tpe: Type, ctor: (SSymbol, Type) => A): A = {
+    tpe match {
+      case extractRecord(value, extractStringConstant(key)) => ctor(key, value)
+      case _ => c.abort(c.enclosingPosition, s"invalid record element: $tpe")
+    }
+  }
+
+  def ccFields(tpe: Type): List[CCField] = {
+    val repr = tpe.member(TypeName("Repr")).asType.toType.dealias
+    def extract(tpe: Type, result: List[CCField]): List[CCField] = {
+      tpe.typeArgs match {
+        case List(head, tail) => extract(tail, analyzeKV(head, CCField.apply) :: result)
+        case Nil => result
+      }
+    }
+    extract(repr, Nil).reverse
+  }
+
+  def check(tree: Tree) = c.typecheck(tree, silent = true)
+
+  def inferImplicit(tpe: Tree): Either[String, Type] = {
+    check(q"_root_.shapeless.lazily[$tpe]") match {
+      case EmptyTree => Left(s"implicit $tpe not found")
+      case t => Right(t.tpe)
+    }
+  }
+
+  def checkDecoder(key: SSymbol, tpe: Type): Option[String] = {
+    inferImplicit(tq"${syms.decoder}[$tpe]") match {
+      case Left(err) => Some(s"you must define or import a decoder of `$tpe` for $key ($err)")
+      case _ => None
+    }
+  }
+
+  def mismatch(key: SSymbol, result: Type, target: Type) =
+    s"you specified a map rule for $key with result type `$result`, but the field has type `$target`"
+
+  def ruleError(key: SSymbol, target: Type, rule: Rule): Option[String] = {
+    rule.tpe match {
+      case TypeRef(_, sym, _) if sym == syms.path =>
+        checkDecoder(key, target)
+      case TypeRef(_, sym, _) if sym == syms.manual =>
+        checkDecoder(key, target)
+      case TypeRef(_, sym, List(pre, dec, result)) if sym == syms.ap =>
+        if (result =:= target) ruleError(key, dec, Rule(key, pre))
+        else Some(mismatch(key, result, target))
+      case TypeRef(_, sym, List(pre, dec, result)) if sym == syms.fmap =>
+        target.typeArgs match {
+          case List(tpe) =>
+            val cons = target.typeConstructor
+            val fa = tq"${syms.functor}[${cons}]"
+            inferImplicit(fa) match {
+              case Left(err) => Some(s"you used an fmap rule with `$cons` for $key, but no `$fa` is in scope")
+              case _ =>
+                if (tpe =:= result) ruleError(key, dec, Rule(key, pre))
+                else Some(mismatch(key, result, tpe))
+            }
+          case _ =>
+            Some(s"cannot match shape of $target to fmap rule for $key with type $result")
+        }
+      case TypeRef(_, sym, List(pre, param)) if sym == syms.value =>
+        check(q"${syms.lgen}[$target]") match {
+          case EmptyTree => Some(s"you used a `value` rule for field $key which is not a case class")
+          case t =>
+            ccFields(t.tpe) match {
+              case List(CCField(pkey, tpe)) if !(tpe =:= param) =>
+                Some(s"you specified type `$param` for the value rule for $key," +
+                  s" but the field $pkey of `$target` is `$tpe`")
+              case List(a, b, _*) =>
+                Some(s"you specified a value rule for $key, but `$target` has multiple fields")
+              case _ => None
+            }
+        }
+      case a => Some(s"unknown rule type $a")
+    }
+  }
+
+  def checkRule(key: SSymbol, target: Type, rule: Rule) = {
+    inferImplicit(tq"${syms.extract}[${rule.tpe}, ${target}]") match {
+      case Left(err) => ruleError(key, target, rule).orElse(Some(err))
+      case _ => None
+    }
+  }
+
+  def checkError(main: Type, extra: Seq[c.Expr[Any]]) = {
+    val errors = check(q"${syms.lgen}[$main]") match {
+      case EmptyTree => List(s"$main is not a case class")
+      case t =>
+        val fields = ccFields(t.tpe)
+        val extraFields =
+          extra
+            .map(_.tree)
+            .map(c.typecheck(_))
+            .map(_.tpe)
+            .map(analyzeKV(_, Rule.apply))
+            .toList
+        (fields ++ extraFields)
+          .groupBy(_.key)
+          .values
+          .map {
+            case List(target: CCField, rule: Rule) => checkRule(target.key, target.tpe, rule)
+            case List(target: CCField) => checkDecoder(target.key, target.tpe)
+            case List(rule: Rule) => Some(s"you specified an extraction rule for nonexistent field `${rule.key.name}`")
+            case _ => Some("invalid")
+          }
+          .collect { case Some(err) => err }
+          .toList
+    }
+    val msg = s"deriving json decoder for `class $main` failed because"
+    c.abort(c.enclosingPosition, (msg :: errors.map(a => s" • $a")).mkString("\n"))
+  }
+}
+
+class DeriveMacro(val c: whitebox.Context)
+extends ErrorHints
+{
+  import c.universe._
+
+  val hnil = symbolOf[HNil].companion
+
+  def derive[A](extra: c.Expr[Any]*)(implicit aType: WeakTypeTag[A]): c.Expr[Decoder[A]] = {
+    val hlist = extra.toList.reverse.foldLeft(q"$hnil": Tree)((z, a) => q"$a :: $z")
+    val tree =
+      q"""
+      _root_.io.circe.generic.extras.flex.deriveH[$aType]($hlist)
+      """
+    c.typecheck(tree, silent = true) match {
+      case EmptyTree =>
+        checkError(aType.tpe, extra)
+      case t => c.Expr[Decoder[A]](t)
+    }
+  }
+}

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/flex/ops.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/flex/ops.scala
@@ -1,0 +1,262 @@
+package io.circe
+package generic.extras.flex
+
+import scala.reflect.macros.whitebox
+import scala.language.implicitConversions
+
+import cats.Functor
+import cats.implicits._
+
+import shapeless.{::, Witness, Generic, Poly2, HList, HNil}
+import shapeless.labelled.{FieldType, field}
+import shapeless.poly.Case2
+
+trait Retrieve[A]
+{
+  def apply(a: A)(cursor: ACursor): ACursor
+  def innermostKey(a: A): Option[String]
+  def ap[B, C](a: A)(f: B => C) = Ap(a, f)
+  def map[B, C](a: A)(f: B => C) = Fmap(a, f)
+  def mkValue(a: A) = Value(a)
+}
+
+class RetrieveOps[A](self: A)
+(implicit retrieve: Retrieve[A])
+{
+  def ap[B, C](f: B => C) = retrieve.ap(self)(f)
+  def map[B, C](f: B => C) = retrieve.map(self)(f)
+  def mkValue = retrieve.mkValue(self)
+}
+
+class RetrieveFieldOps[K, A](self: FieldType[K, A])
+(implicit retrieve: Retrieve[A])
+{
+  def ap[B, C](f: B => C) = field[K](retrieve.ap(self)(f))
+
+  def >>[B, C](f: B => C) = ap(f)
+
+  def map[B, C](f: B => C) = field[K](retrieve.map(self)(f))
+
+  def >>>[B, C](f: B => C) = map(f)
+
+  def value[B] = field[K](Value[A, B](self: A))
+
+  def \(key: String): FieldType[K, Chain[A, Path]] = field[K](Chain(self, Path(List(key))))
+
+  def \(key: Symbol): FieldType[K, Chain[A, Path]] = field[K](Chain(self, Path(List(key.name))))
+
+  def fetch(f: ACursor => ACursor): FieldType[K, Chain[A, Manual]] = field[K](Chain(self, Manual(f)))
+}
+
+trait Extract[A]
+{
+  type Out
+
+  def apply[K <: Symbol: Witness.Aux](a: A)(cursor: HCursor): Decoder.Result[Out]
+}
+
+object Extract
+{
+  type Aux[A, Out0] = Extract[A] { type Out = Out0 }
+
+  def apply[A, B](implicit instance: Extract.Aux[A, B]) = instance
+
+  implicit def Extract_Retrieve[A, B: Decoder](implicit R: Retrieve[A]): Aux[A, B] =
+    new Extract[A] {
+      type Out = B
+      def apply[K <: Symbol: Witness.Aux](a: A)(cursor: HCursor): Decoder.Result[B] = {
+        R(a)(cursor).as[B]
+      }
+    }
+
+  implicit def Extract_Function1[A: Decoder, B]: Aux[A => B, B] =
+    new Extract[A => B] {
+      type Out = B
+      def apply[K <: Symbol](f: A => B)(cursor: HCursor)(implicit key: Witness.Aux[K]): Decoder.Result[B] = {
+        val inner = Extract[Ap[Path, A, B], B]
+        inner[K](Path(List(key.value.name)).ap(f))(cursor)
+      }
+    }
+
+  implicit def Extract_Ap[A, B: Decoder, C]
+  (implicit inner: Extract.Aux[A, B])
+  : Aux[Ap[A, B, C], C]
+  = new Extract[Ap[A, B, C]] {
+      type Out = C
+      def apply[K <: Symbol: Witness.Aux](a: Ap[A, B, C])(cursor: HCursor): Decoder.Result[C] = {
+        inner(a.pre)(cursor).map(a.f)
+      }
+    }
+
+  implicit def Extract_Fmap[F[_], A, B, C]
+  (implicit dec: Decoder[F[B]], inner: Extract.Aux[A, F[B]], functor: Functor[F])
+  : Aux[Fmap[A, B, C], F[C]]
+  = new Extract[Fmap[A, B, C]] {
+      type Out = F[C]
+      def apply[K <: Symbol: Witness.Aux](a: Fmap[A, B, C])(cursor: HCursor): Decoder.Result[F[C]] = {
+        inner(a.pre)(cursor).map(functor.map(_)(a.f))
+      }
+    }
+
+  implicit def Extract_Value[A, B, C]
+  (implicit inner: Extract.Aux[A, B], gen: Generic.Aux[C, B :: HNil])
+  : Aux[Value[A, B], C] =
+    new Extract[Value[A, B]] {
+      type Out = C
+      def apply[K <: Symbol: Witness.Aux](a: Value[A, B])(cursor: HCursor): Decoder.Result[C] = {
+        inner(a.pre)(cursor).map(_ :: HNil).map(Generic[C].from)
+      }
+    }
+
+  implicit def Extract_Manual[A: Decoder]: Aux[Manual, A] =
+    new Extract[Manual] {
+      type Out = A
+      def apply[K <: Symbol: Witness.Aux](a: Manual)(cursor: HCursor): Decoder.Result[A] = {
+        a.f(cursor).as[A]
+      }
+  }
+
+  implicit def Extract_Auto[A: Decoder]: Aux[Auto[A], A] =
+    new Extract[Auto[A]] {
+      type Out = A
+      def apply[K <: Symbol](a: Auto[A])(cursor: HCursor)(implicit key: Witness.Aux[K]): Decoder.Result[A] = {
+        cursor.downField(key.value.name).as[A]
+      }
+    }
+
+  implicit def Extract_DefaultValue[A, B]
+  (implicit inner: Extract.Aux[A, B])
+  : Aux[DefaultValue[A, B], B] =
+    new Extract[DefaultValue[A, B]] {
+      type Out = B
+      def apply[K <: Symbol: Witness.Aux](a: DefaultValue[A, B])(cursor: HCursor): Decoder.Result[B] = {
+        inner(a.pre)(cursor).orElse(Right(a.value))
+      }
+    }
+}
+
+class ExtractFieldOps[K, A: Extract](self: FieldType[K, A])
+{
+  def value[B] = field[K](Value[A, B](self: A))
+
+  def ap[B, C](f: B => C) = field[K](Ap(self: A, f))
+
+  def >>[B, C](f: B => C) = ap(f)
+
+  def map[B, C](f: B => C) = field[K](Fmap(self: A, f))
+
+  def >>>[B, C](f: B => C) = map(f)
+}
+
+class FmapFieldOps[K, A, B, C](self: FieldType[K, Fmap[A, B, C]])
+{
+  def ap[F[_], D](f: F[C] => F[D]) = field[K](Ap(self: Fmap[A, B, C], f))
+
+  def >>[F[_], D](f: F[C] => F[D]) = ap(f)
+
+  def map[D](f: C => D) = field[K](Fmap(self: Fmap[A, B, C], f))
+
+  def >>>[D](f: C => D) = map(f)
+}
+
+trait SymbolOps
+{
+  type K <: Symbol
+
+  val self: Symbol
+
+  def \\(key: String): FieldType[K, Path] = field[K](Path(List(key)))
+
+  def \\(key: Symbol): FieldType[K, Path] = field[K](Path(List(key.name)))
+
+  def \(key: String): FieldType[K, Path] = field[K](Path(List(self.name, key)))
+
+  def \(key: Symbol): FieldType[K, Path] = field[K](Path(List(self.name, key.name)))
+
+  def value[A](implicit key: Witness.Aux[K]) = field[K](Value[Path, A](Path(List(key.value.name))))
+
+  def fetch(f: ACursor => ACursor): FieldType[K, Manual] = field[K](Manual(f))
+
+  def ap[B, C](f: B => C)(implicit key: Witness.Aux[K]) = field[K](Ap(Path(List(key.value.name)), f))
+
+  def >>[B, C](f: B => C)(implicit key: Witness.Aux[K]) = ap(f)
+
+  def map[B, C](f: B => C)(implicit key: Witness.Aux[K]) = field[K](Fmap(Path(List(key.value.name)), f))
+
+  def >>>[B, C](f: B => C)(implicit key: Witness.Aux[K]) = map(f)
+
+  def in(path: Symbol*)(implicit key: Witness.Aux[K]) = field[K](Path(path.toList.map(_.name)).descend(key.value.name))
+}
+
+class Dsl(val c: whitebox.Context)
+{
+  val sl = new shapeless.SingletonTypeMacros(c)
+
+  import c.universe.Tree
+  import sl.c.universe.{Tree => SLTree, _}
+
+  val ops = symbolOf[SymbolOps]
+
+  def makeOps(s: Tree): Tree =
+    sl.extractResult(s.asInstanceOf[SLTree]) {
+      (tpe, value) =>
+        q"""
+        new $ops {
+          type K = $tpe
+          val self: Symbol = $value
+        }
+        """
+    }.asInstanceOf[Tree]
+}
+
+class PathDsl[K <: Symbol: Witness.Aux](p: FieldType[K, Path])
+{
+  def \(key: String): FieldType[K, Path] = field[K](p.descend(key))
+
+  def \(key: Symbol): FieldType[K, Path] = field[K](p.descend(key.name))
+}
+
+trait MapWith[HF <: Poly2, L <: HList, In]
+{
+  type Out <: HList
+
+  def apply(l: L, in: In): Out
+}
+
+object MapWith
+{
+  def apply[HF <: Poly2, L <: HList, In](implicit mw: MapWith[HF, L, In]): Aux[HF, L, In, mw.Out] = mw
+
+  type Aux[HF <: Poly2, L <: HList, A, Out0] =
+    MapWith[HF, L, A] { type Out = Out0 }
+
+  implicit def hnilMapWith[HF <: Poly2, T <: HNil, In]: Aux[HF, T, In, HNil] =
+    new MapWith[HF, T, In] {
+      type Out = HNil
+      def apply(l: T, in: In): Out = HNil
+    }
+
+  implicit def hlistMapWith[HF <: Poly2, H, T <: HList, In, OutH, OutT <: HList]
+  (implicit
+    f: Case2.Aux[HF, H, In, OutH],
+    mt: MapWith.Aux[HF, T, In, OutT]
+    )
+  : Aux[HF, H :: T, In, OutH :: OutT] =
+    new MapWith[HF, H :: T, In] {
+      type Out = OutH :: OutT
+      def apply(l: H :: T, in: In): Out = f(l.head, in) :: mt(l.tail, in)
+    }
+}
+
+final class MapWithOps[L <: HList](self: L)
+{
+  def mapWith[A, F <: Poly2](f: F)(a: A)(implicit mw: MapWith[F, L, A]): mw.Out = mw(self, a)
+}
+
+object syntax
+{
+  object mapWith
+  {
+    implicit def ToMapWithOps[L <: HList](l: L): MapWithOps[L] = new MapWithOps(l)
+  }
+}

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/flex/package.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/flex/package.scala
@@ -1,0 +1,49 @@
+package io.circe
+package generic
+package extras
+package flex
+
+import scala.language.experimental.macros
+import scala.language.implicitConversions
+
+import shapeless.Witness
+import shapeless.labelled.FieldType
+
+import cats.instances.EitherInstances
+
+trait FlexFunctions0
+{
+  implicit def extractFieldOps[K, A: Extract](a: FieldType[K, A]): ExtractFieldOps[K, A] =
+    new ExtractFieldOps(a)
+}
+
+trait FlexFunctions
+extends FlexFunctions0
+{
+  def deriveH[A]: DeriveDecoder[A] = new DeriveDecoder[A]
+
+  def derive[A](extra: Any*): Decoder[A] = macro DeriveMacro.derive[A]
+
+  implicit def dsl(s: Symbol): SymbolOps = macro Dsl.makeOps
+
+  implicit def pathDsl[K <: Symbol: Witness.Aux](a: FieldType[K, Path]): PathDsl[K] = new PathDsl(a)
+
+  implicit def retrieveOps[A: Retrieve](a: A): RetrieveOps[A] = new RetrieveOps(a)
+
+  implicit def retrieveOpsField[K, A: Retrieve](a: FieldType[K, A]): RetrieveOps[A] = new RetrieveOps(a: A)
+
+  implicit def retrieveFieldOps[K, A: Retrieve](a: FieldType[K, A]): RetrieveFieldOps[K, A] =
+    new RetrieveFieldOps(a)
+
+  implicit def fmapFieldOps[K, A, B, C](a: FieldType[K, Fmap[A, B, C]]): FmapFieldOps[K, A, B, C] =
+    new FmapFieldOps(a)
+}
+
+object `package`
+extends FlexFunctions
+{
+  object all
+  extends FlexFunctions
+  with EitherInstances
+  with AutoDerivation
+}

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ErrorSpec.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ErrorSpec.scala
@@ -1,0 +1,65 @@
+package io.circe
+package generic.extras
+package flex
+
+import scala.util.{Try, Failure}
+import scala.tools.reflect.{ToolBox, ToolBoxError}
+import scala.reflect.runtime.universe
+
+import tests.CirceSuite
+
+class ErrorSpec
+extends CirceSuite
+{
+  val cm = universe.runtimeMirror(getClass.getClassLoader)
+
+  val toolbox = ToolBox(cm).mkToolBox()
+
+  def compile(code: String) = toolbox.eval(toolbox.parse(code))
+
+  def compileError(code: String) = {
+    Try(compile(code)) match {
+      case Failure(ToolBoxError(e, _)) => e.lines.toList.drop(2).mkString("\n")
+      case a => sys.error(s"invalid error: $a")
+    }
+  }
+
+  val rulesCode = """
+  import io.circe.generic.extras.flex.all._
+
+  case class T(num: Int, s: String)
+  case class U(num: Int)
+  class V(num: Int)
+  {
+    def n = num
+  }
+  case class W(t: T, u: U, v: V, w: U, x: V, y: V, z: U)
+
+  def parseV(v: V) = U(v.n)
+
+  derive[W](
+    't.value[Int],
+    'u \\ 'u,
+    'v \\ 'values,
+    'as \\ 'alues,
+    'w \\ 'w >> parseV,
+    'x \\ 'x >> parseV,
+    'y.value[Int],
+    'z.value[String]
+  )
+  """
+
+  val rulesTarget = """deriving json decoder for `class W` failed because
+ • you specified a map rule for 'x with result type `U`, but the field has type `V`
+ • you used a `value` rule for field 'y which is not a case class
+ • you specified a value rule for 't, but `T` has multiple fields
+ • you specified an extraction rule for nonexistent field `as`
+ • you must define or import a decoder of `V` for 'v (implicit Decoder[V] not found)
+ • you must define or import a decoder of `V` for 'w (implicit Decoder[V] not found)
+ • you specified type `String` for the value rule for 'z, but the field 'num of `U` is `Int`"""
+
+  "deriving a decoder with erroneous overrides" should
+    "give detailed explanations about why implicit resolution failed" in {
+      assert(compileError(rulesCode) == rulesTarget)
+    }
+}

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/flex.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/flex.scala
@@ -1,0 +1,177 @@
+package io.circe
+package generic.extras
+package flex
+
+import cats.Functor
+
+import parser.decode
+
+import shapeless.HNil
+import shapeless.syntax.singleton._
+
+import flex.all._
+import tests.CirceSuite
+
+class AutoSuite extends CirceSuite {
+  case class V(a: Int)
+
+  implicit def dec = deriveH[V]('a ->> Auto[Int]() :: HNil)
+
+  "specifying the `Auto` extractor" should "use the generic decoder" in forAll { (num: Int) =>
+    assert(decode[V](s"""{"a": $num}""") == Right(V(num)))
+  }
+}
+
+class ValueClassSuite extends CirceSuite {
+  case class V(a: Int)
+  case class Outer(value: V)
+
+  "specifying the `Value` extractor" should "fetch a subfield" in forAll { (value: Int) =>
+    implicit def dec = deriveH[Outer](
+      ('value ->> Value[Path, Int](Path(List("value")))) :: HNil
+    )
+    assert(decode[Outer](s"""{"value": $value}""") == Right(Outer(V(value))))
+  }
+
+  "specifying a `Value` with nested `Ap`" should "transform data before applying the class" in forAll { (value: Int) =>
+    implicit def dec =
+      deriveH[Outer](
+        ('value ->> Value[Ap[Path, String, Int], Int](Ap(Path(List("value")), (_: String).toInt))) :: HNil
+      )
+    assert(decode[Outer](s"""{"value": "$value"}""") == Right(Outer(V(value))))
+  }
+}
+
+class ApSuite extends CirceSuite {
+  case class V(nums: List[Int])
+
+  val trans = (in: Option[List[Int]]) => in getOrElse Nil
+
+  implicit def dec = deriveH[V](
+    'nums ->> Ap[Path, Option[List[Int]], List[Int]](Path(List("nums")), trans) :: HNil
+  )
+
+  "specifying an `Ap` extractor" should "map an Option[List[A]] to a List[A]" in forAll { (nums: List[Int]) =>
+    assert(decode[V](s"""{"nums": ${nums.mkString("[", ",", "]")}}""") == Right(V(nums)))
+  }
+}
+
+class FmapSuite extends CirceSuite {
+  case class V(num: Option[Int])
+
+  val trans = (in: String) => in.toInt
+
+  implicit def dec = deriveH[V](
+    'num ->> Fmap[Path, String, Int](Path(List("num")), trans) :: HNil
+  )
+
+  "specifying an `Fmap` extractor" should "map over an Option" in forAll { (num: Int) =>
+    assert(decode[V](s"""{"num": "$num"}""") == Right(V(Some(num))))
+  }
+}
+
+class DefaultValueSuite
+extends CirceSuite
+{
+  trait Y
+  case class X(a: String, b: Boolean = false, private val c: Map[String, Y] = Map.empty)
+
+  case class V(x: X)
+
+  def trans(n: Int): X = X(n.toString)
+
+  implicit def dec = deriveH[V](
+    'x ->> Ap[Path, Int, X](Path(List("x")), trans) :: HNil
+  )
+
+  "decoding a class with default values" should "use the defaults for nonexisting fields" in forAll { (num: Int) =>
+    assert(decode[V](s"""{"x": $num}""") == Right(V(X(num.toString))))
+  }
+}
+
+class ManualChainSuite
+extends CirceSuite
+{
+  case class X(num: Int)
+  case class V(x: X)
+
+  implicit def dec = deriveH[V](
+    'x ->> Chain(Chain(Path(List("a")), Manual(c => c.downArray.right)), Path(List("x"))) :: HNil
+  )
+
+  "specify traversal manually, chained with `Path`s" should "concat the path elements" in forAll { (num: Int) =>
+    assert(decode[V](s"""{"a": [{}, {"x": {"num": $num}}, {}]}""") == Right(V(X(num))))
+  }
+}
+
+class DslSuite
+extends CirceSuite
+{
+  case class V(num: Int)
+  case class Inner(nums: List[V], default: String = "default")
+  case class Outer(inner: Option[Inner], auto: List[V], value: V, absent: Option[String], man: V, mapval: V,
+    fmapval: Option[Int], in: Int, sub: Int, mapFmap: List[Int], default: Int = 11, fmap2: List[Int])
+
+  case class Value(value: String)
+
+  def values[F[_]: Functor] = (vs: F[Value]) => vs map (_.value)
+
+  val fix = """
+  {
+    "root": {
+      "in": {
+        "a": ["1", "2", "3"],
+        "default": "override"
+      },
+      "nest": {
+        "in": {
+          "val": 31
+        }
+      }
+    },
+    "auto": [{"num": 4}],
+    "value": 5,
+    "custom": { "path": [1, 2, { "target": 3 }] },
+    "valmap": "9",
+    "sub": {
+      "a": {
+        "b": 19
+      }
+    },
+    "fmapval": "13",
+    "mapFmap": [{ "value": "27" }, { "value": "29" }],
+    "fmap2": ["37", "41"]
+  }
+  """
+
+  def parseInt(s: String): Int = s.toInt
+
+  def parseInts(l: List[String]): List[V] = l.map(parseInt).map(V(_))
+
+  implicit val innerDecoder = derive[Inner](
+    'nums \\ 'a >> parseInts
+  )
+
+  implicit val outerDecoder = derive[Outer](
+    'inner \\ 'root \ 'in,
+    'value.value[Int],
+    (('man \\ 'custom).fetch(_.downField("path").downArray.right.right) \ 'target).value[Int],
+    ('mapval \\ 'valmap >> parseInt).value[Int],
+    'default \\ 'foo >> parseInt,
+    'in.in('root, 'nest) \ 'val,
+    'sub \ 'a \ 'b,
+    'fmapval >>> parseInt,
+    'mapFmap >> values[List] >>> parseInt,
+    'fmap2 >>> parseInt >>> ((_: Int) + 1)
+  )
+
+  "passing special rules to `derive`" should "create a decoder" in {
+    assert(
+      decode[Outer](fix) == Right(
+        Outer(
+          Some(Inner(List(V(1), V(2), V(3)), "override")),
+          List(V(4)), V(5), None, V(3), V(9), Some(13), 31, 19, List(27, 29), 11, List(38, 42))
+      )
+    )
+  }
+}


### PR DESCRIPTION
This is a tool intended to simplify decoder creation for case classes where some fields need special treatment, especially extracting values from deep json paths.
It features a DSL that looks like this (see test at https://github.com/tek/circe/blob/flex/modules/tests/shared/src/test/scala/io/circe/generic/extras/flex.scala#L107):
```scala
case class Outer(inner: Option[Inner], auto: List[V], value: V, absent: Option[String], man: V, mapval: V,

implicit val outerDecoder = derive[Outer](
  'inner \\ 'root \ 'in,
  'value.value[Int],
  (('man \\ 'custom).fetch(_.downField("path").downArray.right.right) \ 'target).value[Int],
  ('mapval \\ 'valmap >> parseInt).value[Int],
  'default \\ 'foo >> parseInt,
  'in.in('root, 'nest) \ 'val,
  'sub \ 'a \ 'b,
  'fmapval >>> parseInt,
  'mapFmap >> values[List] >>> parseInt,
  'fmap2 >>> parseInt >>> ((_: Int) + 1)
)
```

Typeclasses `Retrieve` and `Extract` allow chaining of actions per case class field, defaulting to `AutoDerivation` for omitted fields.
The `derive` macro also features an error analysis, as erroneous rules produce implicit errors containing little information about the error causes.

Would you consider this a suitable addition to `generic-extras`? If so, please advise on how to integrate it better with the existing auto derivation. The performance is really bad as it is, so hints on how to speed up compilation would be very helpful.