### PR TITLE
@JsonCodec encodeOnly/decodeOnly support

### DIFF
--- a/modules/generic/shared/src/main/scala/io/circe/generic/JsonCodec.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/JsonCodec.scala
@@ -5,7 +5,10 @@ import macrocompat.bundle
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
-class JsonCodec extends scala.annotation.StaticAnnotation {
+class JsonCodec(
+  encodeOnly: Boolean = false,
+  decodeOnly: Boolean = false
+) extends scala.annotation.StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro GenericJsonCodecMacros.jsonCodecAnnotationMacro
 }
 

--- a/modules/tests/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
@@ -2,7 +2,7 @@ package io.circe.generic
 
 import cats.Eq
 import cats.instances.AllInstances
-import io.circe.ObjectEncoder
+import io.circe.{Decoder, Encoder, ObjectEncoder}
 import io.circe.generic.jsoncodecmacrossuiteaux._
 import io.circe.testing.{ ArbitraryInstances, CodecTests }
 import io.circe.tests.{ CirceSuite, MissingInstances }
@@ -155,5 +155,27 @@ class JsonCodecMacrosSuite extends CirceSuite {
     ObjectEncoder[Hierarchy]
     ObjectEncoder[RecursiveHierarchy]
     ObjectEncoder[SelfRecursiveWithOption]
+  }
+
+  it should "allow only one, named argument set to true" in {
+    // Can't supply both
+    assertDoesNotCompile("@JsonCodec(encodeOnly = true, decodeOnly = true) case class X(a: Int)")
+    // Must specify the argument name
+    assertDoesNotCompile("@JsonCodec(true) case class X(a: Int)")
+    // Can't specify false
+    assertDoesNotCompile("@JsonCodec(encodeOnly = false) case class X(a: Int)")
+  }
+
+  "@JsonCodec(encodeOnly = true)" should "only provide Encoder instances" in {
+    @JsonCodec(encodeOnly = true) case class CaseClassEncodeOnly(foo: String, bar: Int)
+    Encoder[CaseClassEncodeOnly]
+    ObjectEncoder[CaseClassEncodeOnly]
+    assertDoesNotCompile("Decoder[CaseClassEncodeOnly]")
+  }
+
+  "@JsonCodec(decodeOnly = true)" should "provide Decoder instances" in {
+    @JsonCodec(decodeOnly = true) case class CaseClassDecodeOnly(foo: String, bar: Int)
+    Decoder[CaseClassDecodeOnly]
+    assertDoesNotCompile("Encoder[CaseClassDecodeOnly]")
   }
 }


### PR DESCRIPTION
We can now supply arguments to `@JsonCodec` to signal to only derive an `Encoder` or `Decoder` instance. This is useful in cases where we can derive one but can't derive the other but still would prefer to use the macro annotation to avoid boilerplate.

The macro annotation requires that if you supply an argument, you must explicitly specify `encodeOnly` or `decodeOnly` and they must be set to `true`.  Supporting anything else is a bit pointless.

I've added test cases which demonstrate this behavior.