### PR TITLE
Add codec for java.time.Duration

### DIFF
--- a/modules/java8/src/main/scala/io/circe/java8/time/TimeInstances.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/TimeInstances.scala
@@ -1,7 +1,14 @@
 package io.circe.java8.time
 
 import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
-import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, Period, YearMonth, ZonedDateTime }
+import java.time.{
+Duration,
+Instant, LocalDate,
+LocalDateTime, LocalTime,
+OffsetDateTime,
+Period, YearMonth,
+ZonedDateTime
+}
 import java.time.format.{ DateTimeFormatter, DateTimeParseException }
 import java.time.format.DateTimeFormatter.{
 ISO_LOCAL_DATE,
@@ -136,4 +143,17 @@ trait TimeInstances {
 
   implicit final val decodeYearMonthDefault: Decoder[YearMonth] = decodeYearMonth(yearMonthFormatter)
   implicit final val encodeYearMonthDefault: Encoder[YearMonth] = encodeYearMonth(yearMonthFormatter)
+
+  implicit final val decodeDuration: Decoder[Duration] =
+    Decoder.instance { c =>
+      c.as[String] match {
+        case Right(s) => try Right(Duration.parse(s)) catch {
+          case _: DateTimeParseException => Left(DecodingFailure("Duration", c.history))
+        }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[Duration]]
+      }
+    }
+
+  implicit final val encodeDuration: Encoder[Duration] =
+    Encoder.instance(duration => Json.fromString(duration.toString))
 }

--- a/modules/java8/src/test/scala/io/circe/java8/time/TimeCodecSuite.scala
+++ b/modules/java8/src/test/scala/io/circe/java8/time/TimeCodecSuite.scala
@@ -3,7 +3,7 @@ package io.circe.java8.time
 import cats.Eq
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
-import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, Period, YearMonth, ZonedDateTime, ZoneId }
+import java.time.{ Duration, Instant, LocalDate, LocalDateTime, LocalTime, OffsetDateTime, Period, YearMonth, ZonedDateTime, ZoneId }
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary.arbitrary
 import scala.collection.JavaConverters._
@@ -56,6 +56,13 @@ class LocalDateTimeCodecSuite extends CirceSuite {
   implicit val arbitraryYearMonth: Arbitrary[YearMonth] = Arbitrary(arbitrary[LocalDateTime].map(
     ldt => YearMonth.of(ldt.getYear, ldt.getMonth)))
 
+  implicit val arbitraryDuration: Arbitrary[Duration] = Arbitrary(
+    for {
+      first <- arbitrary[Instant]
+      second <- arbitrary[Instant]
+    } yield Duration.between(first, second)
+  )
+
   implicit val eqInstant: Eq[Instant] = Eq.fromUniversalEquals
   implicit val eqLocalDateTime: Eq[LocalDateTime] = Eq.fromUniversalEquals
   implicit val eqZonedDateTime: Eq[ZonedDateTime] = Eq.fromUniversalEquals
@@ -64,6 +71,7 @@ class LocalDateTimeCodecSuite extends CirceSuite {
   implicit val eqLocalTime: Eq[LocalTime] = Eq.fromUniversalEquals
   implicit val eqPeriod: Eq[Period] = Eq.fromUniversalEquals
   implicit val eqYearMonth: Eq[YearMonth] = Eq.fromUniversalEquals
+  implicit val eqDuration: Eq[Duration] = Eq.fromUniversalEquals
 
   checkLaws("Codec[Instant]", CodecTests[Instant].codec)
   checkLaws("Codec[LocalDateTime]", CodecTests[LocalDateTime].codec)
@@ -73,4 +81,5 @@ class LocalDateTimeCodecSuite extends CirceSuite {
   checkLaws("Codec[LocalTime]", CodecTests[LocalTime].codec)
   checkLaws("Codec[Period]", CodecTests[Period].codec)
   checkLaws("Codec[YearMonth]", CodecTests[YearMonth].codec)
+  checkLaws("Codec[Duration]", CodecTests[Duration].codec)
 }

--- a/modules/java8/src/test/scala/io/circe/java8/time/TimeCodecSuite.scala
+++ b/modules/java8/src/test/scala/io/circe/java8/time/TimeCodecSuite.scala
@@ -8,7 +8,7 @@ import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary.arbitrary
 import scala.collection.JavaConverters._
 
-class LocalDateTimeCodecSuite extends CirceSuite {
+class TimeCodecSuite extends CirceSuite {
   private[this] val minInstant: Instant = Instant.EPOCH
   private[this] val maxInstant: Instant = Instant.parse("3000-01-01T00:00:00.00Z")
 


### PR DESCRIPTION
Yet another type to make java.time support more complete.