### PR TITLE
Fix KeyDecoder bug and add laws checking

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
@@ -78,7 +78,7 @@ final object KeyDecoder {
     }
 
     final def handleErrorWith[A](fa: KeyDecoder[A])(f: Unit => KeyDecoder[A]): KeyDecoder[A] = new KeyDecoder[A] {
-      final def apply(key: String): Option[A] = f(())(key)
+      final def apply(key: String): Option[A] = fa(key).orElse(f(())(key))
     }
 
     final def tailRecM[A, B](a: A)(f: A => KeyDecoder[Either[A, B]]): KeyDecoder[B] = new KeyDecoder[B] {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -83,6 +83,14 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
     arbitrary[String].map(DecodingFailure(_, Nil))
   )
 
+  implicit def arbitraryKeyEncoder[A: Cogen]: Arbitrary[KeyEncoder[A]] = Arbitrary(
+    arbitrary[A => String].map(KeyEncoder.instance)
+  )
+
+  implicit def arbitraryKeyDecoder[A: Arbitrary]: Arbitrary[KeyDecoder[A]] = Arbitrary(
+    arbitrary[String => Option[A]].map(KeyDecoder.instance)
+  )
+
   implicit def arbitraryEncoder[A: Cogen]: Arbitrary[Encoder[A]] = Arbitrary(
     arbitrary[A => Json].map(Encoder.instance)
   )

--- a/modules/testing/shared/src/main/scala/io/circe/testing/EqInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/EqInstances.scala
@@ -2,8 +2,9 @@ package io.circe.testing
 
 import cats.Eq
 import cats.instances.either._
+import cats.instances.option._
 import cats.syntax.eq._
-import io.circe.{ AccumulatingDecoder, ArrayEncoder, Decoder, Encoder, Json, ObjectEncoder }
+import io.circe.{ AccumulatingDecoder, ArrayEncoder, Decoder, Encoder, Json, KeyDecoder, KeyEncoder, ObjectEncoder }
 import org.scalacheck.Arbitrary
 
 trait EqInstances { this: ArbitraryInstances =>
@@ -16,6 +17,14 @@ trait EqInstances { this: ArbitraryInstances =>
   private[this] def arbitraryValues[A](implicit A: Arbitrary[A]): Stream[A] = Stream.continually(
     A.arbitrary.sample
   ).flatten
+
+  implicit def eqKeyEncoder[A: Arbitrary]: Eq[KeyEncoder[A]] = Eq.instance { (e1, e2) =>
+    arbitraryValues[A].take(codecEqualityCheckCount).forall(a => e1(a) == e2(a))
+  }
+
+  implicit def eqKeyDecoder[A: Eq]: Eq[KeyDecoder[A]] = Eq.instance { (d1, d2) =>
+    arbitraryValues[String].take(codecEqualityCheckCount).forall(s => d1(s) === d2(s))
+  }
 
   implicit def eqEncoder[A: Arbitrary]: Eq[Encoder[A]] = Eq.instance { (e1, e2) =>
     arbitraryValues[A].take(codecEqualityCheckCount).forall(a => e1(a) === e2(a))

--- a/modules/tests/shared/src/test/scala/io/circe/KeyDecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyDecoderSuite.scala
@@ -1,0 +1,8 @@
+package io.circe
+
+import cats.laws.discipline.MonadErrorTests
+import io.circe.tests.CirceSuite
+
+class KeyDecoderSuite extends CirceSuite {
+  checkLaws("KeyDecoder[Int]", MonadErrorTests[KeyDecoder, Unit].monadError[Int, Int, Int])
+}

--- a/modules/tests/shared/src/test/scala/io/circe/KeyEncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyEncoderSuite.scala
@@ -1,0 +1,9 @@
+package io.circe
+
+import cats.laws.discipline.ContravariantTests
+import io.circe.tests.CirceSuite
+
+class KeyEncoderSuite extends CirceSuite {
+  checkLaws("KeyEncoder[Int]", ContravariantTests[KeyEncoder].contravariant[Int, Int, Int])
+}
+


### PR DESCRIPTION
`KeyDecoder`'s `handleErrorWith` wasn't even trying the original decoder. This is a quick fix and some laws checking.