### PR TITLE
Add forSumN methods [WIP]

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -274,15 +274,18 @@ trait Decoder[A] extends Serializable { self =>
  * @groupname Product Case class and other product instances
  * @groupprio Product 7
  *
+ * @groupname Sum Sealed trait hierarchy and other sum instances
+ * @groupprio Sum 8
+ *
  * @groupname Time Java date and time instances
- * @groupprio Time 8
+ * @groupprio Time 9
  *
  * @groupname Prioritization Instance prioritization
  * @groupprio Prioritization 10
  *
  * @author Travis Brown
  */
-final object Decoder extends CollectionDecoders with TupleDecoders with ProductDecoders
+final object Decoder extends CollectionDecoders with TupleDecoders with ProductDecoders with SumDecoders
     with JavaTimeDecoders with LowPriorityDecoders {
   /**
    * @group Aliases

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -67,15 +67,19 @@ trait Encoder[A] extends Serializable { self =>
  * @groupname Product Case class and other product instances
  * @groupprio Product 7
  *
+ * @groupname Sum Sealed trait hierarchy and other sum instances
+ * @groupprio Sum 8
+ *
  * @groupname Time Java date and time instances
- * @groupprio Time 8
+ * @groupprio Time 9
  *
  * @groupname Prioritization Instance prioritization
  * @groupprio Prioritization 10
  *
  * @author Travis Brown
  */
-final object Encoder extends TupleEncoders with ProductEncoders with JavaTimeEncoders with MidPriorityEncoders {
+final object Encoder extends TupleEncoders with ProductEncoders with SumEncoders
+    with JavaTimeEncoders with MidPriorityEncoders {
   /**
    * Return an instance for a given type `A`.
    *

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -405,23 +405,23 @@ object Boilerplate {
       block"""
         |package io.circe
         |
-        |private[circe] abstract class SumEncoder[A](typeField: Option[String]) extends ObjectEncoder[A] {
-        |  protected def encodeWithoutType: PartialFunction[A, (String, JsonObject)]
+        |private[circe] trait SumEncoders {
+        |  private[this] abstract class SumEncoder[A](typeField: Option[String]) extends ObjectEncoder[A] {
+        |    protected def encodeWithoutType: PartialFunction[A, (String, JsonObject)]
         |
-        |  private[this] val encodeWithType: ((String, JsonObject)) => JsonObject = typeField match {
-        |    case Some(typeFieldKey) => p => (typeFieldKey, Json.fromString(p._1)) +: p._2
-        |    case None => p => JsonObject.singleton(p._1, Json.fromJsonObject(p._2))
+        |    private[this] val encodeWithType: ((String, JsonObject)) => JsonObject = typeField match {
+        |      case Some(typeFieldKey) => p => (typeFieldKey, Json.fromString(p._1)) +: p._2
+        |      case None => p => JsonObject.singleton(p._1, Json.fromJsonObject(p._2))
+        |    }
+        |
+        |    private[this] val encoder: PartialFunction[A, JsonObject] =
+        |      encodeWithoutType.andThen[JsonObject](encodeWithType)
+        |
+        |    private[this] val constEmpty: A => JsonObject = _ => JsonObject.empty
+        |
+        |    final def encodeObject(a: A): JsonObject = encoder.applyOrElse(a, constEmpty)
         |  }
         |
-        |  private[this] val encoder: PartialFunction[A, JsonObject] =
-        |    encodeWithoutType.andThen[JsonObject](encodeWithType)
-        |
-        |  private[this] val constEmpty: A => JsonObject = _ => JsonObject.empty
-        |
-        |  final def encodeObject(a: A): JsonObject = encoder.applyOrElse(a, constEmpty)
-        |}
-        |
-        |private[circe] trait SumEncoders {
         -  /**
         -   * @group Sum
         -   */


### PR DESCRIPTION
This is a quick implementation of a set of `forSumN` methods on the model of `forProductN` that are designed to make the macro-less creation of instances for sealed trait hierarchies a little less painful.

For example, suppose you've got this code:

```scala
import io.circe.{ Decoder, Encoder, ObjectEncoder }, io.circe.syntax._

sealed trait Visitor { def id: String }
case class User(id: String, displayName: String) extends Visitor
case class Anon(id: String) extends Visitor

object Visitor {
  implicit val encodeUser: ObjectEncoder[User] =
    Encoder.forProduct2("id", "displayName")((user: User) => (user.id, user.displayName))
  implicit val decodeUser: Decoder[User] =
    Decoder.forProduct2("id", "displayName")(User(_, _))

  implicit val encodeAnon: ObjectEncoder[Anon] =
    ObjectEncoder[Map[String, String]].contramapObject((anon: Anon) => Map("id" -> anon.id))
  implicit val decodeAnon: Decoder[Anon] =
    Decoder[String].prepare(_.downField("id")).map(Anon(_))

  implicit val encodeVisitor: ObjectEncoder[Visitor] = ObjectEncoder.instance {
    case u @ User(_, _) => u.asJsonObject.add("type", "user".asJson)
    case a @ Anon(_) => a.asJsonObject.add("type", "anon".asJson)
  }

  implicit val decodeVisitor: Decoder[Visitor] = for {
    visitorType <- Decoder[String].prepare(_.downField("type"))
    value <- visitorType match {
      case "user" => Decoder[User]
      case "anon" => Decoder[Anon]
      case other => Decoder.failedWithMessage(s"invalid type: $other")
    }
  } yield value
}
```

The additions in this PR allow you to write the following instead:

```scala
import io.circe.{ Decoder, Encoder, ObjectEncoder }

sealed trait Visitor { def id: String }
case class User(id: String, displayName: String) extends Visitor
case class Anon(id: String) extends Visitor

object Visitor {
  implicit val encodeUser: ObjectEncoder[User] =
    Encoder.forProduct2("id", "displayName")((user: User) => (user.id, user.displayName))
  implicit val decodeUser: Decoder[User] =
    Decoder.forProduct2("id", "displayName")(User(_, _))

  implicit val encodeAnon: ObjectEncoder[Anon] =
    ObjectEncoder[Map[String, String]].contramapObject((anon: Anon) => Map("id" -> anon.id))
  implicit val decodeAnon: Decoder[Anon] =
    Decoder[String].prepare(_.downField("id")).map(Anon(_))

  implicit val encodeVisitor: ObjectEncoder[Visitor] =
    Encoder.forSum2(Some("type"))("user", "anon")(
      { case user @ User(_, _) => user },
      { case anon @ Anon(_) => anon }
    )

  implicit val decodeVisitor: Decoder[Visitor] =
    Decoder.forSum2[User, Anon, Visitor](Some("type"))("user", "anon")
}
```

It's only six or seven lines lighter but it's arguably a little cleaner and more consistent. It also makes it easy to switch between the `{ "type": "anon", "id": "foo" }` and `{ "anon": { "id": "foo" }}` formats—you'd simply replace the `Some("type")` with `None` to get the latter in this case.

I'm not sure how I feel about this. If people like it, we should add tests and maybe clean up the `forSumN` implementation a little for consistency.