### PR TITLE
Printing optimizations

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.Eq
 import io.circe.numbers.BiggerDecimal
+import java.lang.StringBuilder
 import java.math.{ BigDecimal => JavaBigDecimal }
 
 /**
@@ -128,6 +129,8 @@ sealed abstract class JsonNumber extends Serializable {
    * Hashing that is consistent with our universal equality.
    */
   override final def hashCode: Int = toBiggerDecimal.hashCode
+
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit
 }
 
 private[circe] sealed abstract class BiggerDecimalJsonNumber extends JsonNumber {
@@ -151,12 +154,14 @@ private[circe] final case class JsonDecimal(value: String) extends BiggerDecimal
   }
 
   override def toString: String = value
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = builder.append(value)
 }
 
 private[circe] final case class JsonBiggerDecimal(value: BiggerDecimal)
   extends BiggerDecimalJsonNumber {
   private[circe] def toBiggerDecimal: BiggerDecimal = value
   override def toString: String = value.toString
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = value.appendToStringBuilder(builder)
 }
 
 /**
@@ -170,6 +175,7 @@ private[circe] final case class JsonBigDecimal(value: BigDecimal) extends JsonNu
   final def toLong: Option[Long] = toBiggerDecimal.toLong
   final def truncateToLong: Long = value.underlying.setScale(0, java.math.BigDecimal.ROUND_DOWN).longValue
   override final def toString: String = value.toString
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = builder.append(value.toString)
 }
 
 /**
@@ -183,6 +189,7 @@ private[circe] final case class JsonLong(value: Long) extends JsonNumber {
   final def toLong: Option[Long] = Some(value)
   final def truncateToLong: Long = value
   override final def toString: String = java.lang.Long.toString(value)
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = builder.append(value)
 }
 
 /**
@@ -209,6 +216,7 @@ private[circe] final case class JsonDouble(value: Double) extends JsonNumber {
 
   final def truncateToLong: Long = value.toLong
   override final def toString: String = java.lang.Double.toString(value)
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = builder.append(value)
 }
 
 /**
@@ -236,6 +244,7 @@ private[circe] final case class JsonFloat(value: Float) extends JsonNumber {
 
   final def truncateToLong: Long = value.toLong
   override final def toString: String = java.lang.Float.toString(value)
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = builder.append(value)
 }
 
 /**

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -1,5 +1,6 @@
 package io.circe.numbers
 
+import java.lang.StringBuilder
 import java.math.{ BigDecimal, BigInteger }
 import scala.annotation.switch
 
@@ -63,6 +64,8 @@ sealed abstract class BiggerDecimal extends Serializable {
    * Convert to the nearest [[scala.Long]].
    */
   def truncateToLong: Long
+
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit
 }
 
 /**
@@ -132,6 +135,15 @@ private[numbers] final class SigAndExp(
   override def toString: String = if (scale == BigInteger.ZERO) unscaled.toString else {
     s"${ unscaled }e${ scale.negate }"
   }
+
+  private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = {
+    builder.append(unscaled)
+
+    if (scale != BigInteger.ZERO) {
+      builder.append('e')
+      builder.append(scale.negate)
+    }
+  }
 }
 
 final object BiggerDecimal {
@@ -149,6 +161,10 @@ final object BiggerDecimal {
     final def toBigIntegerWithMaxDigits(maxDigits: BigInteger): Option[BigInteger] = Some(BigInteger.ZERO)
     final val toLong: Option[Long] = Some(truncateToLong)
     final def truncateToLong: Long = 0L
+
+    private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = {
+      builder.append(toDouble)
+    }
   }
 
   private[this] val UnsignedZero: BiggerDecimal = new Zero {

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -163,7 +163,7 @@ final object BiggerDecimal {
     final def truncateToLong: Long = 0L
 
     private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = {
-      builder.append(toDouble)
+      builder.append(toString)
     }
   }
 

--- a/modules/tests/jvm/src/test/scala/io/circe/PrinterWriterReuseSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/PrinterWriterReuseSuite.scala
@@ -1,0 +1,25 @@
+package io.circe
+
+import io.circe.tests.CirceSuite
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{ Millis, Span }
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class PrinterWriterReuseSuite extends CirceSuite with ScalaFutures {
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(1000, Millis))
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(
+    sizeRange = 1000
+  )
+
+  "Printer#reuseWriters" should "not change the behavior of pretty" in forAll { (values: List[Json]) =>
+    val default = Printer.spaces4
+    val reusing = default.copy(reuseWriters = true)
+    val expected = values.map(default.pretty)
+
+    whenReady(Future.traverse(values)(value => Future(reusing.pretty(value)))) { result =>
+      assert(result === expected)
+    }
+  }
+}

--- a/modules/tests/jvm/src/test/scala/io/circe/PrinterWriterReuseSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/PrinterWriterReuseSuite.scala
@@ -10,7 +10,7 @@ class PrinterWriterReuseSuite extends CirceSuite with ScalaFutures {
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(1000, Millis))
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(
-    sizeRange = 1000
+    sizeRange = 100
   )
 
   "Printer#reuseWriters" should "not change the behavior of pretty" in forAll { (values: List[Json]) =>

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -5,3 +5,18 @@ import io.circe.tests.PrinterSuite
 class Spaces2PrinterSuite extends PrinterSuite(Printer.spaces2, parser.`package`) with Spaces2PrinterExample
 class Spaces4PrinterSuite extends PrinterSuite(Printer.spaces4, parser.`package`)
 class NoSpacesPrinterSuite extends PrinterSuite(Printer.noSpaces, parser.`package`)
+
+class Spaces2PrinterWithWriterReuseSuite extends PrinterSuite(
+  Printer.spaces2.copy(reuseWriters = true),
+  parser.`package`
+)
+
+class Spaces4PrinterWithWriterReuseSuite extends PrinterSuite(
+  Printer.spaces4.copy(reuseWriters = true),
+  parser.`package`
+)
+
+class NoSpacesPrinterWithWriterReuseSuite extends PrinterSuite(
+  Printer.noSpaces.copy(reuseWriters = true),
+  parser.`package`
+)


### PR DESCRIPTION
This change does a couple of things to make printing faster. The first is that it adds package-private methods for writing values to string builders, which lets us (safely) avoid allocating a lot of intermediate strings.

It also adds a new `reuseWriters` option to `Printer`. This option is off by default but allows users to reuse string builders via Java's `ThreadLocal` if they know that they're not on an application server or whatever where thread locals can be a problem (is that still a thing? I have no idea whether that's still a thing).

The results are pretty good—well over twice the throughput vs. 0.8.0 for our integer array printing benchmark, and the allocation rate for that benchmark is down 89%. The case class benchmark doesn't see quite as big of an improvement but it's still not bad.

Spray JSON still has a slight edge in the case class printing benchmark, but this puts us ahead in the integer array printing one (and well ahead of all of the other Scala JSON libraries in both).

Here's throughput for 0.8.0:

```
Benchmark                          Mode  Cnt      Score     Error  Units
PrintingBenchmark.printFoosCirce  thrpt   20   5038.843 ±  92.059  ops/s
PrintingBenchmark.printIntsCirce  thrpt   20  23628.537 ± 260.963  ops/s
```

And here's this PR with `reuseWriters` set to false (the default):

```
Benchmark                          Mode  Cnt      Score     Error  Units
PrintingBenchmark.printFoosCirce  thrpt   20   5317.051 ±  15.540  ops/s
PrintingBenchmark.printIntsCirce  thrpt   20  43372.400 ± 823.195  ops/s
```

And here's this PR with `reuseWriters` enabled:

```
Benchmark                          Mode  Cnt      Score      Error  Units
PrintingBenchmark.printFoosCirce  thrpt   20   5968.110 ±   16.130  ops/s
PrintingBenchmark.printIntsCirce  thrpt   20  50645.811 ± 3065.231  ops/s
```

And allocation rates for 0.8.0:

```
Benchmark                                             Mode  Cnt       Score    Error Units
PrintingBenchmark.printFoosCirce:gc.alloc.rate.norm  thrpt    5  385192.098 ±  0.013  B/op
PrintingBenchmark.printIntsCirce:gc.alloc.rate.norm  thrpt    5   74504.021 ±  0.003  B/op
```

Without `reuseWriters`:

```
Benchmark                                             Mode  Cnt       Score    Error Units
PrintingBenchmark.printFoosCirce:gc.alloc.rate.norm  thrpt    5  367336.091 ±  0.025  B/op
PrintingBenchmark.printIntsCirce:gc.alloc.rate.norm  thrpt    5   26488.010 ±  0.001  B/op
```

And with it:

```
Benchmark                                             Mode  Cnt       Score    Error Units
PrintingBenchmark.printFoosCirce:gc.alloc.rate.norm  thrpt    5  109168.082 ±  0.022  B/op
PrintingBenchmark.printIntsCirce:gc.alloc.rate.norm  thrpt    5    7928.009 ±  0.001  B/op
```

Unfortunately we can't straightforwardly give the `reuseWriters` treatment to `prettyByteBuffer`, since we're handing the user back a `ByteBuffer` that wraps its internal array. Also I really wish Java's `Appendable` had all of the `append` overloads for doubles and stuff that `StringBuilder` has, so that we could use them here for both. I guess we could add our own to `AppendableByteBuffer`, but I'm not sure I care enough.

/cc @vkostyukov