### PR TITLE
Minor tweaks to scodec instances

### DIFF
--- a/modules/scodec/shared/src/main/scala/io/circe/scodec/package.scala
+++ b/modules/scodec/shared/src/main/scala/io/circe/scodec/package.scala
@@ -2,32 +2,32 @@ package io.circe
 
 import _root_.scodec.bits.{ BitVector, ByteVector }
 
-private[circe] trait BitVectorCodec {
-  implicit final val decodeBitVector: Decoder[BitVector] =
-    Decoder.instance { c =>
-      Decoder.decodeJsonObject(c) match {
-        case Right(jsonObject) =>
-          val decoded = for {
-            bitsJ     <- jsonObject("bits")
-            bits      <- bitsJ.asString
-            lengthJ   <- jsonObject("length")
-            length    <- lengthJ.asNumber.flatMap(_.toLong)
-            bitVector <- BitVector.fromBase64Descriptive(bits).right.toOption
-          } yield bitVector.take(length)
+package object scodec {
+  implicit final val decodeByteVector: Decoder[ByteVector] = Decoder[String].emap(ByteVector.fromBase64Descriptive(_))
+  implicit final val encodeByteVector: Encoder[ByteVector] = Encoder.instance(bv => Json.fromString(bv.toBase64))
 
-          decoded match {
-            case Some(bitVector)  => Right(bitVector)
-            case None             => Left(DecodingFailure("Incorrect format of BitVector field", c.history))
-          }
-        case l @ Left(_) => l.asInstanceOf[Decoder.Result[BitVector]]
+  implicit final val decodeBitVector: Decoder[BitVector] = decodeBitVectorWithNames("bits", "length")
+  implicit final val encodeBitVector: Encoder[BitVector] = encodeBitVectorWithNames("bits", "length")
+
+  final def decodeBitVectorWithNames(bitsName: String, lengthName: String): Decoder[BitVector] =
+    Decoder.instance { c =>
+      val bits: Decoder.Result[BitVector] = c.get[String](bitsName).right.flatMap { bs =>
+        BitVector.fromBase64Descriptive(bs) match {
+          case r @ Right(_) => r.asInstanceOf[Decoder.Result[BitVector]]
+          case Left(message) => Left(DecodingFailure(message, c.history))
+        }
       }
+
+      Decoder.resultInstance.map2(bits, c.get[Long](lengthName))(_.take(_))
     }
 
   /**
-    * For serialization of BitVector we use base64. scodec's implementation of `toBase64` adds padding to 8 bits.
-    * That's not desired in our case and to preserve original BitVector length we add field "length".
+    * For serialization of `BitVector` we use base64. scodec's implementation of
+    * `toBase64` adds padding to 8 bits. That's not desired in our case and to
+    * preserve original BitVector length we add a length field.
     *
     * Examples:
+    * {{{
     * encodeBitVector(bin"101")
     * res: io.circe.Json =
     * {
@@ -49,31 +49,13 @@ private[circe] trait BitVectorCodec {
     *   "bits" : "zA==",
     *   "length" : 8
     * }
-    *
+    * }}}
     */
-  implicit final val encodeBitVector: Encoder[BitVector] =
-    Encoder.encodeJsonObject.contramap { bv =>
-      JsonObject.empty
-        .add("bits", Json.fromString(bv.toBase64))
-        .add("length", Json.fromLong(bv.size))
+  final def encodeBitVectorWithNames(bitsName: String, lengthName: String): ObjectEncoder[BitVector] =
+    ObjectEncoder.instance { bv =>
+      JsonObject.singleton(bitsName, Json.fromString(bv.toBase64)).add(
+        lengthName,
+        Json.fromLong(bv.size)
+      )
     }
 }
-
-private[circe] trait ByteVectorCodec {
-  implicit final val decodeByteVector: Decoder[ByteVector] =
-    Decoder.instance { c =>
-      Decoder.decodeString(c) match {
-        case Right(str) =>
-          ByteVector.fromBase64Descriptive(str) match {
-            case r @ Right(_) => r.asInstanceOf[Decoder.Result[ByteVector]]
-            case Left(err) => Left(DecodingFailure(err, c.history))
-          }
-        case l @ Left(_) => l.asInstanceOf[Decoder.Result[ByteVector]]
-      }
-    }
-
-  implicit final val encodeByteVector: Encoder[ByteVector] =
-    Encoder.encodeString.contramap(_.toBase64)
-}
-
-package object scodec extends ByteVectorCodec with BitVectorCodec

--- a/modules/tests/shared/src/test/scala/io/circe/scodec/ScodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/scodec/ScodecSuite.scala
@@ -1,14 +1,14 @@
 package io.circe.scodec
 
-import _root_.scodec.bits._
 import cats.Eq
-import io.circe.{Decoder, Json}
+import io.circe.{ Decoder, Json }
 import io.circe.parser.parse
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
 import org.scalacheck.Arbitrary
 import org.scalatest.Matchers
-import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.matchers.{ MatchResult, Matcher }
+import _root_.scodec.bits._
 
 class ScodecSuite extends CirceSuite with Matchers with BitVectorMatchers {
   implicit val arbitraryBitVector: Arbitrary[BitVector] =
@@ -17,14 +17,10 @@ class ScodecSuite extends CirceSuite with Matchers with BitVectorMatchers {
   implicit val arbitraryByteVector: Arbitrary[ByteVector] =
     Arbitrary(Arbitrary.arbitrary[Array[Byte]].map(ByteVector.view))
 
-  implicit val eqBitVector: Eq[BitVector] =
-    Eq.fromUniversalEquals
-
-  implicit val eqByteVector: Eq[ByteVector] =
-    Eq.fromUniversalEquals
+  implicit val eqBitVector: Eq[BitVector] = Eq.fromUniversalEquals
+  implicit val eqByteVector: Eq[ByteVector] = Eq.fromUniversalEquals
 
   checkLaws("Codec[BitVector]", CodecTests[BitVector].codec)
-
   checkLaws("Codec[ByteVector]", CodecTests[ByteVector].codec)
 
   "Codec[ByteVector]" should "return failure for Json String" in {


### PR DESCRIPTION
Follow-up to #614 with some minor stuff. @note, I've made a few cosmetic changes as well as a few that affect behavior (if the user is accumulating errors they'll now get any in both the bits and length fields and the bit vector error message is passed through). I've also added some non-implicit methods to allow users to pick their own field names if desired, and I've recombined everything into a single package object (mostly just because vals in traits make me nervous). Let me know if you don't agree.