### PR TITLE
Fold instance over fields of a JsonObject

### DIFF
--- a/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
@@ -2,9 +2,9 @@ package io.circe.optics
 
 import cats.instances.list.catsStdInstancesForList
 import io.circe.{ Json, JsonObject }
-import monocle.{ Lens, Traversal }
+import monocle.{ Fold, Lens, Traversal }
 import monocle.function.{ At, Each, FilterIndex, Index }
-import scalaz.{ Applicative, Traverse }
+import scalaz.{ Applicative, Monoid, Traverse }
 import scalaz.std.ListInstances
 
 /**
@@ -20,6 +20,10 @@ trait JsonObjectOptics extends CatsConversions with ListInstances {
         F: Applicative[F]
       ): F[JsonObject] = from.traverse(f)(csApplicative(F))
     }
+  }
+
+  implicit final lazy val objectFoldKV: Fold[JsonObject, (String, Json)] = new Fold[JsonObject, (String, Json)] {
+    def foldMap[M: Monoid](f: ((String, Json)) => M)(obj: JsonObject): M = scalaz.Foldable[List].foldMap(obj.toList)(f)
   }
 
   implicit final lazy val objectAt: At[JsonObject, String, Option[Json]] =

--- a/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
@@ -7,6 +7,8 @@ import io.circe.{ Json, JsonNumber, JsonObject }
 import monocle.function.Plated.plate
 import monocle.law.discipline.function.{ AtTests, EachTests, FilterIndexTests, IndexTests }
 import monocle.law.discipline.{ PrismTests, TraversalTests }
+import monocle.syntax.all._
+
 import scalaz.Equal
 import scalaz.std.anyVal._
 import scalaz.std.math.bigDecimal._
@@ -64,5 +66,9 @@ class OpticsSuite extends CirceSuite {
     val json = Json.fromJsonNumber(JsonNumber.fromString((BigDecimal(Double.MaxValue) + 1).toString).get)
 
     assert(jsonDouble.getOrModify(json).fold(identity, jsonDouble.reverseGet) === json)
+  }
+
+  "objectFoldKV" should "fold over all fields" in forAll { (obj: JsonObject) =>
+    assert(obj.applyFold(JsonObjectOptics.objectFoldKV).foldMap(List(_)) === obj.toList)
   }
 }


### PR DESCRIPTION
See #612 for previous attempt at an `Each` instance.

`Fold` is a weaker operation that can get, but not modify, the labelled fields of a `JsonObject`. 

@travisbrown Would like some guidance on what test this PR should include, as`Fold` has no laws that can be verified. What about generating a json object with known fields and assert the fold visits them all?