### PR TITLE
Fix Serializable issues (partially)

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/ACursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ACursor.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.Applicative
 import cats.kernel.Eq
+import java.io.Serializable
 import scala.collection.immutable.Set
 
 /**

--- a/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.{ ApplicativeError, Semigroup, SemigroupK }
 import cats.data.{ NonEmptyList, Validated, ValidatedNel }
+import java.io.Serializable
 
 sealed trait AccumulatingDecoder[A] extends Serializable { self =>
   /**

--- a/modules/core/shared/src/main/scala/io/circe/CursorOp.scala
+++ b/modules/core/shared/src/main/scala/io/circe/CursorOp.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.{ Eq, Show }
+import java.io.Serializable
 
 sealed abstract class CursorOp extends Product with Serializable {
   /**

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -16,7 +16,7 @@ import scala.util.{ Failure, Success, Try }
 
 trait Decoder[A] extends Serializable { self =>
   /**
-   * Decode the given hcursor.
+   * Decode the given [[HCursor]].
    */
   def apply(c: HCursor): Decoder.Result[A]
 
@@ -248,11 +248,17 @@ trait Decoder[A] extends Serializable { self =>
 /**
  * Utilities and instances for [[Decoder]].
  *
- * @groupname Utilities Miscellaneous utilities
- * @groupprio Utilities 0
+ * @groupname Aliases Type aliases
+ * @groupprio Aliases 0
  *
- * @groupname Decoding Decoder instances
+ * @groupname Utilities Defining decoders
+ * @groupprio Utilities 1
+ *
+ * @groupname Decoding General decoder instances
  * @groupprio Decoding 2
+ *
+ * @groupname Collection Collection instances
+ * @groupprio Collection 4
  *
  * @groupname Disjunction Disjunction instances
  * @groupdesc Disjunction Instance creation methods for disjunction-like types. Note that these
@@ -262,25 +268,27 @@ trait Decoder[A] extends Serializable { self =>
  * {{{
  *   import io.circe.disjunctionCodecs._
  * }}}
- * @groupprio Disjunction 3
+ * @groupprio Disjunction 5
  *
  * @groupname Instances Type class instances
- * @groupprio Instances 4
+ * @groupprio Instances 6
  *
  * @groupname Tuple Tuple instances
- * @groupprio Tuple 5
+ * @groupprio Tuple 7
  *
  * @groupname Product Case class and other product instances
- * @groupprio Product 6
+ * @groupprio Product 8
+ *
+ * @groupname Prioritization Instance prioritization
+ * @groupprio Prioritization 9
  *
  * @author Travis Brown
  */
 final object Decoder extends TupleDecoders with ProductDecoders with LowPriorityDecoders {
-  import Json._
-
+  /**
+   * @group Aliases
+   */
   type Result[A] = Either[DecodingFailure, A]
-
-  val resultInstance: MonadError[Result, DecodingFailure] = catsStdInstancesForEither[DecodingFailure]
 
   private[circe] val resultSemigroupK: SemigroupK[Result] = catsStdSemigroupKForEither[DecodingFailure]
 
@@ -296,7 +304,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   final def apply[A](implicit instance: Decoder[A]): Decoder[A] = instance
 
   /**
-   * Create a decoder that always returns a single value, useful with some flatMap situations
+   * Create a decoder that always returns a single value, useful with some `flatMap` situations.
+   *
+   * @group Utilities
    */
   final def const[A](a: A): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Result[A] = Right(a)
@@ -323,8 +333,10 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   }
 
   /**
-   * This is for easier interop with code that already returns Try. You should
-   * prefer instance for any new code.
+   * This is for easier interop with code that already returns [[scala.util.Try]]. You should
+   * prefer `instance` for any new code.
+   *
+   * @group Utilities
    */
   final def instanceTry[A](f: HCursor => Try[A]): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Result[A] = f(c) match {
@@ -412,7 +424,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeString: Decoder[String] = new Decoder[String] {
     final def apply(c: HCursor): Result[String] = c.value match {
-      case JString(string) => Right(string)
+      case Json.JString(string) => Right(string)
       case _ => Left(DecodingFailure("String", c.history))
     }
   }
@@ -422,8 +434,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeUnit: Decoder[Unit] = new Decoder[Unit] {
     final def apply(c: HCursor): Result[Unit] = c.value match {
-      case JObject(obj) if obj.isEmpty => Right(())
-      case JArray(arr) if arr.isEmpty => Right(())
+      case Json.JObject(obj) if obj.isEmpty => Right(())
+      case Json.JArray(arr) if arr.isEmpty => Right(())
       case other if other.isNull => Right(())
       case _ => Left(DecodingFailure("Unit", c.history))
     }
@@ -434,7 +446,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeBoolean: Decoder[Boolean] = new Decoder[Boolean] {
     final def apply(c: HCursor): Result[Boolean] = c.value match {
-      case JBoolean(b) => Right(b)
+      case Json.JBoolean(b) => Right(b)
       case _ => Left(DecodingFailure("Boolean", c.history))
     }
   }
@@ -444,7 +456,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeChar: Decoder[Char] = new Decoder[Char] {
     final def apply(c: HCursor): Result[Char] = c.value match {
-      case JString(string) if string.length == 1 => Right(string.charAt(0))
+      case Json.JString(string) if string.length == 1 => Right(string.charAt(0))
       case _ => Left(DecodingFailure("Char", c.history))
     }
   }
@@ -458,8 +470,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeFloat: Decoder[Float] = new DecoderWithFailure[Float]("Float") {
     final def apply(c: HCursor): Result[Float] = c.value match {
-      case JNumber(number) => Right(number.toDouble.toFloat)
-      case JString(string) => JsonNumber.fromString(string).map(_.toDouble.toFloat) match {
+      case Json.JNumber(number) => Right(number.toDouble.toFloat)
+      case Json.JString(string) => JsonNumber.fromString(string).map(_.toDouble.toFloat) match {
         case Some(v) => Right(v)
         case None => fail(c)
       }
@@ -479,8 +491,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeDouble: Decoder[Double] = new DecoderWithFailure[Double]("Double") {
     final def apply(c: HCursor): Result[Double] = c.value match {
-      case JNumber(number) => Right(number.toDouble)
-      case JString(string) => JsonNumber.fromString(string).map(_.toDouble) match {
+      case Json.JNumber(number) => Right(number.toDouble)
+      case Json.JString(string) => JsonNumber.fromString(string).map(_.toDouble) match {
         case Some(v) => Right(v)
         case None => fail(c)
       }
@@ -498,11 +510,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeByte: Decoder[Byte] = new DecoderWithFailure[Byte]("Byte") {
     final def apply(c: HCursor): Result[Byte] = c.value match {
-      case JNumber(number) => number.toByte match {
+      case Json.JNumber(number) => number.toByte match {
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => JsonNumber.fromString(string).flatMap(_.toByte) match {
+      case Json.JString(string) => JsonNumber.fromString(string).flatMap(_.toByte) match {
         case Some(value) => Right(value)
         case None => fail(c)
       }
@@ -519,11 +531,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeShort: Decoder[Short] = new DecoderWithFailure[Short]("Short") {
     final def apply(c: HCursor): Result[Short] = c.value match {
-      case JNumber(number) => number.toShort match {
+      case Json.JNumber(number) => number.toShort match {
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => JsonNumber.fromString(string).flatMap(_.toShort) match {
+      case Json.JString(string) => JsonNumber.fromString(string).flatMap(_.toShort) match {
         case Some(value) => Right(value)
         case None => fail(c)
       }
@@ -540,11 +552,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeInt: Decoder[Int] = new DecoderWithFailure[Int]("Int") {
     final def apply(c: HCursor): Result[Int] = c.value match {
-      case JNumber(number) => number.toInt match {
+      case Json.JNumber(number) => number.toInt match {
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => JsonNumber.fromString(string).flatMap(_.toInt) match {
+      case Json.JString(string) => JsonNumber.fromString(string).flatMap(_.toInt) match {
         case Some(value) => Right(value)
         case None => fail(c)
       }
@@ -564,11 +576,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeLong: Decoder[Long] = new DecoderWithFailure[Long]("Long") {
     final def apply(c: HCursor): Result[Long] = c.value match {
-      case JNumber(number) => number.toLong match {
+      case Json.JNumber(number) => number.toLong match {
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => JsonNumber.fromString(string).flatMap(_.toLong) match {
+      case Json.JString(string) => JsonNumber.fromString(string).flatMap(_.toLong) match {
         case Some(value) => Right(value)
         case None => fail(c)
       }
@@ -588,11 +600,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeBigInt: Decoder[BigInt] = new DecoderWithFailure[BigInt]("BigInt") {
     final def apply(c: HCursor): Result[BigInt] = c.value match {
-      case JNumber(number) => number.toBigInt match {
+      case Json.JNumber(number) => number.toBigInt match {
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => JsonNumber.fromString(string).flatMap(_.toBigInt) match {
+      case Json.JString(string) => JsonNumber.fromString(string).flatMap(_.toBigInt) match {
         case Some(value) => Right(value)
         case None => fail(c)
       }
@@ -615,11 +627,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeBigDecimal: Decoder[BigDecimal] = new DecoderWithFailure[BigDecimal]("BigDecimal") {
     final def apply(c: HCursor): Result[BigDecimal] = c.value match {
-      case JNumber(number) => number.toBigDecimal match {
+      case Json.JNumber(number) => number.toBigDecimal match {
         case Some(v) => Right(v)
         case None => fail(c)
       }
-      case JString(string) => JsonNumber.fromString(string).flatMap(_.toBigDecimal) match {
+      case Json.JString(string) => JsonNumber.fromString(string).flatMap(_.toBigDecimal) match {
         case Some(value) => Right(value)
         case None => fail(c)
       }
@@ -634,7 +646,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     private[this] def fail(c: HCursor): Result[UUID] = Left(DecodingFailure("UUID", c.history))
 
     final def apply(c: HCursor): Result[UUID] = c.value match {
-      case JString(string) if string.length == 36 => try Right(UUID.fromString(string)) catch {
+      case Json.JString(string) if string.length == 36 => try Right(UUID.fromString(string)) catch {
         case _: IllegalArgumentException => fail(c)
       }
       case _ => fail(c)
@@ -674,7 +686,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   /**
    * @note The resulting instance will not be serializable (in the `java.io.Serializable` sense)
    *       unless the provided [[scala.collection.generic.CanBuildFrom]] is serializable.
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeMapLike[K, V, M[K, V] <: Map[K, V]](implicit
     decodeK: KeyDecoder[K],
@@ -687,7 +699,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   /**
    * @note The resulting instance will not be serializable (in the `java.io.Serializable` sense)
    *       unless the provided [[scala.collection.generic.CanBuildFrom]] is serializable.
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeCanBuildFrom[A, C[_]](implicit
     decodeA: Decoder[A],
@@ -696,6 +708,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     final protected def createBuilder(): Builder[A, C[A]] = cbf.apply()
   }
 
+  /**
+   * @group Collection
+   */
   implicit final def decodeMap[K, V](implicit
     decodeK: KeyDecoder[K],
     decodeV: Decoder[V]
@@ -704,28 +719,28 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   }
 
   /**
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeSeq[A](implicit decodeA: Decoder[A]): Decoder[Seq[A]] = new SeqDecoder[A, Seq](decodeA) {
     final protected def createBuilder(): Builder[A, Seq[A]] = Seq.newBuilder[A]
   }
 
   /**
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeSet[A](implicit decodeA: Decoder[A]): Decoder[Set[A]] = new SeqDecoder[A, Set](decodeA) {
     final protected def createBuilder(): Builder[A, Set[A]] = Set.newBuilder[A]
   }
 
   /**
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeList[A](implicit decodeA: Decoder[A]): Decoder[List[A]] = new SeqDecoder[A, List](decodeA) {
     final protected def createBuilder(): Builder[A, List[A]] = List.newBuilder[A]
   }
 
   /**
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeVector[A](implicit decodeA: Decoder[A]): Decoder[Vector[A]] =
     new SeqDecoder[A, Vector](decodeA) {
@@ -735,7 +750,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   /**
    * @note The resulting instance will not be serializable (in the `java.io.Serializable` sense)
    *       unless the provided [[scala.collection.generic.CanBuildFrom]] is serializable.
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeOneAnd[A, C[_]](implicit
     decodeA: Decoder[A],
@@ -746,7 +761,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   }
 
   /**
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeNonEmptyList[A](implicit decodeA: Decoder[A]): Decoder[NonEmptyList[A]] =
     new NonEmptySeqDecoder[A, List, NonEmptyList[A]](decodeA) {
@@ -755,7 +770,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     }
 
   /**
-   * @group Decoding
+   * @group Collection
    */
   implicit final def decodeNonEmptyVector[A](implicit decodeA: Decoder[A]): Decoder[NonEmptyVector[A]] =
     new NonEmptySeqDecoder[A, Vector, NonEmptyVector[A]](decodeA) {
@@ -810,6 +825,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   /**
    * @group Instances
    */
+  final val resultInstance: MonadError[Result, DecodingFailure] = catsStdInstancesForEither[DecodingFailure]
+
+  /**
+   * @group Instances
+   */
   implicit final val decoderInstances: SemigroupK[Decoder] with MonadError[Decoder, DecodingFailure] =
     new SemigroupK[Decoder] with MonadError[Decoder, DecodingFailure] {
       final def combineK[A](x: Decoder[A], y: Decoder[A]): Decoder[A] = x.or(y)
@@ -834,12 +854,13 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     }
 
   /**
-    * @group Enumeration
-    * {{{
-    *   object WeekDay extends Enumeration { ... }
-    *   implicit val weekDayDecoder = Decoder.enumDecoder(WeekDay)
-    * }}}
-    */
+   * {{{
+   *   object WeekDay extends Enumeration { ... }
+   *   implicit val weekDayDecoder = Decoder.enumDecoder(WeekDay)
+   * }}}
+   *
+   * @group Utilities
+   */
   final def enumDecoder[E <: Enumeration](enum: E): Decoder[E#Value] =
     Decoder.decodeString.flatMap { str =>
       Decoder.instanceTry { _ =>
@@ -853,7 +874,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    *
    * @group Utilities
    */
-  object state {
+  final object state {
     /**
      * Attempt to decode a value at key `k` and remove it from the [[ACursor]].
      */
@@ -887,5 +908,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
 }
 
 private[circe] trait LowPriorityDecoders {
+  /**
+   * @group Prioritization
+   */
   implicit def importedDecoder[A](implicit exported: Exported[Decoder[A]]): Decoder[A] = exported.instance
 }

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -5,6 +5,7 @@ import cats.data.{ Kleisli, NonEmptyList, NonEmptyVector, OneAnd, StateT, Valida
 import cats.data.Validated.{ Invalid, Valid }
 import cats.instances.either.{ catsStdInstancesForEither, catsStdSemigroupKForEither }
 import io.circe.export.Exported
+import java.io.Serializable
 import java.util.UUID
 import scala.annotation.tailrec
 import scala.collection.Map

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -40,11 +40,14 @@ trait Encoder[A] extends Serializable { self =>
 /**
  * Utilities and instances for [[Encoder]].
  *
- * @groupname Utilities Miscellaneous utilities
+ * @groupname Utilities Defining encoders
  * @groupprio Utilities 0
  *
- * @groupname Encoding Encoder instances
+ * @groupname Encoding General encoder instances
  * @groupprio Encoding 1
+ *
+ * @groupname Collection Collection instances
+ * @groupprio Collection 2
  *
  * @groupname Disjunction Disjunction instances
  * @groupdesc Disjunction Instance creation methods for disjunction-like types. Note that these
@@ -54,16 +57,19 @@ trait Encoder[A] extends Serializable { self =>
  * {{{
  *   import io.circe.disjunctionCodecs._
  * }}}
- * @groupprio Disjunction 2
+ * @groupprio Disjunction 3
  *
  * @groupname Instances Type class instances
- * @groupprio Instances 3
+ * @groupprio Instances 4
  *
  * @groupname Tuple Tuple instances
- * @groupprio Tuple 4
+ * @groupprio Tuple 5
  *
  * @groupname Product Case class and other product instances
- * @groupprio Product 5
+ * @groupprio Product 6
+ *
+ * @groupname Prioritization Instance prioritization
+ * @groupprio Prioritization 9
  *
  * @author Travis Brown
  */
@@ -234,7 +240,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeSeq[A](implicit encodeA: Encoder[A]): ArrayEncoder[Seq[A]] =
     new IterableArrayEncoder[A, Seq](encodeA) {
@@ -242,7 +248,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
     }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeSet[A](implicit encodeA: Encoder[A]): ArrayEncoder[Set[A]] =
     new IterableArrayEncoder[A, Set](encodeA) {
@@ -250,7 +256,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
     }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeList[A](implicit encodeA: Encoder[A]): ArrayEncoder[List[A]] =
     new IterableArrayEncoder[A, List](encodeA) {
@@ -258,7 +264,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
     }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeVector[A](implicit encodeA: Encoder[A]): ArrayEncoder[Vector[A]] =
     new IterableArrayEncoder[A, Vector](encodeA) {
@@ -266,7 +272,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
     }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeNonEmptyList[A](implicit encodeA: Encoder[A]): ArrayEncoder[NonEmptyList[A]] =
     new ArrayEncoder[NonEmptyList[A]] {
@@ -274,7 +280,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
     }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeNonEmptyVector[A](implicit encodeA: Encoder[A]): ArrayEncoder[NonEmptyVector[A]] =
     new ArrayEncoder[NonEmptyVector[A]] {
@@ -282,7 +288,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
     }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeOneAnd[A, C[_]](implicit
     encodeA: Encoder[A],
@@ -294,7 +300,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeMap[K, V](implicit
     encodeK: KeyEncoder[K],
@@ -308,7 +314,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeMapLike[K, V, M[K, V] <: Map[K, V]](implicit
     encodeK: KeyEncoder[K],
@@ -350,12 +356,12 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
-    * @group Enumeration
-    * {{{
-    *   object WeekDay extends Enumeration { ... }
-    *   implicit val weekDayEncoder = Encoder.enumEncoder(WeekDay)
-    * }}}
-    */
+   * {{{
+   *   object WeekDay extends Enumeration { ... }
+   *   implicit val weekDayEncoder = Encoder.enumEncoder(WeekDay)
+   * }}}
+   * @group Utilities
+   */
   final def enumEncoder[E <: Enumeration](enum: E): Encoder[E#Value] = new Encoder[E#Value] {
     override def apply(e: E#Value): Json = Encoder.encodeString(e.toString)
   }
@@ -382,7 +388,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
 
 private[circe] trait MidPriorityEncoders extends LowPriorityEncoders {
   /**
-   * @group Encoding
+   * @group Collection
    */
   implicit final def encodeIterable[A, C[_]](implicit
     encodeA: Encoder[A],
@@ -408,5 +414,8 @@ private[circe] trait MidPriorityEncoders extends LowPriorityEncoders {
 }
 
 private[circe] trait LowPriorityEncoders {
+  /**
+   * @group Prioritization
+   */
   implicit final def importedEncoder[A](implicit exported: Exported[ObjectEncoder[A]]): Encoder[A] = exported.instance
 }

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -4,6 +4,7 @@ import cats.data.{ NonEmptyList, NonEmptyVector, OneAnd, Validated }
 import cats.functor.Contravariant
 import cats.Foldable
 import io.circe.export.Exported
+import java.io.Serializable
 import java.util.UUID
 import scala.collection.Map
 import scala.collection.immutable.{ Map => ImmutableMap, Set }

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.{ Eq, Show }
 import io.circe.numbers.BiggerDecimal
+import java.io.Serializable
 
 /**
  * A data type representing possible JSON values.

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.Eq
 import io.circe.numbers.BiggerDecimal
+import java.io.Serializable
 import java.lang.StringBuilder
 import java.math.{ BigDecimal => JavaBigDecimal }
 

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.{ Applicative, Eq, Foldable, Show }
 import cats.data.Kleisli
 import cats.instances.map._
+import java.io.Serializable
 import scala.collection.breakOut
 import scala.collection.immutable.{ Map, Set }
 

--- a/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.MonadError
+import java.io.Serializable
 import java.util.UUID
 import scala.annotation.tailrec
 

--- a/modules/core/shared/src/main/scala/io/circe/KeyEncoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyEncoder.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.functor.Contravariant
+import java.io.Serializable
 import java.util.UUID
 
 /**

--- a/modules/core/shared/src/main/scala/io/circe/Parser.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Parser.scala
@@ -1,6 +1,7 @@
 package io.circe
 
 import cats.data.{ NonEmptyList, Validated, ValidatedNel }
+import java.io.Serializable
 
 trait Parser extends Serializable {
   def parse(input: String): Either[ParsingFailure, Json]

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -264,7 +264,7 @@ final case class Printer(
    * Returns a string representation of a pretty-printed JSON value.
    */
   final def pretty(json: Json): String = {
-    val writer = if (reuseWriters) {
+    val writer = if (reuseWriters && stringWriter.ne(null)) {
       val w = stringWriter.get()
       w.setLength(0)
       w

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import java.io.Serializable
 import java.lang.StringBuilder
 import java.nio.{ ByteBuffer, CharBuffer }
 import java.nio.charset.{ Charset, StandardCharsets }

--- a/modules/generic/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/modules/generic/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -12,7 +12,7 @@ import org.scalacheck.{ Arbitrary, Gen }
 import shapeless.Witness, shapeless.labelled.{ FieldType, field }
 import shapeless.test.illTyped
 
-class SemiautoDerivedSuite extends CirceSuite {
+object SemiautoDerivedSuite {
   implicit def decodeBox[A: Decoder]: Decoder[Box[A]] = deriveDecoder
   implicit def encodeBox[A: Encoder]: Encoder[Box[A]] = deriveEncoder
 
@@ -76,11 +76,17 @@ class SemiautoDerivedSuite extends CirceSuite {
   case class OvergenerationExampleInner(i: Int)
   case class OvergenerationExampleOuter0(i: OvergenerationExampleInner)
   case class OvergenerationExampleOuter1(oi: Option[OvergenerationExampleInner])
+}
+
+class SemiautoDerivedSuite extends CirceSuite {
+  import SemiautoDerivedSuite._
 
   checkLaws("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
   checkLaws("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
   checkLaws("Codec[Box[Int]]", CodecTests[Box[Int]].codec)
   checkLaws("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
+  checkLaws("Codec[Seq[Foo]]", CodecTests[Seq[Foo]].codec)
+  checkLaws("Codec[Baz]", CodecTests[Baz].codec)
   checkLaws("Codec[Foo]", CodecTests[Foo].codec)
   checkLaws("Codec[RecursiveAdtExample]", CodecTests[RecursiveAdtExample].codec)
   checkLaws("Codec[RecursiveWithOptionExample]", CodecTests[RecursiveWithOptionExample].codec)

--- a/modules/java8/src/main/scala/io/circe/java8/time/TimeInstances.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/TimeInstances.scala
@@ -2,20 +2,23 @@ package io.circe.java8.time
 
 import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
 import java.time.{
-Duration,
-Instant, LocalDate,
-LocalDateTime, LocalTime,
-OffsetDateTime,
-Period, YearMonth,
-ZonedDateTime
+  Duration,
+  Instant,
+  LocalDate,
+  LocalDateTime,
+  LocalTime,
+  OffsetDateTime,
+  Period,
+  YearMonth,
+  ZonedDateTime
 }
 import java.time.format.{ DateTimeFormatter, DateTimeParseException }
 import java.time.format.DateTimeFormatter.{
-ISO_LOCAL_DATE,
-ISO_LOCAL_DATE_TIME,
-ISO_LOCAL_TIME,
-ISO_OFFSET_DATE_TIME,
-ISO_ZONED_DATE_TIME
+  ISO_LOCAL_DATE,
+  ISO_LOCAL_DATE_TIME,
+  ISO_LOCAL_TIME,
+  ISO_OFFSET_DATE_TIME,
+  ISO_ZONED_DATE_TIME
 }
 
 trait TimeInstances {

--- a/modules/java8/src/test/scala/io/circe/java8/time/TimeCodecSuite.scala
+++ b/modules/java8/src/test/scala/io/circe/java8/time/TimeCodecSuite.scala
@@ -75,13 +75,13 @@ class TimeCodecSuite extends CirceSuite {
   implicit val eqDuration: Eq[Duration] = Eq.fromUniversalEquals
 
   checkLaws("Codec[Instant]", CodecTests[Instant].codec)
-  checkLaws("Codec[LocalDateTime]", CodecTests[LocalDateTime].codec)
-  checkLaws("Codec[ZonedDateTime]", CodecTests[ZonedDateTime].codec)
-  checkLaws("Codec[OffsetDateTime]", CodecTests[OffsetDateTime].codec)
-  checkLaws("Codec[LocalDate]", CodecTests[LocalDate].codec)
-  checkLaws("Codec[LocalTime]", CodecTests[LocalTime].codec)
+  checkLaws("Codec[LocalDateTime]", CodecTests[LocalDateTime].unserializableCodec)
+  checkLaws("Codec[ZonedDateTime]", CodecTests[ZonedDateTime].unserializableCodec)
+  checkLaws("Codec[OffsetDateTime]", CodecTests[OffsetDateTime].unserializableCodec)
+  checkLaws("Codec[LocalDate]", CodecTests[LocalDate].unserializableCodec)
+  checkLaws("Codec[LocalTime]", CodecTests[LocalTime].unserializableCodec)
   checkLaws("Codec[Period]", CodecTests[Period].codec)
-  checkLaws("Codec[YearMonth]", CodecTests[YearMonth].codec)
+  checkLaws("Codec[YearMonth]", CodecTests[YearMonth].unserializableCodec)
   checkLaws("Codec[Duration]", CodecTests[Duration].codec)
 
   val invalidJson: Json = Json.fromString("abc")

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -1,5 +1,6 @@
 package io.circe.numbers
 
+import java.io.Serializable
 import java.lang.StringBuilder
 import java.math.{ BigDecimal, BigInteger }
 import scala.annotation.switch

--- a/modules/refined/shared/src/test/scala/io/circe/refined/RefinedSuite.scala
+++ b/modules/refined/shared/src/test/scala/io/circe/refined/RefinedSuite.scala
@@ -48,7 +48,7 @@ class RefinedSuite extends CirceSuite {
   }
 }
 
-class RefinedFieldsSuite extends CirceSuite {
+object RefinedFieldsSuite {
   case class RefinedFields(
     i: Int Refined Positive,
     s: String Refined NonEmpty,
@@ -76,6 +76,10 @@ class RefinedFieldsSuite extends CirceSuite {
       case RefinedFields(i, s, l) => (i, s, l)
     }
   }
+}
+
+class RefinedFieldsSuite extends CirceSuite {
+  import RefinedFieldsSuite._
 
   checkLaws("Codec[RefinedFields]", CodecTests[RefinedFields].codec)
 

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -3,6 +3,7 @@ package io.circe.testing
 import cats.data.ValidatedNel
 import cats.laws.discipline.arbitrary._
 import io.circe._
+import io.circe.export.Exported
 import io.circe.numbers.BiggerDecimal
 import io.circe.numbers.testing.JsonNumberString
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
@@ -113,5 +114,9 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
     arbitrary[Json => ValidatedNel[DecodingFailure, A]].map(f =>
       AccumulatingDecoder.instance(c => f(c.value))
     )
+  )
+
+  implicit def arbitraryExported[A: Arbitrary]: Arbitrary[Exported[A]] = Arbitrary(
+    arbitrary[A].map(Exported.apply)
   )
 }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -3,7 +3,6 @@ package io.circe.testing
 import cats.data.ValidatedNel
 import cats.laws.discipline.arbitrary._
 import io.circe._
-import io.circe.export.Exported
 import io.circe.numbers.BiggerDecimal
 import io.circe.numbers.testing.JsonNumberString
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
@@ -114,9 +113,5 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
     arbitrary[Json => ValidatedNel[DecodingFailure, A]].map(f =>
       AccumulatingDecoder.instance(c => f(c.value))
     )
-  )
-
-  implicit def arbitraryExported[A: Arbitrary]: Arbitrary[Exported[A]] = Arbitrary(
-    arbitrary[A].map(Exported.apply)
   )
 }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
@@ -47,6 +47,23 @@ trait CodecTests[A] extends Laws {
     "decoder serializability" -> SerializableLaws.serializable(laws.decode),
     "encoder serializability" -> SerializableLaws.serializable(laws.encode)
   )
+
+  def unserializableCodec(implicit
+    arbitraryA: Arbitrary[A],
+    shrinkA: Shrink[A],
+    eqA: Eq[A],
+    arbitraryJson: Arbitrary[Json],
+    shrinkJson: Shrink[Json]
+  ): RuleSet = new DefaultRuleSet(
+    name = "codec",
+    parent = None,
+    "roundTrip" -> Prop.forAll { (a: A) =>
+      laws.codecRoundTrip(a)
+    },
+    "consistency with accumulating" -> Prop.forAll { (json: Json) =>
+      laws.codecAccumulatingConsistency(json)
+    }
+  )
 }
 
 object CodecTests {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
@@ -43,7 +43,9 @@ trait CodecTests[A] extends Laws {
     },
     "consistency with accumulating" -> Prop.forAll { (json: Json) =>
       laws.codecAccumulatingConsistency(json)
-    }
+    },
+    "decoder serializability" -> SerializableLaws.serializable(laws.decode),
+    "encoder serializability" -> SerializableLaws.serializable(laws.encode)
   )
 }
 

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
@@ -60,6 +60,7 @@ case class ParserTests[P <: Parser](p: P) extends Laws {
     "decodingAccumulatingRoundTripWithSpaces" -> Prop.forAll { (json: Json) =>
       laws.decodingAccumulatingRoundTrip[A](json)(json =>
         serialize(json.spaces2), decodeAccumulating)
-    }
+    },
+    "parser serializability" -> SerializableLaws.serializable(p)
   )
 }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
@@ -37,7 +37,8 @@ trait PrinterTests[A] extends Laws {
       parent = None,
       "roundTrip" -> Prop.forAll { (a: A) =>
         laws.printerRoundTrip(printer, parser, a)
-      }
+      },
+      "printer serializability" -> SerializableLaws.serializable(printer)
     )
 }
 

--- a/modules/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
@@ -26,6 +26,8 @@ trait MissingInstances {
   implicit lazy val eqThrowable: Eq[Throwable] = Eq.fromUniversalEquals
   implicit lazy val eqBigDecimal: Eq[BigDecimal] = Eq.fromUniversalEquals
   implicit lazy val eqUUID: Eq[UUID] = Eq.fromUniversalEquals
+  implicit def eqRefArray[A <: AnyRef: Eq]: Eq[Array[A]] =
+    cats.kernel.instances.vector.catsKernelStdEqForVector[A].on(value => Predef.wrapRefArray(value).toVector)
 
   implicit def arbitraryTuple1[A](implicit A: Arbitrary[A]): Arbitrary[Tuple1[A]] =
     Arbitrary(A.arbitrary.map(Tuple1(_)))

--- a/modules/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
@@ -28,6 +28,7 @@ trait MissingInstances {
   implicit lazy val eqUUID: Eq[UUID] = Eq.fromUniversalEquals
   implicit def eqRefArray[A <: AnyRef: Eq]: Eq[Array[A]] =
     cats.kernel.instances.vector.catsKernelStdEqForVector[A].on(value => Predef.wrapRefArray(value).toVector)
+  implicit def eqSeq[A: Eq]: Eq[Seq[A]] = cats.kernel.instances.vector.catsKernelStdEqForVector[A].on(_.toVector)
 
   implicit def arbitraryTuple1[A](implicit A: Arbitrary[A]): Arbitrary[Tuple1[A]] =
     Arbitrary(A.arbitrary.map(Tuple1(_)))

--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -76,7 +76,7 @@ package examples {
     implicit val eqBar: Eq[Bar] = Eq.fromUniversalEquals
     implicit val arbitraryBar: Arbitrary[Bar] = Arbitrary(
       for {
-       i <- Arbitrary.arbitrary[Int]
+        i <- Arbitrary.arbitrary[Int]
         s <- Arbitrary.arbitrary[String]
       } yield Bar(i, s)
     )

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -56,6 +56,7 @@ class StdLibCodecSuite extends CirceSuite {
   checkLaws("Codec[Map[Int, Int]]", CodecTests[Map[Int, Int]].codec)
   checkLaws("Codec[Map[Long, Int]]", CodecTests[Map[Long, Int]].codec)
   checkLaws("Codec[Set[Int]]", CodecTests[Set[Int]].codec)
+  checkLaws("Codec[Array[String]]", CodecTests[Array[String]].codec)
 
   "A tuple encoder" should "return a JSON array" in forAll { (t: (Int, String, Char)) =>
     val json = Encoder[(Int, String, Char)].apply(t)

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -8,6 +8,10 @@ import io.circe.tests.CirceSuite
 import io.circe.tests.examples.Foo
 import java.util.UUID
 import org.scalacheck.{ Arbitrary, Gen }
+import scala.collection.generic.CanBuildFrom
+import scala.collection.immutable.SortedMap
+import scala.collection.mutable.{ ArrayBuilder, Builder, HashMap }
+import scala.reflect.ClassTag
 
 class AnyValCodecSuite extends CirceSuite {
   /**
@@ -38,6 +42,18 @@ class AnyValCodecSuite extends CirceSuite {
 }
 
 class StdLibCodecSuite extends CirceSuite {
+  /**
+   * We need serializable `CanBuildFrom` instances for arrays for our `Array` codec tests.
+   */
+  implicit def canBuildFromRefArraySerializable[A <: AnyRef: ClassTag]: CanBuildFrom[Array[A], A, Array[A]] =
+    new CanBuildFrom[Array[A], A, Array[A]] with Serializable {
+      def apply(from: Array[A]): Builder[A, Array[A]] = new ArrayBuilder.ofRef[A]
+      def apply(): Builder[A, Array[A]] = new ArrayBuilder.ofRef[A]
+    }
+
+  implicit def eqHashMap[Long, Int]: Eq[HashMap[Long, Int]] = Eq.fromUniversalEquals
+  implicit def eqSortedMap[Long, Int]: Eq[SortedMap[Long, Int]] = Eq.fromUniversalEquals
+
   implicit val arbitraryUUID: Arbitrary[UUID] = Arbitrary(Gen.uuid)
 
   checkLaws("Codec[String]", CodecTests[String].codec)
@@ -48,6 +64,7 @@ class StdLibCodecSuite extends CirceSuite {
   checkLaws("Codec[Some[Int]]", CodecTests[Some[Int]].codec)
   checkLaws("Codec[None.type]", CodecTests[None.type].codec)
   checkLaws("Codec[List[Int]]", CodecTests[List[Int]].codec)
+  checkLaws("Codec[Seq[Int]]", CodecTests[Seq[Int]].codec)
   checkLaws("Codec[Map[String, Int]]", CodecTests[Map[String, Int]].codec)
   checkLaws("Codec[Map[Symbol, Int]]", CodecTests[Map[Symbol, Int]].codec)
   checkLaws("Codec[Map[UUID, Int]]", CodecTests[Map[UUID, Int]].codec)
@@ -55,6 +72,8 @@ class StdLibCodecSuite extends CirceSuite {
   checkLaws("Codec[Map[Short, Int]]", CodecTests[Map[Short, Int]].codec)
   checkLaws("Codec[Map[Int, Int]]", CodecTests[Map[Int, Int]].codec)
   checkLaws("Codec[Map[Long, Int]]", CodecTests[Map[Long, Int]].codec)
+  checkLaws("Codec[HashMap[Long, Int]]", CodecTests[HashMap[Long, Int]].unserializableCodec)
+  checkLaws("Codec[SortedMap[Long, Int]]", CodecTests[SortedMap[Long, Int]].unserializableCodec)
   checkLaws("Codec[Set[Int]]", CodecTests[Set[Int]].codec)
   checkLaws("Codec[Array[String]]", CodecTests[Array[String]].codec)
 
@@ -103,6 +122,15 @@ class StdLibCodecSuite extends CirceSuite {
 }
 
 class CatsCodecSuite extends CirceSuite {
+  /**
+   * We need serializable `CanBuildFrom` instances for streams for our `NonEmptyStream` codec tests.
+   */
+  implicit def canBuildFromStreamSerializable[A]: CanBuildFrom[Stream[A], A, Stream[A]] =
+    new CanBuildFrom[Stream[A], A, Stream[A]] with Serializable {
+      def apply(from: Stream[A]): Builder[A, Stream[A]] = Stream.newBuilder[A]
+      def apply(): Builder[A, Stream[A]] = Stream.newBuilder[A]
+    }
+
   checkLaws("Codec[NonEmptyList[Int]]", CodecTests[NonEmptyList[Int]].codec)
   checkLaws("Codec[NonEmptyVector[Int]]", CodecTests[NonEmptyVector[Int]].codec)
   checkLaws("Codec[NonEmptyStream[Int]]", CodecTests[NonEmptyStream[Int]].codec)

--- a/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
@@ -2,7 +2,6 @@ package io.circe
 
 import cats.laws.SerializableLaws
 import cats.laws.discipline.SerializableTests
-import io.circe.export.Exported
 import io.circe.tests.CirceSuite
 
 class SerializableSuite extends CirceSuite {
@@ -12,10 +11,6 @@ class SerializableSuite extends CirceSuite {
 
   "HCursor" should "be serializable" in forAll { (j: Json) =>
     SerializableLaws.serializable(j.hcursor); ()
-  }
-
-  "Exported" should "be serializable" in forAll { (value: String) =>
-    SerializableLaws.serializable(Exported(value)); ()
   }
 
   checkLaws("Decoder[Int]", SerializableTests.serializable(Decoder[Int]))

--- a/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.laws.SerializableLaws
 import cats.laws.discipline.SerializableTests
+import io.circe.export.Exported
 import io.circe.tests.CirceSuite
 
 class SerializableSuite extends CirceSuite {
@@ -11,6 +12,10 @@ class SerializableSuite extends CirceSuite {
 
   "HCursor" should "be serializable" in forAll { (j: Json) =>
     SerializableLaws.serializable(j.hcursor); ()
+  }
+
+  "Exported" should "be serializable" in forAll { (value: String) =>
+    SerializableLaws.serializable(Exported(value)); ()
   }
 
   checkLaws("Decoder[Int]", SerializableTests.serializable(Decoder[Int]))

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -317,7 +317,7 @@ object Boilerplate {
         -    implicit val decodeCc$arity: Decoder[Cc$arity] =
         -      Decoder.forProduct$arity($memberNames)(Cc$arity.apply)
         -  }
-        -  checkLaws("Codec[Cc$arity]", CodecTests[Cc$arity].codec)
+        -  checkLaws("Codec[Cc$arity]", CodecTests[Cc$arity].unserializableCodec)
         |}
       """
     }


### PR DESCRIPTION
This is a pretty big change that addresses #664 and does a couple of other things.

The problem is that Scala's `CanBuildFrom` and `IsTraversableOnce` type classes by default don't extend `Serializable`, which means that `Decoder` and `Encoder` instances that capture them aren't serializable (which causes problems on frameworks like Spark).

This change makes it so that instances for the following types are `Serializable`:

* `scala.collection.Seq`
* `scala.collection.immutable.List`
* `scala.collection.immutable.Vector`
* `scala.collection.immutable.Set`
* `scala.collection.immutable.Map` 
* `cats.data.NonEmptyList`
* `cats.data.NonEmpyVector`

Instances for other collection types will not be serializable unless you provide a serializable `CanBuildFrom` or `C[A] => Iterable[A]` (see [the tests](https://github.com/circe/circe/blob/bb728f12e627079cfef97db3025d029ca2057a81/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala#L48) for an example of how to do this).

I've made a few other changes for the sake of cleanliness and consistency while I'm here. Some type parameters are rearranged, and we now provide instances for mutable maps (to match the instances we've been providing for mutable sequences). I've also changed `Encoder` to use evidence of a subtype of / conversion to `Iterable` rather than the `IsTraversableOnce` type class.

I've also added better tests for `Serializable` that turned up a few other problems. The `java.time` instances in circe-java8 are not serializable for the types that require a `java.time.format.DateTimeFormatter` (which isn't `Serializable`), and `forProductN`-created instances aren't serializable unless the function you provide is.

The changes here shouldn't be user-facing for the most part.