### PR TITLE
Move io.circe.numbers tests to the circe-numbers project

### DIFF
--- a/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/IntegralString.scala
+++ b/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/IntegralString.scala
@@ -1,4 +1,4 @@
-package io.circe.testing
+package io.circe.numbers.testing
 
 import org.scalacheck.{ Arbitrary, Gen }
 

--- a/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/JsonNumberString.scala
+++ b/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/JsonNumberString.scala
@@ -1,4 +1,4 @@
-package io.circe.testing
+package io.circe.numbers.testing
 
 import org.scalacheck.{ Arbitrary, Gen }
 

--- a/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -1,6 +1,6 @@
 package io.circe.numbers
 
-import io.circe.testing.{ IntegralString, JsonNumberString }
+import io.circe.numbers.testing.{ IntegralString, JsonNumberString }
 import java.math.BigDecimal
 import org.scalatest.FlatSpec
 import org.scalatest.prop.GeneratorDrivenPropertyChecks

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -4,6 +4,7 @@ import cats.data.ValidatedNel
 import cats.laws.discipline.arbitrary._
 import io.circe._
 import io.circe.numbers.BiggerDecimal
+import io.circe.numbers.testing.JsonNumberString
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
 import org.scalacheck.Arbitrary.arbitrary
 

--- a/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import io.circe.testing.JsonNumberString
+import io.circe.numbers.testing.JsonNumberString
 import io.circe.tests.CirceSuite
 import scala.math.{ min, max }
 


### PR DESCRIPTION
This change moves some stuff around so that the tests for `BiggerDecimal` are actually in the circe-numbers project.