### PR TITLE
Add Json.Folder

### DIFF
--- a/modules/benchmark/src/main/scala/io/circe/benchmark/FoldingBenchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/FoldingBenchmark.scala
@@ -1,0 +1,69 @@
+package io.circe.benchmark
+
+import io.circe.{ Json, JsonNumber, JsonObject }
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+/**
+ * Compare the performance of various ways of folding JSON values.
+ *
+ * The following command will run the benchmarks with reasonable settings:
+ *
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.FoldingBenchmark"
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class FoldingBenchmark extends ExampleData {
+  val doc: Json = Json.arr(intsJson, booleansJson, foosJson, helloWorldJson)
+
+  @Benchmark
+  def withFoldWith: Int = doc.foldWith(
+    new Json.Folder[Int] {
+      private[this] val accumulate: (Int, Json) => Int = _ + _.foldWith(this)
+
+      def onNull: Int = 0
+      def onBoolean(value: Boolean): Int = if (value) 1 else 0
+      def onNumber(value: JsonNumber): Int = value.truncateToInt
+      def onString(value: String): Int = value.length
+      def onArray(value: Vector[Json]): Int = value.foldLeft(0)(accumulate)
+      def onObject(value: JsonObject): Int = value.values.foldLeft(0)(accumulate)
+    }
+  )
+
+  @Benchmark
+  def withFold: Int = {
+    def foldToInt(json: Json): Int = json.fold(
+      0,
+      if (_) 1 else 0,
+      _.truncateToInt,
+      _.length,
+      _.foldLeft(0) {
+        case (acc, json) => acc + foldToInt(json)
+      },
+      _.values.foldLeft(0) {
+        case (acc, json) => acc + foldToInt(json)
+      }
+    )
+
+    foldToInt(doc)
+  }
+
+  @Benchmark
+  def withPatternMatch: Int = {
+    def foldToInt(json: Json): Int = json match {
+      case Json.JNull => 0
+      case Json.JBoolean(value) => if (value) 1 else 0
+      case Json.JNumber(value) => value.truncateToInt
+      case Json.JString(value) => value.length
+      case Json.JArray(value) => value.foldLeft(0) {
+        case (acc, json) => acc + foldToInt(json)
+      }
+      case Json.JObject(value) => value.values.foldLeft(0) {
+        case (acc, json) => acc + foldToInt(json)
+      }
+    }
+
+    foldToInt(doc)
+  }
+}

--- a/modules/benchmark/src/main/scala/io/circe/benchmark/FoldingBenchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/FoldingBenchmark.scala
@@ -19,15 +19,15 @@ class FoldingBenchmark extends ExampleData {
 
   @Benchmark
   def withFoldWith: Int = doc.foldWith(
-    new Json.Folder[Int] {
-      private[this] val accumulate: (Int, Json) => Int = _ + _.foldWith(this)
+    new Json.Folder[Int] with ((Int, Json) => Int) {
+      def apply(i: Int, j: Json): Int = i + j.foldWith(this)
 
       def onNull: Int = 0
       def onBoolean(value: Boolean): Int = if (value) 1 else 0
       def onNumber(value: JsonNumber): Int = value.truncateToInt
       def onString(value: String): Int = value.length
-      def onArray(value: Vector[Json]): Int = value.foldLeft(0)(accumulate)
-      def onObject(value: JsonObject): Int = value.values.foldLeft(0)(accumulate)
+      def onArray(value: Vector[Json]): Int = value.foldLeft(0)(this)
+      def onObject(value: JsonObject): Int = value.values.foldLeft(0)(this)
     }
   )
 

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/FoldingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/FoldingBenchmarkSpec.scala
@@ -1,0 +1,19 @@
+package io.circe.benchmark
+
+import org.scalatest.FlatSpec
+
+class FoldingBenchmarkSpec extends FlatSpec {
+  val benchmark: FoldingBenchmark = new FoldingBenchmark
+
+  "withFoldWith" should "give the correct result" in {
+    assert(benchmark.withFoldWith === 5463565)
+  }
+
+  "withFold" should "give the correct result" in {
+    assert(benchmark.withFold === 5463565)
+  }
+
+  "withPatternMatch" should "give the correct result" in {
+    assert(benchmark.withPatternMatch === 5463565)
+  }
+}

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -66,17 +66,19 @@ sealed abstract class Json extends Product with Serializable {
   def isArray: Boolean
   def isObject: Boolean
 
+  def asNull: Option[Unit]
   def asBoolean: Option[Boolean]
   def asNumber: Option[JsonNumber]
   def asString: Option[String]
   def asArray: Option[Vector[Json]]
   def asObject: Option[JsonObject]
 
-  final def withBoolean(f: Boolean => Json): Json = asBoolean.fold(this)(f)
-  final def withNumber(f: JsonNumber => Json): Json = asNumber.fold(this)(f)
-  final def withString(f: String => Json): Json = asString.fold(this)(f)
-  final def withArray(f: Vector[Json] => Json): Json = asArray.fold(this)(f)
-  final def withObject(f: JsonObject => Json): Json = asObject.fold(this)(f)
+  def withNull(f: => Json): Json
+  def withBoolean(f: Boolean => Json): Json
+  def withNumber(f: JsonNumber => Json): Json
+  def withString(f: String => Json): Json
+  def withArray(f: Vector[Json] => Json): Json
+  def withObject(f: JsonObject => Json): Json
 
   def mapBoolean(f: Boolean => Boolean): Json
   def mapNumber(f: JsonNumber => JsonNumber): Json
@@ -209,11 +211,19 @@ final object Json {
     final def isArray: Boolean = false
     final def isObject: Boolean = false
 
+    final def asNull: Option[Unit] = Some(())
     final def asBoolean: Option[Boolean] = None
     final def asNumber: Option[JsonNumber] = None
     final def asString: Option[String] = None
     final def asArray: Option[Vector[Json]] = None
     final def asObject: Option[JsonObject] = None
+
+    final def withNull(f: => Json): Json = f
+    final def withBoolean(f: Boolean => Json): Json = this
+    final def withNumber(f: JsonNumber => Json): Json = this
+    final def withString(f: String => Json): Json = this
+    final def withArray(f: Vector[Json] => Json): Json = this
+    final def withObject(f: JsonObject => Json): Json = this
 
     final def mapBoolean(f: Boolean => Boolean): Json = this
     final def mapNumber(f: JsonNumber => JsonNumber): Json = this
@@ -232,11 +242,19 @@ final object Json {
     final def isArray: Boolean = false
     final def isObject: Boolean = false
 
+    final def asNull: Option[Unit] = None
     final def asBoolean: Option[Boolean] = Some(value)
     final def asNumber: Option[JsonNumber] = None
     final def asString: Option[String] = None
     final def asArray: Option[Vector[Json]] = None
     final def asObject: Option[JsonObject] = None
+
+    final def withNull(f: => Json): Json = this
+    final def withBoolean(f: Boolean => Json): Json = f(value)
+    final def withNumber(f: JsonNumber => Json): Json = this
+    final def withString(f: String => Json): Json = this
+    final def withArray(f: Vector[Json] => Json): Json = this
+    final def withObject(f: JsonObject => Json): Json = this
 
     final def mapBoolean(f: Boolean => Boolean): Json = JBoolean(f(value))
     final def mapNumber(f: JsonNumber => JsonNumber): Json = this
@@ -255,11 +273,19 @@ final object Json {
     final def isArray: Boolean = false
     final def isObject: Boolean = false
 
+    final def asNull: Option[Unit] = None
     final def asBoolean: Option[Boolean] = None
     final def asNumber: Option[JsonNumber] = Some(value)
     final def asString: Option[String] = None
     final def asArray: Option[Vector[Json]] = None
     final def asObject: Option[JsonObject] = None
+
+    final def withNull(f: => Json): Json = this
+    final def withBoolean(f: Boolean => Json): Json = this
+    final def withNumber(f: JsonNumber => Json): Json = f(value)
+    final def withString(f: String => Json): Json = this
+    final def withArray(f: Vector[Json] => Json): Json = this
+    final def withObject(f: JsonObject => Json): Json = this
 
     final def mapBoolean(f: Boolean => Boolean): Json = this
     final def mapNumber(f: JsonNumber => JsonNumber): Json = JNumber(f(value))
@@ -278,11 +304,19 @@ final object Json {
     final def isArray: Boolean = false
     final def isObject: Boolean = false
 
+    final def asNull: Option[Unit] = None
     final def asBoolean: Option[Boolean] = None
     final def asNumber: Option[JsonNumber] = None
     final def asString: Option[String] = Some(value)
     final def asArray: Option[Vector[Json]] = None
     final def asObject: Option[JsonObject] = None
+
+    final def withNull(f: => Json): Json = this
+    final def withBoolean(f: Boolean => Json): Json = this
+    final def withNumber(f: JsonNumber => Json): Json = this
+    final def withString(f: String => Json): Json = f(value)
+    final def withArray(f: Vector[Json] => Json): Json = this
+    final def withObject(f: JsonObject => Json): Json = this
 
     final def mapBoolean(f: Boolean => Boolean): Json = this
     final def mapNumber(f: JsonNumber => JsonNumber): Json = this
@@ -301,11 +335,19 @@ final object Json {
     final def isArray: Boolean = true
     final def isObject: Boolean = false
 
+    final def asNull: Option[Unit] = None
     final def asBoolean: Option[Boolean] = None
     final def asNumber: Option[JsonNumber] = None
     final def asString: Option[String] = None
     final def asArray: Option[Vector[Json]] = Some(value)
     final def asObject: Option[JsonObject] = None
+
+    final def withNull(f: => Json): Json = this
+    final def withBoolean(f: Boolean => Json): Json = this
+    final def withNumber(f: JsonNumber => Json): Json = this
+    final def withString(f: String => Json): Json = this
+    final def withArray(f: Vector[Json] => Json): Json = f(value)
+    final def withObject(f: JsonObject => Json): Json = this
 
     final def mapBoolean(f: Boolean => Boolean): Json = this
     final def mapNumber(f: JsonNumber => JsonNumber): Json = this
@@ -324,11 +366,19 @@ final object Json {
     final def isArray: Boolean = false
     final def isObject: Boolean = true
 
+    final def asNull: Option[Unit] = None
     final def asBoolean: Option[Boolean] = None
     final def asNumber: Option[JsonNumber] = None
     final def asString: Option[String] = None
     final def asArray: Option[Vector[Json]] = None
     final def asObject: Option[JsonObject] = Some(value)
+
+    final def withNull(f: => Json): Json = this
+    final def withBoolean(f: Boolean => Json): Json = this
+    final def withNumber(f: JsonNumber => Json): Json = this
+    final def withString(f: String => Json): Json = this
+    final def withArray(f: Vector[Json] => Json): Json = this
+    final def withObject(f: JsonObject => Json): Json = f(value)
 
     final def mapBoolean(f: Boolean => Boolean): Json = this
     final def mapNumber(f: JsonNumber => JsonNumber): Json = this

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -125,16 +125,16 @@ sealed abstract class Json extends Product with Serializable {
   final def spaces4: String = Printer.spaces4.pretty(this)
 
   /**
-    * Perform a deep merge of this JSON value with another JSON value.
-    *
-    * Objects are merged by key, values from the argument JSON take
-    * precedence over values from this JSON. Nested objects are
-    * recursed.
-    *
-    * Null, Array, Boolean, String and Number are treated as values,
-    * and values from the argument JSON completely replace values
-    * from this JSON.
-    */
+   * Perform a deep merge of this JSON value with another JSON value.
+   *
+   * Objects are merged by key, values from the argument JSON take
+   * precedence over values from this JSON. Nested objects are
+   * recursed.
+   *
+   * Null, Array, Boolean, String and Number are treated as values,
+   * and values from the argument JSON completely replace values
+   * from this JSON.
+   */
   def deepMerge(that: Json): Json =
     (asObject, that.asObject) match {
       case (Some(lhs), Some(rhs)) =>
@@ -169,11 +169,11 @@ sealed abstract class Json extends Product with Serializable {
   final def \\(key: String): List[Json] = findAllByKey(key)
 
   /**
-    * Recursively return all values matching the specified `key`.
-    *
-    * The Play docs, from which this method was inspired, reads:
-    *   "Lookup for fieldName in the current object and all descendants."
-    */
+   * Recursively return all values matching the specified `key`.
+   *
+   * The Play docs, from which this method was inspired, reads:
+   *   "Lookup for fieldName in the current object and all descendants."
+   */
   final def findAllByKey(key: String): List[Json] = keyValues(this).collect {
     case (k, v) if (k == key) => v
   }

--- a/modules/tests/jvm/src/test/scala/io/circe/MemoizedPiecesSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/MemoizedPiecesSuite.scala
@@ -18,7 +18,7 @@ class MemoizedPiecesSuite extends CirceSuite with ScalaFutures {
     )
   }
 
-  def makePieces: Printer.MemoizedPieces = new Printer.MemoizedPieces {
+  def makePieces: Printer.MemoizedPieces = new Printer.MemoizedPieces(" ") {
     def compute(i: Int): Printer.Pieces = new Printer.Pieces(
       "%s%s%s".format(" " * i, "a", " " * (i + 1)),
       "%s%s%s".format(" " * i, "b", " " * (i + 1)),

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -5,7 +5,7 @@ import io.circe.syntax._
 import io.circe.tests.CirceSuite
 
 class JsonSuite extends CirceSuite with FloatJsonTests {
-  "foldWith" should "give the same value as fold" in forAll { (json: Json) =>
+  "foldWith" should "give the same result as fold" in forAll { (json: Json) =>
     val z: Int = 0
     val b: Boolean => Int = if (_) 1 else 2
     val n: JsonNumber => Int = _.truncateToInt
@@ -25,6 +25,54 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     )
 
     assert(result === json.fold(z, b, n, s, a, o))
+  }
+
+  "asNull" should "give the same result as fold" in forAll { (json: Json) =>
+    assert(json.asNull === json.fold(Some(()), _ => None, _ => None, _ => None, _ => None, _ => None))
+  }
+
+  "asBoolean" should "give the same result as fold" in forAll { (json: Json) =>
+    assert(json.asBoolean === json.fold(None, Some(_), _ => None, _ => None, _ => None, _ => None))
+  }
+
+  "asNumber" should "give the same result as fold" in forAll { (json: Json) =>
+    assert(json.asNumber === json.fold(None, _ => None, Some(_), _ => None, _ => None, _ => None))
+  }
+
+  "asString" should "give the same result as fold" in forAll { (json: Json) =>
+    assert(json.asString === json.fold(None, _ => None, _ => None, Some(_), _ => None, _ => None))
+  }
+
+  "asArray" should "give the same result as fold" in forAll { (json: Json) =>
+    assert(json.asArray === json.fold(None, _ => None, _ => None, _ => None, Some(_), _ => None))
+  }
+
+  "asObject" should "give the same result as fold" in forAll { (json: Json) =>
+    assert(json.asObject === json.fold(None, _ => None, _ => None, _ => None, _ => None, Some(_)))
+  }
+
+  "withNull" should "be identity with Json.Null" in forAll { (json: Json) =>
+    assert(json.withNull(Json.Null) === json)
+  }
+
+  "withBoolean" should "be identity with Json.fromBoolean" in forAll { (json: Json) =>
+    assert(json.withBoolean(Json.fromBoolean) === json)
+  }
+
+  "withNumber" should "be identity with Json.fromJsonNumber" in forAll { (json: Json) =>
+    assert(json.withNumber(Json.fromJsonNumber) === json)
+  }
+
+  "withString" should "be identity with Json.fromString" in forAll { (json: Json) =>
+    assert(json.withString(Json.fromString) === json)
+  }
+
+  "withArray" should "be identity with Json.fromValues" in forAll { (json: Json) =>
+    assert(json.withArray(Json.fromValues) === json)
+  }
+
+  "withObject" should "be identity with Json.fromJsonObject" in forAll { (json: Json) =>
+    assert(json.withObject(Json.fromJsonObject) === json)
   }
 
   "deepMerge" should "preserve argument order" in forAll { (js: List[Json]) =>


### PR DESCRIPTION
This change introduces a new way to fold `Json` values that's a little more verbose than `Json#fold` but is faster and involves fewer allocations. It also seems to perform better than pattern matching on the (package-private) `Json` constructors in the benchmark included here:

```
FoldingBenchmark.withFold          thrpt   40   6073.949 ±  47.519  ops/s
FoldingBenchmark.withFoldWith      thrpt   40  11401.499 ±  89.627  ops/s
FoldingBenchmark.withPatternMatch  thrpt   40   7537.532 ± 219.453  ops/s
```

The allocation rates also look pretty good:

```
FoldingBenchmark.withFold:gc.alloc.rate.norm          thrpt  5  150744.081 ±  0.003  B/op
FoldingBenchmark.withFoldWith:gc.alloc.rate.norm      thrpt  5  117752.045 ±  0.008  B/op
FoldingBenchmark.withPatternMatch:gc.alloc.rate.norm  thrpt  5  132024.068 ±  0.005  B/op
```

The benchmark is intended to test idiomatic use of the three styles.

The primary motivation for this change is #654—I'm adding a couple new `Json` constructors and would prefer to avoid using pattern matching even internally, but I don't want to pay the extra cost of `fold`. I believe it's a reasonable addition even apart from #654, though.

I've also added `asNull` and `withNull` methods for the sake of consistency, since I've found myself wanting these a couple of times recently.

After this addition the recommendation would continue to be something like "start with `fold` or the `asX` or `withX` methods" but with a new "unless you know the performance cost is unacceptable, in which case there's `foldWith`".