### PR TITLE
Use java.math.BigDecimal in JsonBigDecimal

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -500,7 +500,7 @@ final object Json {
   /**
    * Create a `Json` value representing a JSON number from a `BigDecimal`.
    */
-  final def fromBigDecimal(value: BigDecimal): Json = JNumber(JsonBigDecimal(value))
+  final def fromBigDecimal(value: BigDecimal): Json = JNumber(JsonBigDecimal(value.underlying))
 
   /**
    * Calling `.isNaN` and `.isInfinity` directly on the value boxes; we

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -167,13 +167,13 @@ private[circe] final case class JsonBiggerDecimal(value: BiggerDecimal)
 /**
  * Represent a valid JSON number as a [[scala.math.BigDecimal]].
  */
-private[circe] final case class JsonBigDecimal(value: BigDecimal) extends JsonNumber {
-  private[circe] def toBiggerDecimal: BiggerDecimal = BiggerDecimal.fromBigDecimal(value.underlying)
-  final def toBigDecimal: Option[BigDecimal] = Some(value)
+private[circe] final case class JsonBigDecimal(value: JavaBigDecimal) extends JsonNumber {
+  private[circe] def toBiggerDecimal: BiggerDecimal = BiggerDecimal.fromBigDecimal(value)
+  final def toBigDecimal: Option[BigDecimal] = Some(new BigDecimal(value))
   final def toBigInt: Option[BigInt] = toBiggerDecimal.toBigInteger.map(BigInt(_))
-  final def toDouble: Double = value.toDouble
+  final def toDouble: Double = value.doubleValue
   final def toLong: Option[Long] = toBiggerDecimal.toLong
-  final def truncateToLong: Long = value.underlying.setScale(0, java.math.BigDecimal.ROUND_DOWN).longValue
+  final def truncateToLong: Long = value.setScale(0, java.math.BigDecimal.ROUND_DOWN).longValue
   override final def toString: String = value.toString
   private[circe] def appendToStringBuilder(builder: StringBuilder): Unit = builder.append(value.toString)
 }
@@ -295,7 +295,7 @@ final object JsonNumber {
     case (JsonLong(x), JsonLong(y)) => x == y
     case (JsonDouble(x), JsonDouble(y)) => java.lang.Double.compare(x, y) == 0
     case (JsonFloat(x), JsonFloat(y)) => java.lang.Float.compare(x, y) == 0
-    case (JsonBigDecimal(x), JsonBigDecimal(y)) => x == y
+    case (JsonBigDecimal(x), JsonBigDecimal(y)) => x.compareTo(y) == 0
     case (a, b) => a.toBiggerDecimal == b.toBiggerDecimal
   }
 }

--- a/modules/optics/src/main/scala/io/circe/optics/JsonNumberOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonNumberOptics.scala
@@ -1,7 +1,7 @@
 package io.circe.optics
 
 import io.circe.{ JsonBigDecimal, JsonLong, JsonNumber }
-import java.math.MathContext
+import java.math.{ BigDecimal => JavaBigDecimal, MathContext }
 import monocle.Prism
 
 /**
@@ -16,7 +16,7 @@ import monocle.Prism
 trait JsonNumberOptics {
   final lazy val jsonNumberBigInt: Prism[JsonNumber, BigInt] = Prism[JsonNumber, BigInt](jn =>
     if (JsonNumberOptics.isNegativeZero(jn)) None else jn.toBigInt
-  )(b => JsonBigDecimal(BigDecimal(b, MathContext.UNLIMITED)))
+  )(b => JsonBigDecimal(new JavaBigDecimal(b.underlying, MathContext.UNLIMITED)))
 
   final lazy val jsonNumberLong: Prism[JsonNumber, Long] = Prism[JsonNumber, Long](jn =>
     if (JsonNumberOptics.isNegativeZero(jn)) None else jn.toLong
@@ -37,7 +37,7 @@ trait JsonNumberOptics {
   final lazy val jsonNumberBigDecimal: Prism[JsonNumber, BigDecimal] =
     Prism[JsonNumber, BigDecimal](jn =>
       if (JsonNumberOptics.isNegativeZero(jn)) None else jn.toBigDecimal
-    )(JsonBigDecimal(_))
+    )(b => JsonBigDecimal(b.underlying))
 }
 
 final object JsonNumberOptics extends JsonNumberOptics {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -39,7 +39,7 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
     Gen.oneOf(
       arbitrary[JsonNumberString].map(jns => JsonNumber.fromDecimalStringUnsafe(jns.value)),
       arbitrary[BiggerDecimal].map(JsonBiggerDecimal(_)),
-      arbitrary[BigDecimal].map(JsonBigDecimal(_)),
+      arbitrary[BigDecimal].map(value => JsonBigDecimal(value.underlying)),
       arbitrary[Long].map(JsonLong(_)),
       arbitrary[Double].map(d => if (d.isNaN || d.isInfinity) JsonDouble(0.0) else JsonDouble(d)),
       arbitrary[Float].map(f => if (f.isNaN || f.isInfinity) JsonFloat(0.0f) else JsonFloat(f))

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ShrinkInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ShrinkInstances.scala
@@ -27,7 +27,7 @@ private[testing] trait ShrinkInstances {
           zero #:: interleave(hs, hs.map(h => -h))
         }
 
-        ns.map(JsonBigDecimal(_))
+        ns.map(value => JsonBigDecimal(value.underlying))
       case None => Stream(jn)
     }
   }


### PR DESCRIPTION
I don't think there's any good reason for `JsonBigDecimal` to use the `scala.math.BigDecimal` wrapper rather than `java.math.BigDecimal`, and it's likely to play a more central role soon, so I'm switching to the unwrapped version.

This change is not public facing, although if someone were constructing a bunch of `Json` values using `fromBigDecimal` and then immediately decoding them back into `scala.math.BigDecimal`, they might see a tiny  performance hit. Most (less unusual) use cases are likely to benefit, though.