### PR TITLE
Do not override error msg's of CanBuildFrom #643

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -689,19 +689,19 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    * @group Decoding
    */
   implicit final def decodeSet[A: Decoder]: Decoder[Set[A]] =
-    decodeCanBuildFrom[A, List].map(_.toSet).withErrorMessage("[A]Set[A]")
+    decodeCanBuildFrom[A, List].map(_.toSet)
 
   /**
    * @group Decoding
    */
   implicit final def decodeList[A: Decoder]: Decoder[List[A]] =
-    decodeCanBuildFrom[A, List].withErrorMessage("[A]List[A]")
+    decodeCanBuildFrom[A, List]
 
   /**
    * @group Decoding
    */
   implicit final def decodeVector[A: Decoder]: Decoder[Vector[A]] =
-    decodeCanBuildFrom[A, Vector].withErrorMessage("[A]Vector[A]")
+    decodeCanBuildFrom[A, Vector]
 
   /**
    * @group Decoding


### PR DESCRIPTION
Addresses issue #643 which contained an example of a custom error
message being lost for a List type when an item in that list failed to
decode properly.

The problem is present for three basic types of collections

	- Set
	- List
	- Vector

since each of these decoders defined in Decoder.scala call
withErrorMessage and therefore lose any message bubbled up from within
that collection.