### PR TITLE
Less ambiguous name for default config import

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -19,5 +19,5 @@ final object Configuration {
 }
 
 final object defaults {
-  implicit val defaults: Configuration = Configuration.default
+  implicit val defaultGenericConfiguration: Configuration = Configuration.default
 }


### PR DESCRIPTION
This is a quick follow-up to #597—if we're asking people to import an implicit value we want it to have a less ambiguous name than `default`.