### PR TITLE
Rename unsafe BiggerDecimal.fromDouble method

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -196,7 +196,7 @@ private[circe] final case class JsonLong(value: Long) extends JsonNumber {
  * Represent a valid JSON number as a [[scala.Double]].
  */
 private[circe] final case class JsonDouble(value: Double) extends JsonNumber {
-  private[circe] def toBiggerDecimal: BiggerDecimal = BiggerDecimal.fromDouble(value)
+  private[circe] def toBiggerDecimal: BiggerDecimal = BiggerDecimal.fromDoubleUnsafe(value)
   private[this] def toJavaBigDecimal = JavaBigDecimal.valueOf(value)
 
   final def toBigDecimal: Option[BigDecimal] = Some(toJavaBigDecimal)

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -211,7 +211,13 @@ final object BiggerDecimal {
   def fromBigDecimal(d: BigDecimal): BiggerDecimal = fromUnscaledAndScale(d.unscaledValue, d.scale.toLong)
   def fromLong(d: Long): BiggerDecimal = fromUnscaledAndScale(BigInteger.valueOf(d), 0L)
 
-  def fromDouble(d: Double): BiggerDecimal = if (java.lang.Double.compare(d, -0.0) == 0) {
+  /**
+   * Convert a [[scala.Double]] into a [[BiggerDecimal]].
+   *
+   * @note This method assumes that the input is not `NaN` or infinite, and will throw a
+   *       `NumberFormatException` if that assumption does not hold.
+   */
+  def fromDoubleUnsafe(d: Double): BiggerDecimal = if (java.lang.Double.compare(d, -0.0) == 0) {
     NegativeZero
   } else fromBigDecimal(BigDecimal.valueOf(d))
 

--- a/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -17,12 +17,12 @@ class BiggerDecimalSuite extends FlatSpec with GeneratorDrivenPropertyChecks {
   private[this] def trailingZeros(i: BigInt): Int = i.toString.reverse.takeWhile(_ == '0').size
   private[this] def significantDigits(i: BigInt): Int = i.toString.size - trailingZeros(i)
 
-  "fromDouble(0)" should "equal fromBigDecimal(ZERO) (#348)" in {
-    assert(BiggerDecimal.fromDouble(0) === BiggerDecimal.fromBigDecimal(BigDecimal.ZERO))
+  "fromDoubleUnsafe(0)" should "equal fromBigDecimal(ZERO) (#348)" in {
+    assert(BiggerDecimal.fromDoubleUnsafe(0) === BiggerDecimal.fromBigDecimal(BigDecimal.ZERO))
   }
 
-  "fromDouble" should "round-trip Double values" in forAll { (value: Double) =>
-    val d = BiggerDecimal.fromDouble(value)
+  "fromDoubleUnsafe" should "round-trip Double values" in forAll { (value: Double) =>
+    val d = BiggerDecimal.fromDoubleUnsafe(value)
 
     assert(
       doubleEqv(d.toDouble, value) && d.toBigDecimal.exists { roundTripped =>
@@ -32,7 +32,7 @@ class BiggerDecimalSuite extends FlatSpec with GeneratorDrivenPropertyChecks {
   }
 
   it should "round-trip negative zero" in {
-    val d = BiggerDecimal.fromDouble(-0.0)
+    val d = BiggerDecimal.fromDoubleUnsafe(-0.0)
 
     assert(doubleEqv(d.toDouble, -0.0))
   }
@@ -56,7 +56,7 @@ class BiggerDecimalSuite extends FlatSpec with GeneratorDrivenPropertyChecks {
   }
 
   it should "agree with Double" in forAll { (value: Double) =>
-    val d = BiggerDecimal.fromDouble(value)
+    val d = BiggerDecimal.fromDoubleUnsafe(value)
 
     assert(d.signum == value.signum)
   }
@@ -133,9 +133,9 @@ class BiggerDecimalSuite extends FlatSpec with GeneratorDrivenPropertyChecks {
     assert(d.toBigIntegerWithMaxDigits(BigInteger.valueOf(9L)) === d.toBigInteger)
   }
 
-  "fromLong and fromDouble" should "agree on Int-sized integral values" in forAll { (value: Int) =>
+  "fromLong and fromDoubleUnsafe" should "agree on Int-sized integral values" in forAll { (value: Int) =>
     val dl = BiggerDecimal.fromLong(value.toLong)
-    val dd = BiggerDecimal.fromDouble(value.toDouble)
+    val dd = BiggerDecimal.fromDoubleUnsafe(value.toDouble)
 
     assert(dl === dd)
   }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -28,7 +28,7 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
     Gen.oneOf(
       Arbitrary.arbitrary[JsonNumberString].map(s => BiggerDecimal.parseBiggerDecimalUnsafe(s.value)),
       Arbitrary.arbitrary[Long].map(BiggerDecimal.fromLong),
-      Arbitrary.arbitrary[Double].map(BiggerDecimal.fromDouble),
+      Arbitrary.arbitrary[Double].map(BiggerDecimal.fromDoubleUnsafe),
       Arbitrary.arbitrary[BigInt].map(_.bigInteger).map(BiggerDecimal.fromBigInteger),
       Arbitrary.arbitrary[BigDecimal].map(_.bigDecimal).map(BiggerDecimal.fromBigDecimal),
       Gen.const(BiggerDecimal.NegativeZero)


### PR DESCRIPTION
This method violates our policy that no method in the circe public API should return null, throw an exception, or have any observable side effects unless it's explicitly marked as unsafe in the name (and there should be as few of those as possible).

For now I've fixed this by renaming it, but the `numbers` API will be changing a lot soon, and `fromDouble` will probably be removed altogether.