### PR TITLE
Allow transforming the value of the discriminator field.

### DIFF
--- a/docs/src/main/tut/codec.md
+++ b/docs/src/main/tut/codec.md
@@ -196,7 +196,7 @@ all you need is a custom implicit configuration:
 ```tut:book
 import io.circe.generic.extras._, io.circe.syntax._
 
-implicit val config: Configuration = Configuration.default.withSnakeCaseKeys
+implicit val config: Configuration = Configuration.default.withSnakeCaseMemberNames
 
 @ConfiguredJsonCodec case class User(firstName: String, lastName: String)
 
@@ -209,7 +209,7 @@ In other cases you may need more complex mappings. These can be provided as a fu
 import io.circe.generic.extras._, io.circe.syntax._
 
 implicit val config: Configuration = Configuration.default.copy(
-  transformKeys = {
+  transformMemberNames = {
     case "i" => "my-int"
     case other => other
   }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
@@ -25,22 +25,22 @@ class ConfigurableDeriver(val c: whitebox.Context)
   protected[this] val decodeAccumulatingMethodName: TermName = TermName("configuredDecodeAccumulating")
 
   protected[this] override def decodeMethodArgs: List[Tree] = List(
-    q"transformKeys: (_root_.java.lang.String => _root_.java.lang.String)",
+    q"transformMemberNames: (_root_.java.lang.String => _root_.java.lang.String)",
     q"defaults: _root_.scala.collection.immutable.Map[_root_.java.lang.String, _root_.scala.Any]",
     q"discriminator: _root_.scala.Option[_root_.java.lang.String]",
-    q"transformDiscriminators: (_root_.java.lang.String => _root_.java.lang.String)"
+    q"transformConstructorNames: (_root_.java.lang.String => _root_.java.lang.String)"
   )
 
   protected[this] def encodeMethodName: TermName = TermName("configuredEncodeObject")
   protected[this] override def encodeMethodArgs: List[Tree] = List(
-    q"transformKeys: (_root_.java.lang.String => _root_.java.lang.String)",
+    q"transformMemberNames: (_root_.java.lang.String => _root_.java.lang.String)",
     q"discriminator: _root_.scala.Option[_root_.java.lang.String]",
-    q"transformDiscriminators: (_root_.java.lang.String => _root_.java.lang.String)"
+    q"transformConstructorNames: (_root_.java.lang.String => _root_.java.lang.String)"
   )
 
   protected[this] def decodeField(name: String, decode: TermName): Tree = q"""
     orDefault(
-      $decode.tryDecode(c.downField(transformKeys($name))),
+      $decode.tryDecode(c.downField(transformMemberNames($name))),
       $name,
       defaults
     )
@@ -48,7 +48,7 @@ class ConfigurableDeriver(val c: whitebox.Context)
 
   protected[this] def decodeFieldAccumulating(name: String, decode: TermName): Tree = q"""
     orDefaultAccumulating(
-      $decode.tryDecodeAccumulating(c.downField(transformKeys($name))),
+      $decode.tryDecodeAccumulating(c.downField(transformMemberNames($name))),
       $name,
       defaults
     )
@@ -58,7 +58,7 @@ class ConfigurableDeriver(val c: whitebox.Context)
     withDiscriminator(
       $decode,
       c,
-      transformDiscriminators($name),
+      transformConstructorNames($name),
       discriminator
     )
   """
@@ -67,14 +67,14 @@ class ConfigurableDeriver(val c: whitebox.Context)
     withDiscriminatorAccumulating(
       $decode,
       c,
-      transformDiscriminators($name),
+      transformConstructorNames($name),
       discriminator
     )
   """
 
   protected[this] def encodeField(name: String, encode: TermName, value: TermName): Tree =
-    q"(transformKeys($name), $encode($value))"
+    q"(transformMemberNames($name), $encode($value))"
 
   protected[this] def encodeSubtype(name: String, encode: TermName, value: TermName): Tree =
-    q"addDiscriminator($encode, $value, transformDiscriminators($name), discriminator)"
+    q"addDiscriminator($encode, $value, transformConstructorNames($name), discriminator)"
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
@@ -27,14 +27,15 @@ class ConfigurableDeriver(val c: whitebox.Context)
   protected[this] override def decodeMethodArgs: List[Tree] = List(
     q"transformKeys: (_root_.java.lang.String => _root_.java.lang.String)",
     q"defaults: _root_.scala.collection.immutable.Map[_root_.java.lang.String, _root_.scala.Any]",
-    q"discriminator: _root_.scala.Option[_root_.java.lang.String]"
+    q"discriminator: _root_.scala.Option[_root_.java.lang.String]",
+    q"transformDiscriminators: (_root_.java.lang.String => _root_.java.lang.String)"
   )
-
 
   protected[this] def encodeMethodName: TermName = TermName("configuredEncodeObject")
   protected[this] override def encodeMethodArgs: List[Tree] = List(
     q"transformKeys: (_root_.java.lang.String => _root_.java.lang.String)",
-    q"discriminator: _root_.scala.Option[_root_.java.lang.String]"
+    q"discriminator: _root_.scala.Option[_root_.java.lang.String]",
+    q"transformDiscriminators: (_root_.java.lang.String => _root_.java.lang.String)"
   )
 
   protected[this] def decodeField(name: String, decode: TermName): Tree = q"""
@@ -57,7 +58,7 @@ class ConfigurableDeriver(val c: whitebox.Context)
     withDiscriminator(
       $decode,
       c,
-      $name,
+      transformDiscriminators($name),
       discriminator
     )
   """
@@ -66,7 +67,7 @@ class ConfigurableDeriver(val c: whitebox.Context)
     withDiscriminatorAccumulating(
       $decode,
       c,
-      $name,
+      transformDiscriminators($name),
       discriminator
     )
   """
@@ -75,5 +76,5 @@ class ConfigurableDeriver(val c: whitebox.Context)
     q"(transformKeys($name), $encode($value))"
 
   protected[this] def encodeSubtype(name: String, encode: TermName, value: TermName): Tree =
-    q"addDiscriminator($encode, $value, $name, discriminator)"
+    q"addDiscriminator($encode, $value, transformDiscriminators($name), discriminator)"
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -1,8 +1,27 @@
 package io.circe.generic.extras
 
-final case class Configuration(transformKeys: String => String, useDefaults: Boolean, discriminator: Option[String]) {
+/**
+  * Configuration allowing customisation of the JSON produced when encoding, or expected when decoding. Can be used
+  * with the [[ConfiguredJsonCodec]] annotation to allow customisation of the semi-automatic derivation.
+  *
+  * @param transformKeys Transforms the names of the keys in the JSON allowing, for example, formatting or case changes.
+  * @param useDefaults Whether to allow default values as specified in any case-classes/ADT fields.
+  * @param discriminator Optional key name that, when given, will be used to store the name of the type of an ADT in a
+  *                      nested field with this name. If not given, the type is instead stored as a key under which the
+  *                      contents of the ADT are stored as an object.
+  * @param transformDiscriminators Transforms the value of the discriminator in the JSON allowing, for example,
+  *                                formatting or case changes.
+  */
+final case class Configuration(transformKeys: String => String,
+                               useDefaults: Boolean,
+                               discriminator: Option[String],
+                               transformDiscriminators: String => String) {
   def withSnakeCaseKeys: Configuration = copy(
     transformKeys = Configuration.snakeCaseTransformation
+  )
+
+  def withSnakeCaseDiscriminators: Configuration = copy(
+    transformDiscriminators = Configuration.snakeCaseTransformation
   )
 
   def withDefaults: Configuration = copy(useDefaults = true)
@@ -10,7 +29,7 @@ final case class Configuration(transformKeys: String => String, useDefaults: Boo
 }
 
 final object Configuration {
-  val default: Configuration = Configuration(Predef.identity, false, None)
+  val default: Configuration = Configuration(Predef.identity, false, None, Predef.identity)
 
   val snakeCaseTransformation: String => String = _.replaceAll(
     "([A-Z]+)([A-Z][a-z])",

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -4,24 +4,29 @@ package io.circe.generic.extras
   * Configuration allowing customisation of the JSON produced when encoding, or expected when decoding. Can be used
   * with the [[ConfiguredJsonCodec]] annotation to allow customisation of the semi-automatic derivation.
   *
-  * @param transformKeys Transforms the names of the keys in the JSON allowing, for example, formatting or case changes.
-  * @param useDefaults Whether to allow default values as specified in any case-classes/ADT fields.
-  * @param discriminator Optional key name that, when given, will be used to store the name of the type of an ADT in a
-  *                      nested field with this name. If not given, the type is instead stored as a key under which the
-  *                      contents of the ADT are stored as an object.
-  * @param transformDiscriminators Transforms the value of the discriminator in the JSON allowing, for example,
-  *                                formatting or case changes.
+  * @param transformMemberNames Transforms the names of any case class members in the JSON allowing, for example,
+  *                             formatting or case changes.
+  * @param useDefaults Whether to allow default values as specified for any case-class members.
+  * @param discriminator Optional key name that, when given, will be used to store the name of the constructor of an ADT
+  *                      in a nested field with this name. If not given, the name is instead stored as a key under which
+  *                      the contents of the ADT are stored as an object.
+  * @param transformConstructorNames Transforms the value of any constructor names in the JSON allowing, for example,
+  *                                  formatting or case changes.
   */
-final case class Configuration(transformKeys: String => String,
+final case class Configuration(transformMemberNames: String => String,
                                useDefaults: Boolean,
                                discriminator: Option[String],
-                               transformDiscriminators: String => String) {
-  def withSnakeCaseKeys: Configuration = copy(
-    transformKeys = Configuration.snakeCaseTransformation
+                               transformConstructorNames: String => String) {
+
+  def withSnakeCaseMemberNames: Configuration = copy(
+    transformMemberNames = Configuration.snakeCaseTransformation
   )
 
-  def withSnakeCaseDiscriminators: Configuration = copy(
-    transformDiscriminators = Configuration.snakeCaseTransformation
+  @deprecated("Use withSnakeCaseMemberNames instead", "0.9.0")
+  def withSnakeCaseKeys: Configuration = withSnakeCaseMemberNames
+
+  def withSnakeCaseConstructorNames: Configuration = copy(
+    transformConstructorNames = Configuration.snakeCaseTransformation
   )
 
   def withDefaults: Configuration = copy(useDefaults = true)

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
@@ -34,14 +34,14 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
         case (field, Some(keyAnnotation)) => (field, keyAnnotation.value)
       }.toMap
 
-    private[this] def keyTransformer(transformKeys: String => String)(value: String): String =
-      keyAnnotationMap.getOrElse(value, transformKeys(value))
+    private[this] def memberNameTransformer(transformMemberNames: String => String)(value: String): String =
+      keyAnnotationMap.getOrElse(value, transformMemberNames(value))
 
     final def apply(c: HCursor): Decoder.Result[A] = decode.value.configuredDecode(c)(
-      if (hasKeyAnnotations) keyTransformer(config.transformKeys) else config.transformKeys,
+      if (hasKeyAnnotations) memberNameTransformer(config.transformMemberNames) else config.transformMemberNames,
       defaultMap,
       None,
-      config.transformDiscriminators
+      config.transformConstructorNames
     ) match {
       case Right(r) => Right(gen.from(r))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
@@ -49,10 +49,10 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
 
     override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
       decode.value.configuredDecodeAccumulating(c)(
-        if (hasKeyAnnotations) keyTransformer(config.transformKeys) else config.transformKeys,
+        if (hasKeyAnnotations) memberNameTransformer(config.transformMemberNames) else config.transformMemberNames,
         defaultMap,
         None,
-        config.transformDiscriminators
+        config.transformConstructorNames
       ).map(gen.from)
   }
 
@@ -65,7 +65,7 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
       Predef.identity,
       Map.empty,
       config.discriminator,
-      config.transformDiscriminators
+      config.transformConstructorNames
     ) match {
       case Right(r) => Right(gen.from(r))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
@@ -76,7 +76,7 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
         Predef.identity,
         Map.empty,
         config.discriminator,
-        config.transformDiscriminators
+        config.transformConstructorNames
       ).map(gen.from)
   }
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
@@ -40,7 +40,8 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
     final def apply(c: HCursor): Decoder.Result[A] = decode.value.configuredDecode(c)(
       if (hasKeyAnnotations) keyTransformer(config.transformKeys) else config.transformKeys,
       defaultMap,
-      None
+      None,
+      config.transformDiscriminators
     ) match {
       case Right(r) => Right(gen.from(r))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
@@ -50,7 +51,8 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
       decode.value.configuredDecodeAccumulating(c)(
         if (hasKeyAnnotations) keyTransformer(config.transformKeys) else config.transformKeys,
         defaultMap,
-        None
+        None,
+        config.transformDiscriminators
       ).map(gen.from)
   }
 
@@ -62,7 +64,8 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
     final def apply(c: HCursor): Decoder.Result[A] = decode.value.configuredDecode(c)(
       Predef.identity,
       Map.empty,
-      config.discriminator
+      config.discriminator,
+      config.transformDiscriminators
     ) match {
       case Right(r) => Right(gen.from(r))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
@@ -72,7 +75,8 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
       decode.value.configuredDecodeAccumulating(c)(
         Predef.identity,
         Map.empty,
-        config.discriminator
+        config.discriminator,
+        config.transformDiscriminators
       ).map(gen.from)
   }
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/IncompleteConfiguredDecoders.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/IncompleteConfiguredDecoders.scala
@@ -24,7 +24,8 @@ private[circe] trait IncompleteConfiguredDecoders {
     final def apply(c: HCursor): Decoder.Result[F] = decode.configuredDecode(c)(
       config.transformKeys,
       defaultMap,
-      None
+      None,
+      config.transformDiscriminators
     ) match {
       case Right(r) => Right(ffp(p => gen.from(removeAll.reinsert((p, r)))))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[F]]
@@ -34,7 +35,8 @@ private[circe] trait IncompleteConfiguredDecoders {
       decode.configuredDecodeAccumulating(c)(
         config.transformKeys,
         defaultMap,
-        None
+        None,
+        config.transformDiscriminators
       ).map(r => ffp(p => gen.from(removeAll.reinsert((p, r)))))
   }
 
@@ -51,7 +53,8 @@ private[circe] trait IncompleteConfiguredDecoders {
     final def apply(c: HCursor): Decoder.Result[A => A] = decode.configuredDecode(c)(
       config.transformKeys,
       defaultMap,
-      None
+      None,
+      config.transformDiscriminators
     ) match {
       case Right(o) => Right(a => gen.from(patch(gen.to(a), o)))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A => A]]
@@ -61,7 +64,8 @@ private[circe] trait IncompleteConfiguredDecoders {
       decode.configuredDecodeAccumulating(c)(
         config.transformKeys,
         defaultMap,
-        None
+        None,
+        config.transformDiscriminators
       ).map(o => a => gen.from(patch(gen.to(a), o)))
   }
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/IncompleteConfiguredDecoders.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/IncompleteConfiguredDecoders.scala
@@ -22,10 +22,10 @@ private[circe] trait IncompleteConfiguredDecoders {
     private[this] val defaultMap: Map[String, Any] = if (config.useDefaults) defaultMapper(defaults()) else Map.empty
 
     final def apply(c: HCursor): Decoder.Result[F] = decode.configuredDecode(c)(
-      config.transformKeys,
+      config.transformMemberNames,
       defaultMap,
       None,
-      config.transformDiscriminators
+      config.transformConstructorNames
     ) match {
       case Right(r) => Right(ffp(p => gen.from(removeAll.reinsert((p, r)))))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[F]]
@@ -33,10 +33,10 @@ private[circe] trait IncompleteConfiguredDecoders {
 
     override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[F] =
       decode.configuredDecodeAccumulating(c)(
-        config.transformKeys,
+        config.transformMemberNames,
         defaultMap,
         None,
-        config.transformDiscriminators
+        config.transformConstructorNames
       ).map(r => ffp(p => gen.from(removeAll.reinsert((p, r)))))
   }
 
@@ -51,10 +51,10 @@ private[circe] trait IncompleteConfiguredDecoders {
     private[this] val defaultMap: Map[String, Any] = if (config.useDefaults) defaultMapper(defaults()) else Map.empty
 
     final def apply(c: HCursor): Decoder.Result[A => A] = decode.configuredDecode(c)(
-      config.transformKeys,
+      config.transformMemberNames,
       defaultMap,
       None,
-      config.transformDiscriminators
+      config.transformConstructorNames
     ) match {
       case Right(o) => Right(a => gen.from(patch(gen.to(a), o)))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A => A]]
@@ -62,10 +62,10 @@ private[circe] trait IncompleteConfiguredDecoders {
 
     override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A => A] =
       decode.configuredDecodeAccumulating(c)(
-        config.transformKeys,
+        config.transformMemberNames,
         defaultMap,
         None,
-        config.transformDiscriminators
+        config.transformConstructorNames
       ).map(o => a => gen.from(patch(gen.to(a), o)))
   }
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
@@ -16,17 +16,17 @@ import shapeless.HNil
  */
 abstract class ReprDecoder[A] extends Decoder[A] {
   def configuredDecode(c: HCursor)(
-    transformKeys: String => String,
+    transformMemberNames: String => String,
     defaults: Map[String, Any],
     discriminator: Option[String],
-    transformDiscriminators: String => String
+    transformConstructorNames: String => String
   ): Decoder.Result[A]
 
   def configuredDecodeAccumulating(c: HCursor)(
-    transformKeys: String => String,
+    transformMemberNames: String => String,
     defaults: Map[String, Any],
     discriminator: Option[String],
-    transformDiscriminators: String => String
+    transformConstructorNames: String => String
   ): AccumulatingDecoder.Result[A]
 
   final protected[this] def orDefault[B](
@@ -102,17 +102,17 @@ final object ReprDecoder {
 
   val hnilReprDecoder: ReprDecoder[HNil] = new ReprDecoder[HNil] {
     def configuredDecode(c: HCursor)(
-      transformKeys: String => String,
+      transformMemberNames: String => String,
       defaults: Map[String, Any],
       discriminator: Option[String],
-      transformDiscriminators: String => String
+      transformConstructorNames: String => String
     ): Decoder.Result[HNil] = Right(HNil)
 
     def configuredDecodeAccumulating(c: HCursor)(
-      transformKeys: String => String,
+      transformMemberNames: String => String,
       defaults: Map[String, Any],
       discriminator: Option[String],
-      transformDiscriminators: String => String
+      transformConstructorNames: String => String
     ): AccumulatingDecoder.Result[HNil] = Validated.valid(HNil)
   }
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
@@ -18,13 +18,15 @@ abstract class ReprDecoder[A] extends Decoder[A] {
   def configuredDecode(c: HCursor)(
     transformKeys: String => String,
     defaults: Map[String, Any],
-    discriminator: Option[String]
+    discriminator: Option[String],
+    transformDiscriminators: String => String
   ): Decoder.Result[A]
 
   def configuredDecodeAccumulating(c: HCursor)(
     transformKeys: String => String,
     defaults: Map[String, Any],
-    discriminator: Option[String]
+    discriminator: Option[String],
+    transformDiscriminators: String => String
   ): AccumulatingDecoder.Result[A]
 
   final protected[this] def orDefault[B](
@@ -88,9 +90,11 @@ abstract class ReprDecoder[A] extends Decoder[A] {
     }
   }
 
-  final def apply(c: HCursor): Decoder.Result[A] = configuredDecode(c)(Predef.identity, Map.empty, None)
+  final def apply(c: HCursor): Decoder.Result[A] =
+    configuredDecode(c)(Predef.identity, Map.empty, None, Predef.identity)
+
   final override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
-    configuredDecodeAccumulating(c)(Predef.identity, Map.empty, None)
+    configuredDecodeAccumulating(c)(Predef.identity, Map.empty, None, Predef.identity)
 }
 
 final object ReprDecoder {
@@ -100,13 +104,15 @@ final object ReprDecoder {
     def configuredDecode(c: HCursor)(
       transformKeys: String => String,
       defaults: Map[String, Any],
-      discriminator: Option[String]
+      discriminator: Option[String],
+      transformDiscriminators: String => String
     ): Decoder.Result[HNil] = Right(HNil)
 
     def configuredDecodeAccumulating(c: HCursor)(
       transformKeys: String => String,
       defaults: Map[String, Any],
-      discriminator: Option[String]
+      discriminator: Option[String],
+      transformDiscriminators: String => String
     ): AccumulatingDecoder.Result[HNil] = Validated.valid(HNil)
   }
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredObjectEncoder.scala
@@ -34,7 +34,8 @@ final object ConfiguredObjectEncoder {
     final def encodeObject(a: A): JsonObject =
       encode.value.configuredEncodeObject(gen.to(a))(
         if (hasKeyAnnotations) keyTransformer(config.transformKeys) else config.transformKeys,
-        None
+        None,
+        config.transformDiscriminators
       )
   }
 
@@ -44,6 +45,10 @@ final object ConfiguredObjectEncoder {
     config: Configuration
   ): ConfiguredObjectEncoder[A] = new ConfiguredObjectEncoder[A] {
     final def encodeObject(a: A): JsonObject =
-      encode.value.configuredEncodeObject(gen.to(a))(Predef.identity, config.discriminator)
+      encode.value.configuredEncodeObject(gen.to(a))(
+        Predef.identity,
+        config.discriminator,
+        config.transformDiscriminators
+      )
   }
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredObjectEncoder.scala
@@ -28,14 +28,14 @@ final object ConfiguredObjectEncoder {
         case (field, Some(keyAnnotation)) => (field, keyAnnotation.value)
       }.toMap
 
-    private[this] def keyTransformer(transformKeys: String => String)(value: String): String =
-      keyAnnotationMap.getOrElse(value, transformKeys(value))
+    private[this] def memberNameTransformer(transformMemberNames: String => String)(value: String): String =
+      keyAnnotationMap.getOrElse(value, transformMemberNames(value))
 
     final def encodeObject(a: A): JsonObject =
       encode.value.configuredEncodeObject(gen.to(a))(
-        if (hasKeyAnnotations) keyTransformer(config.transformKeys) else config.transformKeys,
+        if (hasKeyAnnotations) memberNameTransformer(config.transformMemberNames) else config.transformMemberNames,
         None,
-        config.transformDiscriminators
+        config.transformConstructorNames
       )
   }
 
@@ -48,7 +48,7 @@ final object ConfiguredObjectEncoder {
       encode.value.configuredEncodeObject(gen.to(a))(
         Predef.identity,
         config.discriminator,
-        config.transformDiscriminators
+        config.transformConstructorNames
       )
   }
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprObjectEncoder.scala
@@ -10,7 +10,11 @@ import scala.language.experimental.macros
  * Note that users typically will not work with instances of this class.
  */
 abstract class ReprObjectEncoder[A] extends ObjectEncoder[A] {
-  def configuredEncodeObject(a: A)(transformKeys: String => String, discriminator: Option[String]): JsonObject
+  def configuredEncodeObject(a: A)(
+    transformKeys: String => String,
+    discriminator: Option[String],
+    transformDiscriminator: String => String
+  ): JsonObject
 
   final protected[this] def addDiscriminator[B](
     encode: Encoder[B],
@@ -25,7 +29,7 @@ abstract class ReprObjectEncoder[A] extends ObjectEncoder[A] {
     }
   }
 
-  final def encodeObject(a: A): JsonObject = configuredEncodeObject(a)(Predef.identity, None)
+  final def encodeObject(a: A): JsonObject = configuredEncodeObject(a)(Predef.identity, None, Predef.identity)
 }
 
 final object ReprObjectEncoder {

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprObjectEncoder.scala
@@ -11,7 +11,7 @@ import scala.language.experimental.macros
  */
 abstract class ReprObjectEncoder[A] extends ObjectEncoder[A] {
   def configuredEncodeObject(a: A)(
-    transformKeys: String => String,
+    transformMemberNames: String => String,
     discriminator: Option[String],
     transformDiscriminator: String => String
   ): JsonObject

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -63,6 +63,16 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
     }
   }
 
+  "Configuration#transformDiscrimators" should "support discriminator transformation" in forAll { (f: String, a: Int, b: Double) =>
+    implicit val snakeCaseConfig: Configuration = Configuration.default.withDiscriminator("type").withSnakeCaseDiscriminators
+
+    val foo: ConfigExampleBase = ConfigExampleFoo(f, a, b)
+    val json = json"""{ "type": "config_example_foo", "thisIsAField": $f, "a": $a, "b": $b}"""
+
+    assert(Encoder[ConfigExampleBase].apply(foo) === json)
+    assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
+  }
+
   "Configuration options" should "work together" in forAll { (f: String, b: Double) =>
     implicit val customConfig: Configuration =
       Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type")

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -28,8 +28,8 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
 
   import examples._
 
-  "Configuration#transformKeys" should "support key transformation" in forAll { (f: String, a: Int, b: Double) =>
-    implicit val snakeCaseConfig: Configuration = Configuration.default.withSnakeCaseKeys
+  "Configuration#transformMemberNames" should "support member name transformation" in forAll { (f: String, a: Int, b: Double) =>
+    implicit val snakeCaseConfig: Configuration = Configuration.default.withSnakeCaseMemberNames
 
     val foo: ConfigExampleFoo = ConfigExampleFoo(f, a, b)
     val json = json"""{ "this_is_a_field": $f, "a": $a, "b": $b}"""
@@ -63,8 +63,8 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
     }
   }
 
-  "Configuration#transformDiscrimators" should "support discriminator transformation" in forAll { (f: String, a: Int, b: Double) =>
-    implicit val snakeCaseConfig: Configuration = Configuration.default.withDiscriminator("type").withSnakeCaseDiscriminators
+  "Configuration#transformConstructorNames" should "support constructor name transformation" in forAll { (f: String, a: Int, b: Double) =>
+    implicit val snakeCaseConfig: Configuration = Configuration.default.withDiscriminator("type").withSnakeCaseConstructorNames
 
     val foo: ConfigExampleBase = ConfigExampleFoo(f, a, b)
     val json = json"""{ "type": "config_example_foo", "thisIsAField": $f, "a": $a, "b": $b}"""
@@ -75,7 +75,7 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
 
   "Configuration options" should "work together" in forAll { (f: String, b: Double) =>
     implicit val customConfig: Configuration =
-      Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type")
+      Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("type")
 
     val foo: ConfigExampleBase = ConfigExampleFoo(f, 0, b)
     val json = json"""{ "type": "ConfigExampleFoo", "this_is_a_field": $f, "b": $b}"""

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredJsonCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredJsonCodecSuite.scala
@@ -7,7 +7,7 @@ import io.circe.tests.CirceSuite
 
 class ConfiguredJsonCodecSuite extends CirceSuite {
   implicit val customConfig: Configuration =
-    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type")
+    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type").withSnakeCaseDiscriminators
 
   /**
    * This nesting is necessary on 2.10 (possibly related to SI-7406).
@@ -30,8 +30,8 @@ class ConfiguredJsonCodecSuite extends CirceSuite {
 
   "ConfiguredJsonCodec" should "support configuration" in forAll { (f: String, b: Double) =>
     val foo: ConfigExampleBase = ConfigExampleFoo(f, 0, b)
-    val json = json"""{ "type": "ConfigExampleFoo", "this_is_a_field": $f, "b": $b}"""
-    val expected = json"""{ "type": "ConfigExampleFoo", "this_is_a_field": $f, "a": 0, "b": $b}"""
+    val json = json"""{ "type": "config_example_foo", "this_is_a_field": $f, "b": $b}"""
+    val expected = json"""{ "type": "config_example_foo", "this_is_a_field": $f, "a": 0, "b": $b}"""
 
     assert(Encoder[ConfigExampleBase].apply(foo) === expected)
     assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredJsonCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredJsonCodecSuite.scala
@@ -7,7 +7,7 @@ import io.circe.tests.CirceSuite
 
 class ConfiguredJsonCodecSuite extends CirceSuite {
   implicit val customConfig: Configuration =
-    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type").withSnakeCaseDiscriminators
+    Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("type").withSnakeCaseConstructorNames
 
   /**
    * This nesting is necessary on 2.10 (possibly related to SI-7406).

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredJsonCodecWithKeySuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredJsonCodecWithKeySuite.scala
@@ -7,7 +7,7 @@ import io.circe.tests.CirceSuite
 
 class ConfiguredJsonCodecWithKeySuite extends CirceSuite {
   implicit val customConfig: Configuration =
-    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type").withSnakeCaseDiscriminators
+    Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("type").withSnakeCaseConstructorNames
 
   /**
    * This nesting is necessary on 2.10 (possibly related to SI-7406).

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredJsonCodecWithKeySuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredJsonCodecWithKeySuite.scala
@@ -7,7 +7,7 @@ import io.circe.tests.CirceSuite
 
 class ConfiguredJsonCodecWithKeySuite extends CirceSuite {
   implicit val customConfig: Configuration =
-    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type")
+    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type").withSnakeCaseDiscriminators
 
   /**
    * This nesting is necessary on 2.10 (possibly related to SI-7406).
@@ -30,8 +30,8 @@ class ConfiguredJsonCodecWithKeySuite extends CirceSuite {
 
   "ConfiguredJsonCodec" should "support key annotation and configuration" in forAll { (f: String, b: Double) =>
     val foo: ConfigExampleBase = ConfigExampleFoo(f, 0, b)
-    val json = json"""{ "type": "ConfigExampleFoo", "this_is_a_field": $f, "myField": $b}"""
-    val expected = json"""{ "type": "ConfigExampleFoo", "this_is_a_field": $f, "a": 0, "myField": $b}"""
+    val json = json"""{ "type": "config_example_foo", "this_is_a_field": $f, "myField": $b}"""
+    val expected = json"""{ "type": "config_example_foo", "this_is_a_field": $f, "a": 0, "myField": $b}"""
 
     assert(Encoder[ConfigExampleBase].apply(foo) === expected)
     assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
@@ -30,7 +30,7 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite {
   import examples._
 
   implicit val customConfig: Configuration =
-    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type")
+    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type").withSnakeCaseDiscriminators
 
   implicit val decodeIntlessQux: Decoder[Int => Qux[String]] =
     deriveFor[Int => Qux[String]].incomplete
@@ -45,8 +45,8 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite {
 
   "Semi-automatic derivation" should "support configuration" in forAll { (f: String, b: Double) =>
     val foo: ConfigExampleBase = ConfigExampleFoo(f, 0, b)
-    val json = json"""{ "type": "ConfigExampleFoo", "this_is_a_field": $f, "b": $b}"""
-    val expected = json"""{ "type": "ConfigExampleFoo", "this_is_a_field": $f, "a": 0, "b": $b}"""
+    val json = json"""{ "type": "config_example_foo", "this_is_a_field": $f, "b": $b}"""
+    val expected = json"""{ "type": "config_example_foo", "this_is_a_field": $f, "a": 0, "b": $b}"""
 
     assert(Encoder[ConfigExampleBase].apply(foo) === expected)
     assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))

--- a/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
@@ -30,7 +30,7 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite {
   import examples._
 
   implicit val customConfig: Configuration =
-    Configuration.default.withSnakeCaseKeys.withDefaults.withDiscriminator("type").withSnakeCaseDiscriminators
+    Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("type").withSnakeCaseConstructorNames
 
   implicit val decodeIntlessQux: Decoder[Int => Qux[String]] =
     deriveFor[Int => Qux[String]].incomplete


### PR DESCRIPTION
Adds a `transformDiscriminator` option to `Configuration` which allows
transformation of the value used for the discriminator (whether inside
the object or outside). This works the same way as `transformKeys` does.

As an example, given the following classes to encode/decode:

```scala
sealed trait State
case object RedLight extends State
case object YellowLight extends State
case object GreenLight extends State

case class TrafficLight(state: State)
```

One can use the following configuration to get a customised JSON output
even for the `type` field:

```scala
implicit val config = Configuration.default.withDiscriminator("type").copy(transformDiscriminators = _.toLowerCase)
```

```json
{
  "state" : {
    "type" : "redlight"
  }
}
```

Normally, one would get the following JSON:

```json
{
  "state" : {
    "type" : "RedLight"
  }
}
```

It's worth noting as well that, as with `transformKeys`, the
`transformDiscriminator` has a convenience transformation to snake case
(which is undoubtedly one of the most common use cases for this):

```
implicit val config = Configuration.default.withDiscriminator("type").withSnakeCaseDiscriminators
```