### PR TITLE
Rework JsonObject

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/ACursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ACursor.scala
@@ -131,21 +131,30 @@ abstract class ACursor(private val lastCursor: HCursor, private val lastOp: Curs
    *
    * @group ObjectAccess
    */
-  def values: Option[Vector[Json]]
+  def values: Option[Iterable[Json]]
 
   /**
    * If the focus is a JSON object, return its field names in a set.
    *
    * @group ObjectAccess
    */
-  def fieldSet: Option[Set[String]]
+  @deprecated("Use keys.map(_.toSet)", "0.9.0")
+  def fieldSet: Option[Set[String]] = keys.map(_.toSet)
 
   /**
    * If the focus is a JSON object, return its field names in their original order.
    *
    * @group ObjectAccess
    */
-  def fields: Option[Vector[String]]
+  def keys: Option[Iterable[String]]
+
+  /**
+   * If the focus is a JSON object, return its field names in their original order.
+   *
+   * @group ObjectAccess
+   */
+  @deprecated("Use keys", "0.9.0")
+  final def fields: Option[Iterable[String]] = keys
 
   /**
    * Delete the focus and move to its parent.

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -893,9 +893,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
      */
     def requireEmptyWithMessage(createMessage: List[String] => String): StateT[Result, ACursor, Unit] =
       StateT[Result, ACursor, Unit] { c =>
-        val fields = c.focus.flatMap(_.asObject).toList.flatMap(_.fields)
+        val keys = c.focus.flatMap(_.asObject).toList.flatMap(_.keys)
 
-        if (fields.isEmpty) Right((c, ())) else Left(DecodingFailure(createMessage(fields), c.history))
+        if (keys.isEmpty) Right((c, ())) else Left(DecodingFailure(createMessage(keys), c.history))
       }
 
     /**

--- a/modules/core/shared/src/main/scala/io/circe/FailedCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/FailedCursor.scala
@@ -1,7 +1,6 @@
 package io.circe
 
 import cats.Applicative
-import scala.collection.immutable.Set
 
 final class FailedCursor(lastCursor: HCursor, lastOp: CursorOp) extends ACursor(lastCursor, lastOp) {
   /**
@@ -20,9 +19,8 @@ final class FailedCursor(lastCursor: HCursor, lastOp: CursorOp) extends ACursor(
   def withFocus(f: Json => Json): ACursor = this
   def withFocusM[F[_]](f: Json => F[Json])(implicit F: Applicative[F]): F[ACursor] = F.pure(this)
 
-  def values: Option[Vector[Json]] = None
-  def fieldSet: Option[Set[String]] = None
-  def fields: Option[Vector[String]] = None
+  def values: Option[Iterable[Json]] = None
+  def keys: Option[Iterable[String]] = None
   def lefts: Option[Vector[Json]] = None
   def rights: Option[Vector[Json]] = None
 

--- a/modules/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -3,7 +3,6 @@ package io.circe
 import cats.Applicative
 import io.circe.cursor.{ ArrayCursor, ObjectCursor, TopCursor }
 import scala.annotation.tailrec
-import scala.collection.immutable.Set
 
 abstract class HCursor(lastCursor: HCursor, lastOp: CursorOp) extends ACursor(lastCursor, lastOp) {
   def value: Json
@@ -20,18 +19,13 @@ abstract class HCursor(lastCursor: HCursor, lastOp: CursorOp) extends ACursor(la
 
   final def focus: Option[Json] = Some(value)
 
-  final def values: Option[Vector[Json]] = value match {
+  final def values: Option[Iterable[Json]] = value match {
     case Json.JArray(vs) => Some(vs)
     case _ => None
   }
 
-  final def fieldSet: Option[Set[String]] = value match {
-    case Json.JObject(o) => Some(o.fieldSet)
-    case _ => None
-  }
-
-  final def fields: Option[Vector[String]] = value match {
-    case Json.JObject(o) => Some(o.fields)
+  final def keys: Option[Iterable[String]] = value match {
+    case Json.JObject(o) => Some(o.keys)
     case _ => None
   }
 

--- a/modules/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -47,9 +47,7 @@ abstract class HCursor(lastCursor: HCursor, lastOp: CursorOp) extends ACursor(la
 
   final def downField(k: String): ACursor = value match {
     case Json.JObject(o) =>
-      val m = o.toMap
-
-      if (!m.contains(k)) fail(CursorOp.DownField(k)) else {
+      if (!o.contains(k)) fail(CursorOp.DownField(k)) else {
         new ObjectCursor(o, k, this, false)(this, CursorOp.DownField(k))
       }
     case _ => fail(CursorOp.DownField(k))

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -260,9 +260,6 @@ final object JsonObject {
   private[circe] final def fromLinkedHashMap(map: LinkedHashMap[String, Json]): JsonObject =
     new LinkedHashMapJsonObject(map)
 
-  private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject =
-    new MapAndVectorJsonObject(map, keys)
-
   /**
    * Construct an empty [[JsonObject]].
    */

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -225,8 +225,14 @@ final object JsonObject {
   /**
    * Construct a [[JsonObject]] from a foldable collection of key-value pairs.
    */
-  final def from[F[_]](fields: F[(String, Json)])(implicit F: Foldable[F]): JsonObject =
+  final def fromFoldable[F[_]](fields: F[(String, Json)])(implicit F: Foldable[F]): JsonObject =
     F.foldLeft(fields, empty) { case (acc, (key, value)) => acc.add(key, value) }
+
+  /**
+   * Construct a [[JsonObject]] from a foldable collection of key-value pairs.
+   */
+  @deprecated("Use fromFoldable", "0.9.0")
+  final def from[F[_]](fields: F[(String, Json)])(implicit F: Foldable[F]): JsonObject = fromFoldable[F](fields)(F)
 
   /**
    * Construct a [[JsonObject]] from an [[scala.collection.Iterable]] (provided for optimization).

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -18,7 +18,10 @@ import scala.collection.immutable.{ Map, Set }
  * @groupprio Conversions 1
  *
  * @groupname Modification Operations that transform the JSON object
- * @groupprio Modification
+ * @groupprio Modification 2
+ *
+ * @groupname Other Equality and other operations
+ * @groupprio Other 3
  */
 sealed abstract class JsonObject extends Serializable {
   /**
@@ -65,6 +68,8 @@ sealed abstract class JsonObject extends Serializable {
 
   /**
    * Return a Kleisli arrow that gets the JSON value associated with the given field.
+   *
+   * @group Contents
    */
   final val kleisli: Kleisli[Option, String, Json] = Kleisli(apply(_))
 
@@ -186,16 +191,25 @@ sealed abstract class JsonObject extends Serializable {
 
   private[circe] def appendToFolder(folder: Printer.PrintingFolder): Unit
 
+  /**
+   * @group Other
+   */
   final override def toString: String = toIterable.map {
     case (k, v) => s"$k -> ${ Json.showJson.show(v) }"
   }.mkString("object[", ",", "]")
 
+  /**
+   * @group Other
+   */
   final override def equals(that: Any): Boolean = if (that.isInstanceOf[JsonObject]) {
     toMap == that.asInstanceOf[JsonObject].toMap
   } else {
     false
   }
 
+  /**
+   * @group Other
+   */
   final override def hashCode: Int = toMap.hashCode
 }
 

--- a/modules/core/shared/src/main/scala/io/circe/MapDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/MapDecoder.scala
@@ -16,24 +16,24 @@ private[circe] abstract class MapDecoder[K, V, M[K, V] <: Map[K, V]](
 
   protected def createBuilder(): Builder[(K, V), M[K, V]]
 
-  final def apply(c: HCursor): Decoder.Result[M[K, V]] = c.fields match {
+  final def apply(c: HCursor): Decoder.Result[M[K, V]] = c.keys match {
     case None => Left[DecodingFailure, M[K, V]](MapDecoder.failure(c))
-    case Some(fields) =>
-      val it = fields.iterator
+    case Some(keys) =>
+      val it = keys.iterator
       val builder = createBuilder()
       var failed: DecodingFailure = null
 
       while (failed.eq(null) && it.hasNext) {
-        val field = it.next
-        val atH = c.downField(field)
+        val key = it.next
+        val atH = c.downField(key)
 
         if (alwaysDecodeK.ne(null)) {
           atH.as(decodeV) match {
-            case Right(value) => builder += ((alwaysDecodeK.decodeSafe(field), value))
+            case Right(value) => builder += ((alwaysDecodeK.decodeSafe(key), value))
             case Left(error) => failed = error
           }
         } else {
-          decodeK(field) match {
+          decodeK(key) match {
             case None => failed = MapDecoder.failure(atH)
             case Some(k) => atH.as(decodeV) match {
               case Right(value) => builder += ((k, value))
@@ -46,28 +46,28 @@ private[circe] abstract class MapDecoder[K, V, M[K, V] <: Map[K, V]](
       if (failed.eq(null)) Right(builder.result) else Left(failed)
   }
 
-  final override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[M[K, V]] = c.fields match {
+  final override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[M[K, V]] = c.keys match {
     case None => Validated.invalidNel[DecodingFailure, M[K, V]](MapDecoder.failure(c))
-    case Some(fields) =>
-      val it = fields.iterator
+    case Some(keys) =>
+      val it = keys.iterator
       val builder = createBuilder()
       var failed = false
       val failures = List.newBuilder[DecodingFailure]
 
       while (it.hasNext) {
-        val field = it.next
-        val atH = c.downField(field)
+        val key = it.next
+        val atH = c.downField(key)
 
         if (alwaysDecodeK.ne(null)) {
           decodeV.tryDecodeAccumulating(atH) match {
-            case Validated.Valid(value) => if (!failed) builder += ((alwaysDecodeK.decodeSafe(field), value))
+            case Validated.Valid(value) => if (!failed) builder += ((alwaysDecodeK.decodeSafe(key), value))
             case Validated.Invalid(es) =>
               failed = true
               failures += es.head
               failures ++= es.tail
           }
         } else {
-          decodeK(field) match {
+          decodeK(key) match {
             case Some(k) =>
               decodeV.tryDecodeAccumulating(atH) match {
                 case Validated.Valid(value) => if (!failed) builder += ((k, value))

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -62,108 +62,18 @@ final case class Printer(
   private[this] final val commaText = ","
   private[this] final val colonText = ":"
 
-  private[this] final class StringBuilderFolder(writer: StringBuilder) extends PrintingFolder(writer) {
+  private[this] final class StringBuilderFolder(
+    writer: StringBuilder
+  ) extends Printer.PrintingFolder(writer, pieces, dropNullKeys) {
     final def onBoolean(value: Boolean): Unit = writer.append(value)
     final def onNumber(value: JsonNumber): Unit = value.appendToStringBuilder(writer)
   }
 
   private[this] final class AppendableByteBufferFolder(
     writer: Printer.AppendableByteBuffer
-  ) extends PrintingFolder(writer) {
+  ) extends Printer.PrintingFolder(writer, pieces, dropNullKeys) {
     final def onBoolean(value: Boolean): Unit = writer.append(java.lang.Boolean.toString(value))
     final def onNumber(value: JsonNumber): Unit = writer.append(value.toString)
-  }
-
-  private[this] abstract class PrintingFolder(writer: Appendable) extends Json.Folder[Unit] {
-    private[this] var depth: Int = 0
-
-    final def onNull: Unit = writer.append("null")
-
-    final def onString(value: String): Unit = {
-      writer.append('"')
-
-      var i = 0
-      var offset = 0
-
-      while (i < value.length) {
-        val c = value.charAt(i)
-
-        if (
-          (c == '"' || c == '\\' || c == '\b' || c == '\f' || c == '\n' || c == '\r' || c == '\t') ||
-          Character.isISOControl(c)
-        ) {
-          writer.append(value, offset, i)
-          writer.append('\\')
-          (c: @switch) match {
-            case '"'  => writer.append('"')
-            case '\\' => writer.append('\\')
-            case '\b' => writer.append('b')
-            case '\f' => writer.append('f')
-            case '\n' => writer.append('n')
-            case '\r' => writer.append('r')
-            case '\t' => writer.append('t')
-            case control =>
-              writer.append(String.format("u%04x", Integer.valueOf(control.toInt)))
-          }
-          offset = i + 1
-        }
-
-        i += 1
-      }
-
-      if (offset < i) writer.append(value, offset, i)
-      writer.append('"')
-    }
-
-    final def onArray(value: Vector[Json]): Unit = {
-      val orig = depth
-      val p = pieces(depth)
-
-      if (value.isEmpty) writer.append(p.lrEmptyBrackets) else {
-        val iterator = value.iterator
-
-        writer.append(p.lBrackets)
-        depth += 1
-        iterator.next().foldWith(this)
-        depth = orig
-
-        while (iterator.hasNext) {
-          writer.append(p.arrayCommas)
-          depth += 1
-          iterator.next().foldWith(this)
-          depth = orig
-        }
-
-        writer.append(p.rBrackets)
-      }
-    }
-
-    final def onObject(value: JsonObject): Unit = {
-      val orig = depth
-      val p = pieces(depth)
-      val m = value.toMap
-
-      writer.append(p.lBraces)
-      var first = true
-
-      val keyIterator = value.keys.iterator
-
-      while (keyIterator.hasNext) {
-        val key = keyIterator.next()
-        val value = m(key)
-        if (!dropNullKeys || !value.isNull) {
-          if (!first) writer.append(p.objectCommas)
-          onString(key)
-          writer.append(p.colons)
-
-          depth += 1
-          value.foldWith(this)
-          depth = orig
-          first = false
-        }
-      }
-      writer.append(p.rBraces)
-    }
   }
 
   private[this] final def concat(left: String, text: String, right: String): String = {
@@ -327,6 +237,77 @@ final object Printer {
    * A pretty-printer configuration that indents by four spaces.
    */
   final val spaces4: Printer = indented("    ")
+
+  private[circe] abstract class PrintingFolder(
+    private[circe] val writer: Appendable,
+    private[circe] val pieces: PiecesAtDepth,
+    private[circe] val dropNullKeys: Boolean
+  ) extends Json.Folder[Unit] {
+    private[circe] var depth: Int = 0
+
+    final def onNull: Unit = writer.append("null")
+
+    final def onString(value: String): Unit = {
+      writer.append('"')
+
+      var i = 0
+      var offset = 0
+
+      while (i < value.length) {
+        val c = value.charAt(i)
+
+        if (
+          (c == '"' || c == '\\' || c == '\b' || c == '\f' || c == '\n' || c == '\r' || c == '\t') ||
+          Character.isISOControl(c)
+        ) {
+          writer.append(value, offset, i)
+          writer.append('\\')
+          (c: @switch) match {
+            case '"'  => writer.append('"')
+            case '\\' => writer.append('\\')
+            case '\b' => writer.append('b')
+            case '\f' => writer.append('f')
+            case '\n' => writer.append('n')
+            case '\r' => writer.append('r')
+            case '\t' => writer.append('t')
+            case control =>
+              writer.append(String.format("u%04x", Integer.valueOf(control.toInt)))
+          }
+          offset = i + 1
+        }
+
+        i += 1
+      }
+
+      if (offset < i) writer.append(value, offset, i)
+      writer.append('"')
+    }
+
+    final def onArray(value: Vector[Json]): Unit = {
+      val orig = depth
+      val p = pieces(depth)
+
+      if (value.isEmpty) writer.append(p.lrEmptyBrackets) else {
+        val iterator = value.iterator
+
+        writer.append(p.lBrackets)
+        depth += 1
+        iterator.next().foldWith(this)
+        depth = orig
+
+        while (iterator.hasNext) {
+          writer.append(p.arrayCommas)
+          depth += 1
+          iterator.next().foldWith(this)
+          depth = orig
+        }
+
+        writer.append(p.rBrackets)
+      }
+    }
+
+    final def onObject(value: JsonObject): Unit = value.appendToFolder(this)
+  }
 
   private[circe] final case class Pieces(
     lBraces: String,

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -144,13 +144,12 @@ final case class Printer(
       val m = value.toMap
 
       writer.append(p.lBraces)
-      val fields = if (preserveOrder) value.fields else value.fieldSet
       var first = true
 
-      val fieldIterator = fields.iterator
+      val keyIterator = value.keys.iterator
 
-      while (fieldIterator.hasNext) {
-        val key = fieldIterator.next()
+      while (keyIterator.hasNext) {
+        val key = keyIterator.next()
         val value = m(key)
         if (!dropNullKeys || !value.isNull) {
           if (!first) writer.append(p.objectCommas)

--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -1,6 +1,7 @@
 package io.circe.jawn
 
 import io.circe.{ Json, JsonNumber, JsonObject }
+import java.util.LinkedHashMap
 import jawn.{ Facade, FContext, SupportParser }
 
 final object CirceSupportParser extends SupportParser[Json] {
@@ -34,21 +35,18 @@ final object CirceSupportParser extends SupportParser[Json] {
 
     def objectContext(): FContext[Json] = new FContext[Json] {
       private[this] final var key: String = null
-      private[this] final val m = scala.collection.mutable.Map.empty[String, Json]
-      private[this] final val keys = Vector.newBuilder[String]
+      private[this] final val m = new LinkedHashMap[String, Json]
 
       final def add(s: CharSequence): Unit =
         if (key.eq(null)) { key = s.toString } else {
-          if (!m.contains(key)) keys += key
-          m(key) = jstring(s)
+          m.put(key, jstring(s))
           key = null
         }
       final def add(v: Json): Unit = {
-        if (!m.contains(key)) keys += key
-        m(key) = v
+        m.put(key, v)
         key = null
       }
-      final def finish: Json = Json.fromJsonObject(JsonObject.fromMapAndVector(m.toMap, keys.result()))
+      final def finish: Json = Json.fromJsonObject(JsonObject.fromLinkedHashMap(m))
       final def isObj: Boolean = true
     }
   }

--- a/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
@@ -45,7 +45,7 @@ trait JsonObjectOptics extends CatsConversions with ListInstances {
               case (field, json) =>
                 F.map(if (p(field)) f(json) else F.point(json))((field, _))
             }
-          )(JsonObject.from(_)(catsStdInstancesForList))
+          )(JsonObject.fromFoldable(_)(catsStdInstancesForList))
     }
   }
 

--- a/modules/shapes/src/main/scala/io/circe/shapes/LabelledCoproductInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/LabelledCoproductInstances.scala
@@ -44,7 +44,7 @@ private[shapes] trait LowPriorityLabelledCoproductInstances extends CoproductIns
 
     def apply(c: HCursor): Decoder.Result[FieldType[K, V] :+: R] =
       Decoder.resultSemigroupK.combineK(
-        c.fields.flatMap(_.find(isK)).fold[Decoder.Result[String]](
+        c.keys.flatMap(_.find(isK)).fold[Decoder.Result[String]](
           Left(DecodingFailure("Record", c.history))
         )(Right(_)).right.flatMap(c.get[V](_).right.map(v => Inl(field[K](v)))),
         decodeR(c).right.map(Inr(_))

--- a/modules/shapes/src/main/scala/io/circe/shapes/LabelledHListInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/LabelledHListInstances.scala
@@ -69,7 +69,7 @@ private[shapes] trait LowPriorityLabelledHListInstances extends HListInstances {
     private[this] val isK: String => Boolean = decodeW(_).exists(eqW.eqv(widened, _))
 
     def apply(c: HCursor): Decoder.Result[FieldType[K, V] :: T] = Decoder.resultInstance.map2(
-        c.fields.flatMap(_.find(isK)).fold[Decoder.Result[String]](
+        c.keys.flatMap(_.find(isK)).fold[Decoder.Result[String]](
           Left(DecodingFailure("Record", c.history))
         )(Right(_)).right.flatMap(c.get[V](_)),
       decodeT(c)
@@ -77,7 +77,7 @@ private[shapes] trait LowPriorityLabelledHListInstances extends HListInstances {
 
     override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[FieldType[K, V] :: T] =
       AccumulatingDecoder.resultInstance.map2(
-        c.fields.flatMap(_.find(isK)).fold[AccumulatingDecoder.Result[String]](
+        c.keys.flatMap(_.find(isK)).fold[AccumulatingDecoder.Result[String]](
           Validated.invalidNel(DecodingFailure("Record", c.history))
         )(Validated.valid).andThen(k => decodeV.tryDecodeAccumulating(c.downField(k))),
         decodeT.decodeAccumulating(c)

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -81,7 +81,7 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
 
     Gen.oneOf(
       fields.map(JsonObject.fromIterable),
-      fields.map(JsonObject.from[List])
+      fields.map(JsonObject.fromFoldable[List])
     )
   }
 

--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -132,7 +132,7 @@ package examples {
     }
 
     val decodeFoo: Decoder[Foo] = Decoder.instance { c =>
-      c.fields match {
+      c.keys.map(_.toVector) match {
         case Some(Vector("Bar")) => c.get("Bar")(Bar.decodeBar.widen)
         case Some(Vector("Baz")) => c.get("Baz")(Baz.decodeBaz.widen)
         case Some(Vector("Bam")) => c.get("Bam")(Bam.decodeBam.widen)

--- a/modules/tests/shared/src/test/scala/io/circe/ACursorSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/ACursorSuite.scala
@@ -37,8 +37,8 @@ class ACursorSuite extends CirceSuite {
     val c = HCursor.fromJson(j)
 
     val intoObject = for {
-      fields  <- c.fields
-      first   <- fields.headOption
+      keys    <- c.keys
+      first   <- keys.headOption
       atFirst <- c.downField(first).success
     } yield atFirst
 
@@ -53,8 +53,8 @@ class ACursorSuite extends CirceSuite {
     val c = HCursor.fromJson(j)
 
     val intoObject = for {
-      fields  <- c.fields
-      first   <- fields.headOption
+      keys    <- c.keys
+      first   <- keys.headOption
       atFirst <- c.downField(first).success
     } yield atFirst
 
@@ -149,15 +149,15 @@ class ACursorSuite extends CirceSuite {
   }
 
   "values" should "return the expected values" in {
-    assert(cursor.downField("a").values === Some((1 to 5).toVector.map(_.asJson)))
+    assert(cursor.downField("a").values.map(_.toVector) === Some((1 to 5).toVector.map(_.asJson)))
   }
 
   "fieldSet" should "return the expected values" in {
     assert(cursor.fieldSet.map(_.toList.sorted) === Some(List("a", "b", "c")))
   }
 
-  "fields" should "return the expected values" in {
-    assert(cursor.fields === Some(Vector("a", "b", "c")))
+  "keys" should "return the expected values" in {
+    assert(cursor.keys.map(_.toVector) === Some(Vector("a", "b", "c")))
   }
 
   "left" should "successfully select an existing value" in {

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -98,13 +98,13 @@ class JsonObjectSuite extends CirceSuite {
     assert(result2.kleisli(key) === expected)
   }
 
-  "fields" should "return all keys" in forAll { (fields: List[(String, Json)]) =>
+  "keys" should "return all keys" in forAll { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.from(fields)
     val expected = fields.map(_._1).distinct
 
-    assert(result1.fields.toList === expected)
-    assert(result2.fields.toList === expected)
+    assert(result1.keys.toList === expected)
+    assert(result2.keys.toList === expected)
   }
 
   "values" should "return all values" in forAll { (fields: List[(String, Json)]) =>
@@ -132,6 +132,18 @@ class JsonObjectSuite extends CirceSuite {
 
     assert(JsonObject.fromMap(result1.toMap) === expected)
     assert(JsonObject.fromMap(result2.toMap) === expected)
+  }
+
+  "toIterable" should "return all fields" in forAll { (values: List[Json]) =>
+    val fields = values.zipWithIndex.map {
+      case (value, i) => i.toString -> value
+    }.reverse
+
+    val result1 = JsonObject.fromIterable(fields)
+    val result2 = JsonObject.from(fields)
+
+    assert(result1.toIterable.toList === fields)
+    assert(result2.toIterable.toList === fields)
   }
 
   "toList" should "return all fields" in forAll { (values: List[Json]) =>
@@ -218,13 +230,13 @@ class JsonObjectSuite extends CirceSuite {
     }
   }
 
-  "withJsons" should "transform the JSON object appropriately" in forAll { (values: List[Json], replacement: Json) =>
+  "mapValues" should "transform the JSON object appropriately" in forAll { (values: List[Json], replacement: Json) =>
     val fields = values.zipWithIndex.map {
       case (value, i) => i.toString -> value
     }
 
-    val result1 = JsonObject.fromIterable(fields).withJsons(_ => replacement)
-    val result2 = JsonObject.from(fields).withJsons(_ => replacement)
+    val result1 = JsonObject.fromIterable(fields).mapValues(_ => replacement)
+    val result2 = JsonObject.from(fields).mapValues(_ => replacement)
     val expected = JsonObject.from(fields.map(field => field._1 -> replacement))
 
     assert(result1 === expected)

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -205,19 +205,28 @@ class JsonObjectSuite extends CirceSuite {
     }
   }
 
-  "add and remove" should "be applied correctly" in {
-    forAll { (original: JsonObject, operations: List[Either[String, (String, Json)]]) =>
+  "add, +:, and remove" should "be applied correctly" in {
+    forAll { (original: JsonObject, operations: List[Either[String, (String, Json, Boolean)]]) =>
       val result = operations.foldLeft(original) {
-        case (acc, Right((key, value))) => acc.add(key, value)
+        case (acc, Right((key, value, true))) => acc.add(key, value)
+        case (acc, Right((key, value, false))) => (key, value) +: acc
         case (acc, Left(key)) => acc.remove(key)
       }
 
       val expected = operations.foldLeft(original.toList) {
-        case (acc, Right((key, value))) =>
+        case (acc, Right((key, value, true))) =>
           val index = acc.indexWhere(_._1 == key)
 
           if (index < 0) {
             acc :+ (key -> value)
+          } else {
+            acc.updated(index, (key, value))
+          }
+        case (acc, Right((key, value, false))) =>
+          val index = acc.indexWhere(_._1 == key)
+
+          if (index < 0) {
+            (key -> value) :: acc
           } else {
             acc.updated(index, (key, value))
           }

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -1,7 +1,8 @@
 package io.circe
 
-import io.circe.tests.CirceSuite
 import cats.data.Const
+import cats.kernel.Eq
+import io.circe.tests.CirceSuite
 
 class JsonObjectSuite extends CirceSuite {
   "JsonObject.fromIterable" should "drop all but the last instance when fields have the same key" in {
@@ -295,5 +296,14 @@ class JsonObjectSuite extends CirceSuite {
 
   "filterKeys" should "be consistent with Map#filterKeys" in forAll { (value: JsonObject, pred: String => Boolean) =>
     assert(value.filterKeys(pred).toMap === value.toMap.filterKeys(pred))
+  }
+
+  "Eq[JsonObject]" should "be consistent with comparing fields" in {
+    forAll { (fields1: List[(String, Json)], fields2: List[(String, Json)]) =>
+      val result = Eq[JsonObject].eqv(JsonObject.fromIterable(fields1), JsonObject.fromIterable(fields2))
+      val expected = fields1 == fields2
+
+      assert(result === expected)
+    }
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -200,6 +200,29 @@ class JsonObjectSuite extends CirceSuite {
     }
   }
 
+  "add and remove" should "be applied correctly" in {
+    forAll { (original: JsonObject, operations: List[Either[String, (String, Json)]]) =>
+      val result = operations.foldLeft(original) {
+        case (acc, Right((key, value))) => acc.add(key, value)
+        case (acc, Left(key)) => acc.remove(key)
+      }
+
+      val expected = operations.foldLeft(original.toList) {
+        case (acc, Right((key, value))) =>
+          val index = acc.indexWhere(_._1 == key)
+
+          if (index < 0) {
+            acc :+ (key -> value)
+          } else {
+            acc.updated(index, (key, value))
+          }
+        case (acc, Left(key)) => acc.filterNot(_._1 == key)
+      }
+
+      assert(result.toList === expected)
+    }
+  }
+
   "+:" should "replace existing fields with the same key" in {
     forAll { (head: Json, tail: List[Json], replacement: Json) =>
       val fields = (head :: tail).zipWithIndex.map {

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -21,7 +21,11 @@ class JsonObjectSuite extends CirceSuite {
   }
 
   "JsonObject.from" should "match JsonObject.fromIterable" in { (fields: List[(String, Json)]) =>
-    assert(JsonObject.from(fields) === JsonObject.fromIterable(fields))
+    val fromFoldableResult = JsonObject.from(fields)
+    val fromIterableResult = JsonObject.fromIterable(fields)
+
+    assert(fromFoldableResult.hashCode === fromIterableResult.hashCode)
+    assert(fromFoldableResult === fromIterableResult)
   }
 
   it should "drop all but the last instance when fields have the same key" in {

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -20,17 +20,17 @@ class JsonObjectSuite extends CirceSuite {
     assert(JsonObject.fromIterable(fields) === expected)
   }
 
-  "JsonObject.from" should "match JsonObject.fromIterable" in { (fields: List[(String, Json)]) =>
-    val fromFoldableResult = JsonObject.from(fields)
-    val fromIterableResult = JsonObject.fromIterable(fields)
+  "JsonObject.fromFoldable" should "match JsonObject.fromIterable" in { (fields: List[(String, Json)]) =>
+    val result1 = JsonObject.fromIterable(fields)
+    val result2 = JsonObject.fromFoldable(fields)
 
-    assert(fromFoldableResult.hashCode === fromIterableResult.hashCode)
-    assert(fromFoldableResult === fromIterableResult)
+    assert(result1.hashCode === result2.hashCode)
+    assert(result1 === result2)
   }
 
   it should "drop all but the last instance when fields have the same key" in {
     forAll { (key: String, values: List[Json]) =>
-      val result = JsonObject.from(values.map(key -> _))
+      val result = JsonObject.fromFoldable(values.map(key -> _))
       val expected = if (values.isEmpty) JsonObject.empty else JsonObject.singleton(key, values.last)
 
       assert(result === expected)
@@ -41,7 +41,7 @@ class JsonObjectSuite extends CirceSuite {
     val fields = List("a" -> Json.fromInt(0), "b" -> Json.fromInt(1), "c" -> Json.fromInt(2), "b" -> Json.fromInt(3))
     val expected = JsonObject("a" -> Json.fromInt(0), "b" -> Json.fromInt(3), "c" -> Json.fromInt(2))
 
-    assert(JsonObject.from(fields) === expected)
+    assert(JsonObject.fromFoldable(fields) === expected)
   }
 
   "JsonObject.apply" should "match JsonObject.fromIterable" in { (fields: List[(String, Json)]) =>
@@ -50,7 +50,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "apply" should "find fields if they exist" in { (fields: List[(String, Json)], key: String) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.find(_._1 == key).map(_._2)
 
     assert(result1(key) === expected)
@@ -59,7 +59,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "contains" should "find fields if they exist" in { (fields: List[(String, Json)], key: String) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.find(_._1 == key).nonEmpty
 
     assert(result1.contains(key) === expected)
@@ -68,7 +68,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "size" should "return the expected result" in { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.toMap.size
 
     assert(result1.size === expected)
@@ -77,7 +77,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "isEmpty" should "return the expected result" in { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.isEmpty
 
     assert(result1.isEmpty === expected)
@@ -86,7 +86,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "nonEmpty" should "return the expected result" in { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.nonEmpty
 
     assert(result1.nonEmpty === expected)
@@ -95,7 +95,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "kleisli" should "find fields if they exist" in { (fields: List[(String, Json)], key: String) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.find(_._1 == key).map(_._2)
 
     assert(result1.kleisli(key) === expected)
@@ -104,7 +104,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "keys" should "return all keys" in forAll { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.map(_._1).distinct
 
     assert(result1.keys.toList === expected)
@@ -113,7 +113,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "values" should "return all values" in forAll { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected: List[Json] = fields.foldLeft(List.empty[(String, Json)]) {
       case (acc, (key, value)) =>
         val index = acc.indexWhere(_._1 == key)
@@ -131,7 +131,7 @@ class JsonObjectSuite extends CirceSuite {
 
   "toMap" should "round-trip through JsonObject.fromMap" in forAll { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
     val expected = result1
 
     assert(JsonObject.fromMap(result1.toMap) === expected)
@@ -144,7 +144,7 @@ class JsonObjectSuite extends CirceSuite {
     }.reverse
 
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
 
     assert(result1.toIterable.toList === fields)
     assert(result2.toIterable.toList === fields)
@@ -156,7 +156,7 @@ class JsonObjectSuite extends CirceSuite {
     }.reverse
 
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
 
     assert(result1.toList === fields)
     assert(result2.toList === fields)
@@ -168,7 +168,7 @@ class JsonObjectSuite extends CirceSuite {
     }.reverse
 
     val result1 = JsonObject.fromIterable(fields)
-    val result2 = JsonObject.from(fields)
+    val result2 = JsonObject.fromFoldable(fields)
 
     assert(result1.toVector === fields)
     assert(result2.toVector === fields)
@@ -181,8 +181,8 @@ class JsonObjectSuite extends CirceSuite {
       }
 
       val result1 = JsonObject.fromIterable(fields).add("0", replacement)
-      val result2 = JsonObject.from(fields).add("0", replacement)
-      val expected = JsonObject.from(("0" -> replacement) :: fields.tail)
+      val result2 = JsonObject.fromFoldable(fields).add("0", replacement)
+      val expected = JsonObject.fromFoldable(("0" -> replacement) :: fields.tail)
 
       assert(result1 === expected)
       assert(result2 === expected)
@@ -196,8 +196,8 @@ class JsonObjectSuite extends CirceSuite {
       }.reverse
 
       val result1 = JsonObject.fromIterable(fields).add("0", replacement)
-      val result2 = JsonObject.from(fields).add("0", replacement)
-      val expected = JsonObject.from(fields.init :+ ("0" -> replacement))
+      val result2 = JsonObject.fromFoldable(fields).add("0", replacement)
+      val expected = JsonObject.fromFoldable(fields.init :+ ("0" -> replacement))
 
       assert(result1 === expected)
       assert(result2 === expected)
@@ -234,8 +234,8 @@ class JsonObjectSuite extends CirceSuite {
       }.reverse
 
       val result1 = ("0" -> replacement) +: JsonObject.fromIterable(fields)
-      val result2 = ("0" -> replacement) +: JsonObject.from(fields)
-      val expected = JsonObject.from(("0" -> replacement) :: fields.init)
+      val result2 = ("0" -> replacement) +: JsonObject.fromFoldable(fields)
+      val expected = JsonObject.fromFoldable(("0" -> replacement) :: fields.init)
 
       assert(result1 === expected)
       assert(result2 === expected)
@@ -249,8 +249,8 @@ class JsonObjectSuite extends CirceSuite {
       }
 
       val result1 = ("0" -> replacement) +: JsonObject.fromIterable(fields)
-      val result2 = ("0" -> replacement) +: JsonObject.from(fields)
-      val expected = JsonObject.from(("0" -> replacement) :: fields.tail)
+      val result2 = ("0" -> replacement) +: JsonObject.fromFoldable(fields)
+      val expected = JsonObject.fromFoldable(("0" -> replacement) :: fields.tail)
 
       assert(result1 === expected)
       assert(result2 === expected)
@@ -263,8 +263,8 @@ class JsonObjectSuite extends CirceSuite {
     }
 
     val result1 = JsonObject.fromIterable(fields).mapValues(_ => replacement)
-    val result2 = JsonObject.from(fields).mapValues(_ => replacement)
-    val expected = JsonObject.from(fields.map(field => field._1 -> replacement))
+    val result2 = JsonObject.fromFoldable(fields).mapValues(_ => replacement)
+    val expected = JsonObject.fromFoldable(fields.map(field => field._1 -> replacement))
 
     assert(result1 === expected)
     assert(result2 === expected)
@@ -276,8 +276,8 @@ class JsonObjectSuite extends CirceSuite {
     }
 
     val result1: Option[JsonObject] = JsonObject.fromIterable(fields).traverse[Option](Some(_))
-    val result2: Option[JsonObject] = JsonObject.from(fields).traverse[Option](Some(_))
-    val expected = JsonObject.from(fields)
+    val result2: Option[JsonObject] = JsonObject.fromFoldable(fields).traverse[Option](Some(_))
+    val expected = JsonObject.fromFoldable(fields)
 
     assert(result1 === Some(expected))
     assert(result2 === Some(expected))

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -10,7 +10,7 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     val n: JsonNumber => Int = _.truncateToInt
     val s: String => Int = _.length
     val a: Vector[Json] => Int = _.size
-    val o: JsonObject => Int = _.fields.size
+    val o: JsonObject => Int = _.keys.size
 
     val result = json.foldWith(
       new Json.Folder[Int] {


### PR DESCRIPTION
This PR makes a few API changes, including renaming `fields` methods that return the keys in a JSON object to `keys`, since we typically use "fields" to refer to the key-value pairs. These changes are all behind deprecations, so existing code won't break (for that reason). Several methods that previously returned `Vector` now return `Iterable` (which is a breaking change).

There are much more major non-public changes. I've added a `JsonObject` implementation based on Java's `LinkedHashMap`, and have rearranged the logic for printing JSON objects so that each of the two implementations can iterate over fields without unnecessary tuple allocations.

Note that by default new `JsonObject` values parsed by circe-jawn or built with `fromIterable` (or methods that call it, such as `Json.obj`) will use the `LinkedHashMap` implementation, which provides faster lookups and iteration. Calling methods like `add` or `remove` on these values will return instances of the old `Map`-plus-`Vector` implementation, which performs much better in situations where you're creating lots of "modified" (immutable) instances.

Note that it is impossible to modify the `LinkedHashMap` once a `JsonObject` value is created, of course.

The performance impact of this change is pretty remarkable—here are results from circe-benchmarks for this PR (ecfa11f; `new`) vs. the current master (6e17272; `old`):

```
Benchmark                              Mode  Cnt      Score      Error  Units
WritingBenchmark.writeFoosCirce (new) thrpt   10   3709.391 ±   10.734  ops/s
WritingBenchmark.writeFoosCirce (old) thrpt   10   3159.032 ±   48.561  ops/s
WritingBenchmark.writeFoosSpray       thrpt   10   3134.276 ±   16.775  ops/s
WritingBenchmark.writeFoosArgonaut    thrpt   10   2516.612 ±   20.082  ops/s
WritingBenchmark.writeFoosPlay        thrpt   10   1377.191 ±   24.037  ops/s
WritingBenchmark.writeFoosJson4s      thrpt   10   1061.630 ±    4.737  ops/s

Benchmark                              Mode  Cnt      Score      Error  Units
ReadingBenchmark.readFoosCirce (new)  thrpt   10   3578.396 ±   16.370  ops/s
ReadingBenchmark.readFoosCirce (old)  thrpt   10   2762.956 ±   55.975  ops/s
ReadingBenchmark.readFoosSpray        thrpt   10   2167.750 ±    8.348  ops/s
ReadingBenchmark.readFoosArgonaut     thrpt   10   1340.159 ±   24.207  ops/s
ReadingBenchmark.readFoosJson4s       thrpt   10   1270.613 ±    3.686  ops/s
ReadingBenchmark.readFoosPlay         thrpt   10   1249.330 ±   20.976  ops/s
```

I haven't added new tests since it seems like the current tests should exercise the new implementation pretty well, but we should check that.