### PR TITLE
Add encoder and decoder for java.time.YearMonth

### DIFF
--- a/modules/java8/src/main/scala/io/circe/java8/time/TimeInstances.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/TimeInstances.scala
@@ -1,7 +1,7 @@
 package io.circe.java8.time
 
 import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
-import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, Period, ZonedDateTime }
+import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, Period, YearMonth, ZonedDateTime }
 import java.time.format.{ DateTimeFormatter, DateTimeParseException }
 import java.time.format.DateTimeFormatter.{
 ISO_LOCAL_DATE,
@@ -116,4 +116,24 @@ trait TimeInstances {
   implicit final val encodePeriod: Encoder[Period] = Encoder.instance { period =>
     Json.fromString(period.toString)
   }
+
+  final def decodeYearMonth(formatter: DateTimeFormatter): Decoder[YearMonth] =
+    Decoder.instance { c =>
+      c.as[String] match {
+        case Right(s) =>
+          try Right(YearMonth.parse(s, formatter))
+          catch {
+            case _: DateTimeParseException => Left(DecodingFailure("YearMonth", c.history))
+          }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[YearMonth]]
+      }
+    }
+
+  final def encodeYearMonth(formatter: DateTimeFormatter): Encoder[YearMonth] =
+    Encoder.instance(time => Json.fromString(time.format(formatter)))
+
+  private final val yearMonthFormatter = DateTimeFormatter.ofPattern("yyyy-MM")
+
+  implicit final val decodeYearMonthDefault: Decoder[YearMonth] = decodeYearMonth(yearMonthFormatter)
+  implicit final val encodeYearMonthDefault: Encoder[YearMonth] = encodeYearMonth(yearMonthFormatter)
 }

--- a/modules/java8/src/test/scala/io/circe/java8/time/TimeCodecSuite.scala
+++ b/modules/java8/src/test/scala/io/circe/java8/time/TimeCodecSuite.scala
@@ -3,7 +3,7 @@ package io.circe.java8.time
 import cats.Eq
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
-import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, Period, ZonedDateTime, ZoneId }
+import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, Period, YearMonth, ZonedDateTime, ZoneId }
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary.arbitrary
 import scala.collection.JavaConverters._
@@ -53,6 +53,9 @@ class LocalDateTimeCodecSuite extends CirceSuite {
 
   implicit val arbitraryLocalTime: Arbitrary[LocalTime] = Arbitrary(arbitrary[LocalDateTime].map(_.toLocalTime))
 
+  implicit val arbitraryYearMonth: Arbitrary[YearMonth] = Arbitrary(arbitrary[LocalDateTime].map(
+    ldt => YearMonth.of(ldt.getYear, ldt.getMonth)))
+
   implicit val eqInstant: Eq[Instant] = Eq.fromUniversalEquals
   implicit val eqLocalDateTime: Eq[LocalDateTime] = Eq.fromUniversalEquals
   implicit val eqZonedDateTime: Eq[ZonedDateTime] = Eq.fromUniversalEquals
@@ -60,6 +63,7 @@ class LocalDateTimeCodecSuite extends CirceSuite {
   implicit val eqLocalDate: Eq[LocalDate] = Eq.fromUniversalEquals
   implicit val eqLocalTime: Eq[LocalTime] = Eq.fromUniversalEquals
   implicit val eqPeriod: Eq[Period] = Eq.fromUniversalEquals
+  implicit val eqYearMonth: Eq[YearMonth] = Eq.fromUniversalEquals
 
   checkLaws("Codec[Instant]", CodecTests[Instant].codec)
   checkLaws("Codec[LocalDateTime]", CodecTests[LocalDateTime].codec)
@@ -68,4 +72,5 @@ class LocalDateTimeCodecSuite extends CirceSuite {
   checkLaws("Codec[LocalDate]", CodecTests[LocalDate].codec)
   checkLaws("Codec[LocalTime]", CodecTests[LocalTime].codec)
   checkLaws("Codec[Period]", CodecTests[Period].codec)
+  checkLaws("Codec[YearMonth]", CodecTests[YearMonth].codec)
 }


### PR DESCRIPTION
The default implementation will encode/decode `YearMonth` instances to/from strings of the form "2017-04" for example.