### PR TITLE
Rework JsonNumber [WIP]

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -224,7 +224,7 @@ private[circe] final case class JsonDouble(value: Double) extends JsonNumber {
  * Represent a valid JSON number as a [[scala.Float]].
  */
 private[circe] final case class JsonFloat(value: Float) extends JsonNumber {
-  private[circe] def toBiggerDecimal: BiggerDecimal = BiggerDecimal.fromFloat(value)
+  private[circe] def toBiggerDecimal: BiggerDecimal = BiggerDecimal.fromFloatUnsafe(value)
   private[this] def toJavaBigDecimal = new JavaBigDecimal(java.lang.Float.toString(value))
 
   final def toBigDecimal: Option[BigDecimal] = Some(toJavaBigDecimal)
@@ -260,6 +260,7 @@ final object JsonNumber {
    * undefined. This operation is provided for use in situations where the validity of the input has
    * already been verified.
    */
+  @deprecated("Use fromString", "0.9.0")
   final def fromDecimalStringUnsafe(value: String): JsonNumber = JsonDecimal(value)
 
   /**
@@ -270,12 +271,13 @@ final object JsonNumber {
    * undefined. This operation is provided for use in situations where the validity of the input has
    * already been verified.
    */
-  final def fromIntegralStringUnsafe(value: String): JsonNumber =
-    if (!BiggerDecimal.integralIsValidLong(value)) JsonDecimal(value) else {
-      val longValue = java.lang.Long.parseLong(value)
+  @deprecated("Use fromString", "0.9.0")
+  final def fromIntegralStringUnsafe(value: String): JsonNumber = {
+    val result = BiggerDecimal.parseBiggerDecimalUnsafe(value)
 
-      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else JsonLong(longValue)
-    }
+    if (result.eq(null)) null else JsonBiggerDecimal(result)
+
+  }
 
   final def fromString(value: String): Option[JsonNumber] = {
     val result = BiggerDecimal.parseBiggerDecimalUnsafe(value)

--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -4,18 +4,41 @@ import io.circe.{ Json, JsonBigDecimal, JsonBiggerDecimal, JsonObject }
 import io.circe.numbers.{ BiggerDecimal, JsonNumberParser }
 import java.math.{ BigDecimal, BigInteger }
 import java.util.LinkedHashMap
-import jawn.{ Facade, FContext, SupportParser }
+import jawn.{ CharBasedParser, Facade, FContext, SupportParser, SyncParser }
+import scala.util.Try
 
 final object CirceSupportParser extends SupportParser[Json] {
+  final override def parseUnsafe(s: String): Json = new StringParser(s).parse
+  final override def parseFromString(s: String): Try[Json] = Try(new StringParser(s).parse)
+
+  private[this] final class Slice(s: String, start: Int, limit: Int) extends CharSequence {
+    final val length: Int = limit - start
+    final def charAt(i: Int): Char = s.charAt(start + i)
+    final def subSequence(i: Int, j: Int): CharSequence = new Slice(s, start + i, start + j)
+    final override def toString: String = s.substring(start, limit)
+  }
+
+  private[this] final class StringParser(s: String) extends SyncParser[Json] with CharBasedParser[Json] {
+    var line: Int = 0
+    final def column(i: Int): Int = i
+    final def newline(i: Int): Unit = { line += 1 }
+    final def reset(i: Int): Int = i
+    final def checkpoint(state: Int, i: Int, stack: List[FContext[Json]]): Unit = ()
+    final def at(i: Int): Char = s.charAt(i)
+    final def at(i: Int, j: Int): CharSequence = new Slice(s, i, j)
+    final def atEof(i: Int): Boolean = i == s.length
+    final def close(): Unit = ()
+  }
+
   private[this] val jsonNumberParser: JsonNumberParser[Json] = new JsonNumberParser[Json] {
-    def createNegativeZeroValue: Json = Json.JNumber(JsonBiggerDecimal(BiggerDecimal.fromDoubleUnsafe(-0.0)))
-    def createUnsignedZeroValue: Json = Json.fromLong(0)
-    def createLongValue(value: Long): Json = Json.fromLong(value)
-    def createBigDecimalValue(unscaled: BigInteger, scale: Int): Json =
+    final def createNegativeZeroValue: Json = Json.JNumber(JsonBiggerDecimal(BiggerDecimal.fromDoubleUnsafe(-0.0)))
+    final def createUnsignedZeroValue: Json = Json.fromLong(0)
+    final def createLongValue(value: Long): Json = Json.fromLong(value)
+    final def createBigDecimalValue(unscaled: BigInteger, scale: Int): Json =
       Json.JNumber(JsonBigDecimal(new BigDecimal(unscaled, scale)))
-    def createBiggerDecimalValue(unscaled: BigInteger, scale: BigInteger): Json =
+    final def createBiggerDecimalValue(unscaled: BigInteger, scale: BigInteger): Json =
       Json.JNumber(JsonBiggerDecimal(BiggerDecimal(unscaled, scale)))
-    def failureValue: Json = null
+    final def failureValue: Json = null
   }
 
   implicit final val facade: Facade[Json] = new Facade[Json] {
@@ -42,7 +65,7 @@ final object CirceSupportParser extends SupportParser[Json] {
       final def isObj: Boolean = false
     }
 
-    def objectContext(): FContext[Json] = new FContext[Json] {
+    final def objectContext(): FContext[Json] = new FContext[Json] {
       private[this] final var key: String = null
       private[this] final val m = new LinkedHashMap[String, Json]
 

--- a/modules/literal/src/main/scala/io/circe/literal/JsonLiteralMacros.scala
+++ b/modules/literal/src/main/scala/io/circe/literal/JsonLiteralMacros.scala
@@ -138,11 +138,7 @@ class JsonLiteralMacros(val c: blackbox.Context) {
       case ("jstring", Array(cls), Array(arg: CharSequence)) if cls == classOf[CharSequence] => toJsonString(arg)
       case ("jnum", Array(clsS, clsDecIndex, clsExpIndex), Array(s: CharSequence, decIndex, expIndex))
         if clsS == classOf[CharSequence] && clsDecIndex == classOf[Int] && clsExpIndex == classOf[Int] =>
-          if (decIndex.asInstanceOf[Int] < 0 && expIndex.asInstanceOf[Int] < 0) {
-            q"_root_.io.circe.Json.fromJsonNumber(_root_.io.circe.JsonNumber.fromIntegralStringUnsafe(${ s.toString }))"
-          } else {
-            q"_root_.io.circe.Json.fromJsonNumber(_root_.io.circe.JsonNumber.fromDecimalStringUnsafe(${ s.toString }))"
-          }
+          q"_root_.io.circe.Json.fromJsonNumber(_root_.io.circe.JsonNumber.fromString(${ s.toString }).get)"
     }
   }
 

--- a/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/IntegralString.scala
+++ b/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/IntegralString.scala
@@ -3,8 +3,7 @@ package io.circe.numbers.testing
 import org.scalacheck.{ Arbitrary, Gen }
 
 /**
- * An integral string with an optional leading minus sign and between 1 and 25
- * digits (inclusive).
+ * An integral JSON number represented as a string.
  */
 final case class IntegralString(value: String)
 
@@ -14,10 +13,10 @@ final object IntegralString {
       sign    <- Gen.oneOf("", "-")
       nonZero <- Gen.choose(1, 9).map(_.toString)
       /**
-       * We want between 1 and 25 digits, with extra weight on the numbers of
+       * We want between 1 and 256 digits, with extra weight on the numbers of
        * digits around the size of `Long.MaxValue`.
        */
-      count   <- Gen.chooseNum(0, 24, 17, 18, 19)
+      count   <- Gen.chooseNum(0, 255, 17, 18, 19)
       rest    <- Gen.buildableOfN[String, Char](count, Gen.numChar)
     } yield IntegralString(s"$sign$nonZero$rest")
   )

--- a/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/JsonNumberString.scala
+++ b/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/JsonNumberString.scala
@@ -3,12 +3,12 @@ package io.circe.numbers.testing
 import org.scalacheck.{ Arbitrary, Gen }
 
 /**
- * An arbitrary JSON number, represented as a string.
+ * A JSON number represented as a string.
  */
 final case class JsonNumberString(value: String)
 
 final object JsonNumberString {
-  implicit val arbitraryJsonNumberString: Arbitrary[JsonNumberString] = Arbitrary(
+  implicit final val arbitraryJsonNumberString: Arbitrary[JsonNumberString] = Arbitrary(
     for {
       sign <- Gen.oneOf("", "-")
       integral <- Gen.oneOf(

--- a/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/ZeroString.scala
+++ b/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/ZeroString.scala
@@ -1,0 +1,34 @@
+package io.circe.numbers.testing
+
+import org.scalacheck.{ Arbitrary, Gen }
+
+/**
+ * A JSON number with value zero, represented as a string.
+ */
+final case class ZeroString(value: String) {
+  final def isNegative: Boolean = value.charAt(0) == '-'
+}
+
+final object ZeroString {
+  /**
+   * The exponent will either be an integral number or some number of zeroes.
+   */
+  private[this] val exponentPart: Gen[String] = for {
+    e <- Gen.oneOf("e", "E")
+    value <- Gen.oneOf(
+      IntegralString.arbitraryIntegralString.arbitrary.map(_.value),
+      for {
+        sign  <- Gen.oneOf("", "-")
+        zeros <- Gen.chooseNum(1, 255).map("0" * _)
+      } yield s"$sign$zeros"
+    )
+  } yield s"$e$value"
+
+  implicit final val arbitraryZeroString: Arbitrary[ZeroString] = Arbitrary(
+    for {
+      sign       <- Gen.oneOf("", "-")
+      fractional <- Gen.option(Gen.chooseNum(1, 256).map(count => "." + ("0" * count))).map(_.getOrElse(""))
+      exponent   <- Gen.option(exponentPart).map(_.getOrElse(""))
+    } yield ZeroString(s"${ sign }0$fractional$exponent")
+  )
+}

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -3,7 +3,6 @@ package io.circe.numbers
 import java.io.Serializable
 import java.lang.StringBuilder
 import java.math.{ BigDecimal, BigInteger }
-import scala.annotation.switch
 
 /**
  * Represents a large decimal number.
@@ -192,64 +191,47 @@ final object BiggerDecimal {
     final override def toString: String = "-0"
   }
 
-  private[this] def fromUnscaledAndScale(unscaled: BigInteger, scale: Long): BiggerDecimal =
-    if (unscaled == BigInteger.ZERO) UnsignedZero else {
-      var current = unscaled
-      var depth = scale
+  final def apply(unscaled: BigInteger, scale: BigInteger): BiggerDecimal = new SigAndExp(unscaled, scale)
 
-      var divAndRem = current.divideAndRemainder(BigInteger.TEN)
-
-      while (divAndRem(1) == BigInteger.ZERO) {
-        current = divAndRem(0)
-        depth -= 1L
-        divAndRem = current.divideAndRemainder(BigInteger.TEN)
-      }
-
-      new SigAndExp(current, BigInteger.valueOf(depth))
-    }
-
-  def fromBigInteger(i: BigInteger): BiggerDecimal = fromUnscaledAndScale(i, 0L)
-  def fromBigDecimal(d: BigDecimal): BiggerDecimal = fromUnscaledAndScale(d.unscaledValue, d.scale.toLong)
-  def fromLong(d: Long): BiggerDecimal = fromUnscaledAndScale(BigInteger.valueOf(d), 0L)
+  final def fromLong(value: Long): BiggerDecimal = parser.fromLong(value)
+  final def fromBigInteger(value: BigInteger): BiggerDecimal = parser.fromBigInteger(value)
+  final def fromBigDecimal(value: BigDecimal): BiggerDecimal = parser.fromBigDecimal(value)
 
   /**
    * Convert a [[scala.Double]] into a [[BiggerDecimal]].
    *
-   * @note This method assumes that the input is not `NaN` or infinite, and will throw a
-   *       `NumberFormatException` if that assumption does not hold.
+   * @note This method assumes that the input is not `NaN` or infinite, and will return `null` if
+   *       that assumption does not hold.
    */
-  def fromDoubleUnsafe(d: Double): BiggerDecimal = if (java.lang.Double.compare(d, -0.0) == 0) {
-    NegativeZero
-  } else fromBigDecimal(BigDecimal.valueOf(d))
-
-  def fromFloat(f: Float): BiggerDecimal = if (java.lang.Float.compare(f, -0.0f) == 0) {
-    NegativeZero
-  } else fromBigDecimal(new BigDecimal(java.lang.Float.toString(f)))
-
-  private[this] final val MaxLongString = "9223372036854775807"
-  private[this] final val MinLongString = "-9223372036854775808"
+  def fromDoubleUnsafe(value: Double): BiggerDecimal = parser.fromDouble(value)
 
   /**
-   * Is a string representing an integral value a valid [[scala.Long]]?
+   * Convert a [[scala.Float]] into a [[BiggerDecimal]].
    *
-   * Note that this method assumes that the input is a valid integral JSON
-   * number string (e.g. that it does have leading zeros).
+   * @note This method assumes that the input is not `NaN` or infinite, and will return `null` if
+   *       that assumption does not hold.
    */
-  def integralIsValidLong(s: String): Boolean = {
-    val bound = if (s.charAt(0) == '-') MinLongString else MaxLongString
+  def fromFloatUnsafe(value: Float): BiggerDecimal = parser.fromFloat(value)
 
-    s.length < bound.length || (s.length == bound.length && s.compareTo(bound) <= 0)
+  private[this] final val parser: JsonNumberParser[BiggerDecimal] = new JsonNumberParser[BiggerDecimal] {
+    def createNegativeZeroValue: BiggerDecimal = NegativeZero
+    def createUnsignedZeroValue: BiggerDecimal = UnsignedZero
+    def createLongValue(value: Long): BiggerDecimal = {
+      var current = value
+      var depth = 0
+
+      while (current % 10 == 0) {
+        current /= 10
+        depth -= 1
+      }
+
+      apply(BigInteger.valueOf(current), BigInteger.valueOf(depth.toLong))
+    }
+    def createBigDecimalValue(unscaled: BigInteger, scale: Int): BiggerDecimal =
+      apply(unscaled, BigInteger.valueOf(scale.toLong))
+    def createBiggerDecimalValue(unscaled: BigInteger, scale: BigInteger): BiggerDecimal = apply(unscaled, scale)
+    def failureValue: BiggerDecimal = null
   }
-
-  private[this] final val FAILED = 0
-  private[this] final val START = 1
-  private[this] final val AFTER_ZERO = 2
-  private[this] final val AFTER_DOT = 3
-  private[this] final val FRACTIONAL = 4
-  private[this] final val AFTER_E = 5
-  private[this] final val AFTER_EXP_SIGN = 6
-  private[this] final val EXPONENT = 7
-  private[this] final val INTEGRAL = 8
 
   /**
    * Parse string into [[BiggerDecimal]].
@@ -257,131 +239,9 @@ final object BiggerDecimal {
   def parseBiggerDecimal(input: String): Option[BiggerDecimal] = Option(parseBiggerDecimalUnsafe(input))
 
   /**
-   * Parse string into [[BiggerDecimal]], returning `null` on parsing failure.
+   * Parse string into [[BiggerDecimal]], returning `null` on parsing failureValueure.
    */
-  def parseBiggerDecimalUnsafe(input: String): BiggerDecimal = {
-    val len = input.length
-
-    if (len == 0) null else {
-      var zeros = 0
-      var decIndex = -1
-      var expIndex = -1
-      var i = if (input.charAt(0) == '-') 1 else 0
-      var c = input.charAt(i)
-
-      var state = if (input.charAt(i) != '0') START else {
-        i = i + 1
-        AFTER_ZERO
-      }
-
-      while (i < len && state != FAILED) {
-        val c = input.charAt(i)
-
-        (state: @switch) match {
-          case START =>
-            if (c >= '1' && c <= '9') {
-              state = INTEGRAL
-            } else {
-              state = FAILED
-            }
-          case AFTER_ZERO =>
-            if (c == '.') {
-              state = AFTER_DOT
-            } else if (c == 'e' || c == 'E') {
-              state = AFTER_E
-            } else {
-              state = FAILED
-            }
-          case INTEGRAL =>
-            if (c == '0') {
-              zeros = zeros + 1
-              state = INTEGRAL
-            } else if (c >= '1' && c <= '9') {
-              zeros = 0
-              state = INTEGRAL
-            } else if (c == '.') {
-              state = AFTER_DOT
-            } else if (c == 'e' || c == 'E') {
-              state = AFTER_E
-            } else {
-              state = FAILED
-            }
-          case AFTER_DOT =>
-            decIndex = i - 1
-            if (c == '0') {
-              zeros = zeros + 1
-              state = FRACTIONAL
-            } else if (c >= '1' && c <= '9') {
-              zeros = 0
-              state = FRACTIONAL
-            } else {
-              state = FAILED
-            }
-          case AFTER_E =>
-            expIndex = i - 1
-            if (c >= '0' && c <= '9') {
-              state = EXPONENT
-            } else if (c == '+' || c == '-') {
-              state = AFTER_EXP_SIGN
-            } else {
-              state = FAILED
-            }
-          case FRACTIONAL =>
-            if (c == '0') {
-              zeros = zeros + 1
-              state = FRACTIONAL
-            } else if (c >= '1' && c <= '9') {
-              zeros = 0
-              state = FRACTIONAL
-            } else if (c == 'e' || c == 'E') {
-              state = AFTER_E
-            } else {
-              state = FAILED
-            }
-          case AFTER_EXP_SIGN =>
-            if (c >= '0' && c <= '9') {
-              state = EXPONENT
-            } else {
-              state = FAILED
-            }
-          case EXPONENT =>
-            if (c >= '0' && c <= '9') {
-              state = EXPONENT
-            } else {
-              state = FAILED
-            }
-        }
-
-        i += 1
-      }
-
-      if (state == FAILED || state == AFTER_DOT || state == AFTER_E || state == AFTER_EXP_SIGN) null else {
-        val integral = if (decIndex >= 0) input.substring(0, decIndex) else {
-          if (expIndex == -1) input else {
-            input.substring(0, expIndex)
-          }
-        }
-
-        val fractional = if (decIndex == -1) "" else {
-          if (expIndex == -1) input.substring(decIndex + 1) else {
-            input.substring(decIndex + 1, expIndex)
-          }
-        }
-
-        val unscaledString = integral + fractional
-        val unscaled = new BigInteger(unscaledString.substring(0, unscaledString.length - zeros))
-
-        if (unscaled == BigInteger.ZERO) {
-          if (input.charAt(0) == '-') NegativeZero else UnsignedZero
-        } else {
-          val rescale = BigInteger.valueOf((fractional.length - zeros).toLong)
-          val scale = if (expIndex == -1) rescale else {
-            rescale.subtract(new BigInteger(input.substring(expIndex + 1)))
-          }
-
-          new SigAndExp(unscaled, scale)
-        }
-      }
-    }
+  def parseBiggerDecimalUnsafe(input: String): BiggerDecimal = if (!parser.validate(input)) null else {
+    parser.parseUnsafe(input)
   }
 }

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/JsonNumberParser.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/JsonNumberParser.scala
@@ -1,0 +1,477 @@
+package io.circe.numbers
+
+import java.lang.StringBuilder
+import java.math.{ BigDecimal, BigInteger }
+
+/**
+ * A parser for JSON numbers that produces values of type `J`.
+ */
+abstract class JsonNumberParser[J] {
+  /**
+   * Create a `J` value representing negative zero.
+   */
+  def createNegativeZeroValue: J
+
+  /**
+   * Create a `J` value representing zero.
+   */
+  def createUnsignedZeroValue: J
+
+  /**
+   * Create a `J` value from a [[scala.Long]].
+   *
+   * This method will be called if and only if the input is a valid non-zero [[scala.Long]] value.
+   * The parser considers this to be the case even if the input contains a decimal point (followed
+   * only by zeroes) or an exponential part.
+   */
+  def createLongValue(value: Long): J
+
+  /**
+   * Create a `J` value from a `java.math.BigInteger` representing the unscaled value and a
+   * [[scala.Long]] representing the scale.
+   *
+   * This method will not ever be called if the input is zero or a valid [[scala.Long]]. It follows
+   * the convention of `java.math.BigDecimal`, where the scale is the power of ten negated.
+   * Additionally the scale will always be as small as possible (i.e. the unscaled value will not
+   * end with any zeroes).
+   */
+  def createBigDecimalValue(unscaled: BigInteger, scale: Int): J
+
+  /**
+   * Create a `J` value from a `BigInteger` representing the unscaled value and a
+   * `java.math.BigInteger` representing the scale.
+   *
+   * This method will not ever be called if the input is zero or a valid [[scala.Long]], or if the
+   * scale fits in a [[scala.Int]]. It follows the convention of `java.math.BigDecimal`, where the
+   * scale is the power of ten negated.
+   */
+  def createBiggerDecimalValue(unscaled: BigInteger, scale: BigInteger): J
+
+  /**
+   * Create a `J` value representing a number parsing failure (which will often be `null`).
+   */
+  def failureValue: J
+
+  /**
+   * Parse a `CharSequence` representing a JSON number.
+   */
+  final def parse(input: CharSequence): J = if (validate(input)) parseUnsafe(input) else failureValue
+
+  /**
+   * Validate that a `CharSequence` is a valid JSON number.
+   *
+   * Adapted from the implementation in Jawn.
+   */
+  final def validate(input: CharSequence): Boolean = {
+    val length = input.length
+    var i = 0
+
+    if (length == i) return false
+    var c = input.charAt(i)
+
+    if (c == '-') {
+      i += 1
+      if (length == i) return false
+      c = input.charAt(i)
+    }
+
+    if (c == '0') {
+      i += 1
+      if (length == i) return true
+      c = input.charAt(i)
+    } else if ('1' <= c && c <= '9') {
+      while ('0' <= c && c <= '9') {
+        i += 1
+        if (length == i) return true
+        c = input.charAt(i)
+      }
+    } else return false
+
+    if (c == '.') {
+      i += 1
+      if (length == i) return false
+      c = input.charAt(i)
+
+      if ('0' <= c && c <= '9') {
+        while ('0' <= c && c <= '9') {
+          i += 1
+          if (length == i) return true
+          c = input.charAt(i)
+        }
+      } else return false
+    }
+
+    if (c == 'e' || c == 'E') {
+      i += 1
+      if (length == i) return false
+      c = input.charAt(i)
+
+      if (c == '+' || c == '-') {
+        i += 1
+        if (length == i) return false
+        c = input.charAt(i)
+      }
+
+      if ('0' <= c && c <= '9') {
+        while ('0' <= c && c <= '9') {
+          i += 1
+          if (length == i) return true
+          c = input.charAt(i)
+        }
+      } else return false
+    }
+
+    false
+  }
+
+  /**
+   * Parse a `CharSequence` representing a JSON number.
+   *
+   * If the input is not a valid JSON number, the result is undefined (the method will never throw
+   * an exception, but may return nonsense).
+   */
+  final def parseUnsafe(input: CharSequence): J = {
+    val length: Int = input.length
+    var decIndex: Int = -1
+    var expIndex: Int = -1
+    var i: Int = 0
+
+    while (i < length && expIndex == -1) {
+      val c = input.charAt(i)
+      if (c == '.') decIndex = i else if (c == 'e' || c == 'E') expIndex = i
+      i += 1
+    }
+
+    parseUnsafeWithIndices(input, decIndex, expIndex)
+  }
+
+  /**
+   * Parse a `CharSequence` representing a JSON number where the indices of a decimal point and
+   * an `e` or `E` introducing an exponent (if any) are known.
+   *
+   * If the decimal point or `e` are not present in the input, the value of the appropriate index
+   * must be `-1` (otherwise the result is undefined).
+   *
+   * If the input is not a valid JSON number, the result is undefined (the method will never throw
+   * an exception, but may return nonsense).
+   */
+  final def parseUnsafeWithIndices(input: CharSequence, decIndex: Int, expIndex: Int): J = {
+    val length: Int = input.length
+    val lastIndex: Int = length - 1
+
+    if (length == 0 || lastIndex <= decIndex || lastIndex <= expIndex) failureValue else {
+      val sigNeg: Boolean = input.charAt(0) == '-'
+      val sigDigStart: Int = if (sigNeg) 1 else 0
+      var sigDigEnd: Int = if (expIndex >= 0) expIndex else length
+      var expAdjust: Int = if (decIndex < 0) 0 else sigDigEnd - (decIndex + 1)
+
+      while (sigDigEnd - 1 > sigDigStart && (input.charAt(sigDigEnd - 1) == '0' || sigDigEnd == decIndex + 1)) {
+        sigDigEnd -= 1
+        if (sigDigEnd != decIndex) expAdjust -= 1
+      }
+
+      val sigDigSkip = if (decIndex < sigDigEnd) decIndex else -1
+
+      var expNeg: Boolean = false
+      var expDigStart: Int = expIndex + 1
+
+      if (expIndex >= 0) {
+        val c = input.charAt(expIndex + 1)
+
+        if (c == '-') {
+          expNeg = true
+          expDigStart = expDigStart + 1
+        } else if (c == '+') {
+          expDigStart = expDigStart + 1
+        }
+
+        while (expDigStart < lastIndex && input.charAt(expDigStart) == '0') {
+          expDigStart += 1
+        }
+      }
+
+      if (sigDigEnd - sigDigStart == 1 && input.charAt(sigDigStart) == '0') {
+        if (sigNeg) createNegativeZeroValue else createUnsignedZeroValue
+      } else {
+        parse0(input, sigNeg, sigDigStart, sigDigEnd, sigDigSkip, expNeg, expDigStart, length, expAdjust)
+      }
+    }
+  }
+
+  /**
+   * Create a `J` value from a [[scala.Long]].
+   */
+  final def fromLong(value: Long): J = if (value == 0) createUnsignedZeroValue else createLongValue(value)
+
+  /**
+   * Create a `J` value from a [[scala.Double]].
+   */
+  final def fromDouble(value: Double): J = if (java.lang.Double.compare(value, 0.0) == 0) {
+    createUnsignedZeroValue
+  } else if (java.lang.Double.compare(value, -0.0) == 0) {
+    createNegativeZeroValue
+  } else if (java.lang.Double.isNaN(value) || java.lang.Double.isInfinite(value)) {
+    failureValue
+  } else {
+    fromBigDecimal(BigDecimal.valueOf(value))
+  }
+
+  /**
+   * Create a `J` value from a [[scala.Float]].
+   */
+  final def fromFloat(value: Float): J = if (java.lang.Float.compare(value, 0.0f) == 0) {
+    createUnsignedZeroValue
+  } else if (java.lang.Float.compare(value, -0.0f) == 0) {
+    createNegativeZeroValue
+  } else if (java.lang.Float.isNaN(value) || java.lang.Float.isInfinite(value)) {
+    failureValue
+  } else {
+    parseUnsafe(java.lang.Float.toString(value))
+  }
+
+  private[this] val BigIntegerMinLong = BigInteger.valueOf(java.lang.Long.MIN_VALUE)
+  private[this] val BigIntegerMaxLong = BigInteger.valueOf(java.lang.Long.MAX_VALUE)
+
+  private[this] def isValidLong(value: BigInteger): Boolean =
+    value.compareTo(BigIntegerMinLong) >= 0 && value.compareTo(BigIntegerMaxLong) <= 0
+
+  private[this] def fromUnscaledAndScale(unscaled: BigInteger, scale: Int): J =
+    if (unscaled == BigInteger.ZERO) {
+      createUnsignedZeroValue
+    } else {
+      if (scale <= 0 && scale >= -18 && isValidLong(unscaled)) {
+        var asLong = unscaled.longValue
+        var depth = scale
+
+        if (asLong < 0L) {
+          while (depth < 0 && asLong >= limitMult) {
+            asLong *= 10L
+            depth += 1
+          }
+        } else {
+          while (depth < 0 && asLong <= -limitMult) {
+            asLong *= 10L
+            depth += 1
+          }
+        }
+
+        if (depth == 0) return createLongValue(asLong)
+      }
+
+      var current = unscaled
+      var depth = scale.toLong
+
+      var divAndRem = current.divideAndRemainder(BigInteger.TEN)
+
+      while (divAndRem(1) == BigInteger.ZERO) {
+        current = divAndRem(0)
+        depth -= 1L
+        divAndRem = current.divideAndRemainder(BigInteger.TEN)
+
+        if (depth == 0 && isValidLong(current)) {
+          return createLongValue(current.longValue)
+        }
+      }
+
+      if (depth >= java.lang.Integer.MIN_VALUE.toLong) {
+        createBigDecimalValue(current, depth.toInt)
+      } else {
+        createBiggerDecimalValue(current, BigInteger.valueOf(depth))
+      }
+    }
+
+  /**
+   * Create a `J` value from a `java.math.BigDecimal`.
+   */
+  final def fromBigDecimal(value: BigDecimal): J = fromUnscaledAndScale(value.unscaledValue, value.scale)
+
+  /**
+   * Create a `J` value from a `java.math.BigInteger`.
+   */
+  final def fromBigInteger(value: BigInteger): J = fromUnscaledAndScale(value, 0)
+
+  private[this] final def parse0(
+    input: CharSequence,
+    sigNeg: Boolean,
+    sigDigStart: Int,
+    sigDigEnd: Int,
+    sigDigSkip: Int,
+    expNeg: Boolean,
+    expDigStart: Int,
+    expDigEnd: Int,
+    expAdjust: Int
+  ): J = {
+    var sigLong: Long = 0L
+    var sigBig: BigInteger = null
+    var expLong: Long = 0L
+    var expBig: BigInteger = null
+
+    if (sigDigEnd - sigDigStart > 19) {
+      sigBig = parseBigInteger(input, sigDigStart, sigDigEnd, sigDigSkip, sigNeg)
+    } else {
+      sigLong = parseLong(input, sigDigStart, sigDigEnd, sigDigSkip, sigNeg)
+
+      if (sigLong == 0L) {
+        sigBig = parseBigInteger(input, sigDigStart, sigDigEnd, sigDigSkip, sigNeg)
+        if (sigBig == null) return failureValue
+      }
+    }
+
+    if (expDigStart > 0 && (expDigEnd - expDigStart != 1 || input.charAt(expDigStart) != '0')) {
+      if (expDigEnd - expDigStart > 19) {
+        expBig = parseBigInteger(input, expDigStart, expDigEnd, -1, expNeg)
+        if (expBig == null) return failureValue else {
+          expBig = expBig.negate
+        }
+      } else {
+        expLong = parseLong(input, expDigStart, expDigEnd, -1, !expNeg)
+
+        if (expLong == 0L) {
+          expBig = parseBigInteger(input, expDigStart, expDigEnd, -1, expNeg)
+          if (expBig == null) return failureValue else {
+            expBig = expBig.negate
+          }
+        }
+      }
+    }
+
+    if (sigBig.eq(null) && expBig.eq(null) && expLong == 0L && expAdjust == 0) {
+      createLongValue(sigLong)
+    } else {
+      parse1(sigLong, sigBig, expLong, expBig, expAdjust)
+    }
+  }
+
+  private[this] final def parse1(
+    sigLong: Long,
+    sigBig: BigInteger,
+    expLong: Long,
+    expBig: BigInteger,
+    expAdjust: Int
+  ): J = {
+    var expAdjustedInt: Int = 0
+    var expAdjustedBig: BigInteger = expBig
+
+    if (expBig.ne(null)) {
+      expAdjustedBig = expBig.add(BigInteger.valueOf(expAdjust.toLong))
+    } else if (expAdjust != 0 || expLong != 0L) {
+      if (
+        (expAdjust > 0 && expLong > (java.lang.Integer.MAX_VALUE - expAdjust).toLong) ||
+        (expAdjust < 0 && expLong < (java.lang.Integer.MIN_VALUE - expAdjust).toLong) ||
+        (expAdjust == 0 && expLong > java.lang.Integer.MAX_VALUE || expLong < java.lang.Integer.MIN_VALUE)
+      ) {
+        expAdjustedBig = BigInteger.valueOf(expLong).add(BigInteger.valueOf(expAdjust.toLong))
+      } else {
+        expAdjustedInt = expLong.toInt + expAdjust
+      }
+    }
+
+    parse2(sigLong, sigBig, expAdjustedInt, expAdjustedBig)
+  }
+
+  private[this] final def parse2(
+    sigLong: Long,
+    sigBig: BigInteger,
+    expInt: Int,
+    expBig: BigInteger
+  ): J = {
+    if (expBig.ne(null)) {
+      createBiggerDecimalValue(if (sigBig.ne(null)) sigBig else BigInteger.valueOf(sigLong), expBig)
+    } else if (sigBig.ne(null)) {
+      createBigDecimalValue(sigBig, expInt)
+    } else if (expInt > 0) {
+      createBigDecimalValue(BigInteger.valueOf(sigLong), expInt)
+    } else if (expInt == 0) {
+      createLongValue(sigLong)
+    } else {
+      var sigLongValue = sigLong
+      var expIntValue = expInt
+
+      if (sigLongValue > 0L) {
+        while (expIntValue < 0 && sigLongValue <= -limitMult) {
+          sigLongValue *= 10L
+          expIntValue += 1
+        }
+      } else {
+        while (expIntValue < 0 && sigLongValue >= limitMult) {
+          sigLongValue *= 10L
+          expIntValue += 1
+        }
+      }
+
+      if (expIntValue < 0) {
+        createBigDecimalValue(BigInteger.valueOf(sigLong), expInt)
+      } else {
+        createLongValue(sigLongValue)
+      }
+    }
+  }
+
+  private[this] final val posLimit = -java.lang.Long.MAX_VALUE
+  private[this] final val negLimit = java.lang.Long.MIN_VALUE
+  private[this] final val limitMult = posLimit / 10L
+
+  private[this] final def parseLong(
+    input: CharSequence,
+    start: Int,
+    end: Int,
+    skip: Int,
+    negate: Boolean
+  ): Long = {
+    val limit: Long = if (negate) negLimit else posLimit
+
+    var result: Long = 0L
+    var i: Int = start
+
+    while (i < end) {
+      val digit = input.charAt(i).toInt - 48
+
+      if (i - start < 18) {
+        result = result * 10L - digit
+      } else {
+        if (result < limitMult) {
+          return 0L
+        } else {
+          result *= 10L
+
+          if (digit > 0) {
+            if (result < limit + digit) {
+              return 0L
+            } else {
+              result -= digit
+            }
+          }
+        }
+      }
+
+      i += 1
+      if (i == skip) {
+        i += 1
+      }
+    }
+
+    if (negate) result else -result
+  }
+
+  private[this] final def parseBigInteger(
+    input: CharSequence,
+    start: Int,
+    end: Int,
+    skip: Int,
+    negate: Boolean
+  ): BigInteger = try {
+    val substring = if (skip < 0) {
+      input.subSequence(start, end).toString
+    } else {
+      val builder = new StringBuilder(input)
+      builder.deleteCharAt(skip)
+      builder.substring(start, end - 1)
+    }
+
+    val result = new BigInteger(substring)
+
+    if (negate) result.negate else result
+  } catch {
+    case _: NumberFormatException => return null
+  }
+}

--- a/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -197,10 +197,6 @@ class BiggerDecimalSuite extends FlatSpec with GeneratorDrivenPropertyChecks {
     assert(BiggerDecimal.fromBigInteger(value.underlying).toBigInteger === Some(value.underlying))
   }
   
-  "integralIsValidLong" should "agree with toLong" in forAll { (input: IntegralString) =>
-    assert(BiggerDecimal.integralIsValidLong(input.value) === Try(input.value.toLong).isSuccess)
-  }
-
   "parseBiggerDecimal" should "parse any BigDecimal string" in forAll { (value: SBigDecimal) =>
     val d = BiggerDecimal.parseBiggerDecimal(value.toString)
 

--- a/modules/numbers/shared/src/test/scala/io/circe/numbers/JsonNumberParserSuite.scala
+++ b/modules/numbers/shared/src/test/scala/io/circe/numbers/JsonNumberParserSuite.scala
@@ -166,13 +166,13 @@ class JsonNumberParserSuite extends FunSpec with Matchers with GeneratorDrivenPr
         it("on zero") {
           val result = SimpleJsonNumberParser.fromDouble(0.0)
 
-          result shouldBe SimpleJsonNumberParser.parse(0.0.toString)
+          result shouldBe SimpleJsonNumberParser.parse("0.0")
         }
 
         it("on negative zero") {
           val result = SimpleJsonNumberParser.fromDouble(-0.0)
 
-          result shouldBe SimpleJsonNumberParser.parse(-0.0.toString)
+          result shouldBe SimpleJsonNumberParser.parse("-0.0")
         }
       }
 
@@ -204,13 +204,13 @@ class JsonNumberParserSuite extends FunSpec with Matchers with GeneratorDrivenPr
         it("on zero") {
           val result = SimpleJsonNumberParser.fromFloat(0.0f)
 
-          result shouldBe SimpleJsonNumberParser.parse(0.0f.toString)
+          result shouldBe SimpleJsonNumberParser.parse("0.0")
         }
 
         it("on negative zero") {
           val result = SimpleJsonNumberParser.fromFloat(-0.0f)
 
-          result shouldBe SimpleJsonNumberParser.parse(-0.0f.toString)
+          result shouldBe SimpleJsonNumberParser.parse("-0.0")
         }
       }
 

--- a/modules/numbers/shared/src/test/scala/io/circe/numbers/JsonNumberParserSuite.scala
+++ b/modules/numbers/shared/src/test/scala/io/circe/numbers/JsonNumberParserSuite.scala
@@ -1,0 +1,258 @@
+package io.circe.numbers
+
+import io.circe.numbers.testing.{ IntegralString, JsonNumberString, ZeroString }
+import java.math.{ BigDecimal => JavaBigDecimal, BigInteger }
+import org.scalatest.{ FunSpec, Matchers }
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import scala.util.Try
+
+class JsonNumberParserSuite extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(
+    minSuccessful = 1000,
+    sizeRange = 10000
+  )
+
+  private def doubleEqv(x: Double, y: Double): Boolean = java.lang.Double.compare(x, y) == 0
+  private def trailingZeros(value: BigInt): Int = value.toString.reverse.takeWhile(_ == '0').size
+  private def significantDigits(value: BigInt): Int = value.toString.size - trailingZeros(value)
+
+  /**
+   * ScalaCheck generates `BigDecimal` values that can't be round-tripped through `toString`.
+   */
+  private def parseBigDecimalSafe(input: String): Option[BigDecimal] =
+    Try(new JavaBigDecimal(input.toString)).toOption.map(new BigDecimal(_))
+
+  /**
+   * This is a workaround for a Scala.js bug that causes `BigDecimal` values with sufficiently large
+   * exponents to be printed with negative exponents.
+   *
+   * The filter below will have no effect on JVM tests since the condition is clearly nonsense.
+   */
+  private def isBadJsBigDecimal(value: BigDecimal): Boolean =
+    value.abs > BigDecimal(1) && value.toString.contains("E-")
+
+  sealed trait SimpleJsonNumber
+  case object NegativeZero extends SimpleJsonNumber
+  case object UnsignedZero extends SimpleJsonNumber
+  case class JsonLong(value: Long) extends SimpleJsonNumber
+  case class JsonBigDecimal(unscaled: BigInteger, scale: Int) extends SimpleJsonNumber
+  case class JsonBiggerDecimal(unscaled: BigInteger, scale: BigInteger) extends SimpleJsonNumber
+
+  object SimpleJsonNumberParser extends JsonNumberParser[Option[SimpleJsonNumber]] {
+    def createNegativeZeroValue: Option[SimpleJsonNumber] = Some(NegativeZero)
+    def createUnsignedZeroValue: Option[SimpleJsonNumber] = Some(UnsignedZero)
+    def createLongValue(value: Long): Option[SimpleJsonNumber] = Some(JsonLong(value))
+    def createBigDecimalValue(unscaled: BigInteger, scale: Int): Option[SimpleJsonNumber] =
+      Some(JsonBigDecimal(unscaled, scale))
+
+    def createBiggerDecimalValue(unscaled: BigInteger, scale: BigInteger): Option[SimpleJsonNumber] =
+      Some(JsonBiggerDecimal(unscaled, scale))
+
+    def failureValue: Option[SimpleJsonNumber] = None
+  }
+
+  describe("JsonNumberParser") {
+    describe("parse") {
+      describe("should parse") {
+        it("any valid JSON number") {
+          forAll { (input: JsonNumberString) =>
+            SimpleJsonNumberParser.parse(input.value) shouldBe defined
+          }
+        }
+
+        it("any valid integral JSON number") {
+          forAll { (input: IntegralString) =>
+            val result = SimpleJsonNumberParser.parse(input.value)
+
+            result.get match {
+              case NegativeZero => ()
+              case UnsignedZero => ()
+              case JsonLong(_) => ()
+              case JsonBigDecimal(_, scale) => scale should be <= 0
+              case JsonBiggerDecimal(_, scale) => scale.signum should be <= 0
+            }
+          }
+        }
+
+        it("valid JSON zeros as zeros") {
+          forAll { (input: ZeroString) =>
+            val result = SimpleJsonNumberParser.parse(input.value)
+            val expected = if (input.isNegative) NegativeZero else UnsignedZero
+
+            result should contain (expected)
+          }
+        }
+      }
+
+      describe("should fail") {
+        it("on empty strings") {
+          SimpleJsonNumberParser.parse("") shouldBe empty
+        }
+
+        it("on a single negative siqn") {
+          SimpleJsonNumberParser.parse("-") shouldBe empty
+        }
+
+        it("on garbage") {
+          forAll { (input: String) =>
+            SimpleJsonNumberParser.parse(s"${ input }x") shouldBe empty
+          }
+        }
+      }
+    }
+
+    describe("parseUnsafe") {
+      it("should never throw exceptions") {
+        forAll { (input: String) =>
+          SimpleJsonNumberParser.parseUnsafe(input)
+        }
+      }
+
+      it("should fail on 1e922337203685477580x") {
+        SimpleJsonNumberParser.parseUnsafe("1e922337203685477580x") shouldBe empty
+      }
+    }
+
+    describe("parseUnsafeWithIndices") {
+      it("should never throw exceptions") {
+        forAll { (input: String, decIndex: Int, expIndex: Int) =>
+          SimpleJsonNumberParser.parseUnsafeWithIndices(input, decIndex, expIndex)
+        }
+      }
+
+      it("should never throw exceptions on known problematic inputs") {
+        SimpleJsonNumberParser.parseUnsafeWithIndices(" ", -1, 0)
+      }
+
+      it("should fail on invalid indices") {
+        forAll { (input: JsonNumberString) =>
+          SimpleJsonNumberParser.parseUnsafeWithIndices(input.value, -1, input.value.length) shouldBe empty
+          SimpleJsonNumberParser.parseUnsafeWithIndices(input.value, input.value.length, -1) shouldBe empty
+        }
+      }
+    }
+
+    describe("createLongValue") {
+      it("should always be called for non-zero Long values") {
+        forAll { (value: Long) =>
+          val result = SimpleJsonNumberParser.parse(value.toString)
+          val expected = if (value == 0L) UnsignedZero else JsonLong(value)
+
+          result should contain (expected)
+        }
+      }
+    }
+
+    describe("fromLong") {
+      it("should agree with parse") {
+        forAll { (value: Long) =>
+          val result = SimpleJsonNumberParser.fromLong(value)
+
+          result shouldBe SimpleJsonNumberParser.parse(value.toString)
+        }
+      }
+    }
+
+    describe("fromDouble") {
+      describe("should agree with parse") {
+        it("on arbitrary values") {
+          forAll { (value: Double) =>
+            val result = SimpleJsonNumberParser.fromDouble(value)
+
+            result shouldBe SimpleJsonNumberParser.parse(value.toString)
+          }
+        }
+
+        it("on zero") {
+          val result = SimpleJsonNumberParser.fromDouble(0.0)
+
+          result shouldBe SimpleJsonNumberParser.parse(0.0.toString)
+        }
+
+        it("on negative zero") {
+          val result = SimpleJsonNumberParser.fromDouble(-0.0)
+
+          result shouldBe SimpleJsonNumberParser.parse(-0.0.toString)
+        }
+      }
+
+      describe("should reject") {
+        it("NaN") {
+          SimpleJsonNumberParser.fromDouble(Double.NaN) shouldBe empty
+        }
+
+        it("positive infinity") {
+          SimpleJsonNumberParser.fromDouble(Double.PositiveInfinity) shouldBe empty
+        }
+
+        it("negative infinity") {
+          SimpleJsonNumberParser.fromDouble(Double.NegativeInfinity) shouldBe empty
+        }
+      }
+    }
+
+    describe("fromFloat") {
+      describe("should agree with parse") {
+        it("on arbitrary values") {
+          forAll { (value: Float) =>
+            val result = SimpleJsonNumberParser.fromFloat(value)
+
+            result shouldBe SimpleJsonNumberParser.parse(value.toString)
+          }
+        }
+
+        it("on zero") {
+          val result = SimpleJsonNumberParser.fromFloat(0.0f)
+
+          result shouldBe SimpleJsonNumberParser.parse(0.0f.toString)
+        }
+
+        it("on negative zero") {
+          val result = SimpleJsonNumberParser.fromFloat(-0.0f)
+
+          result shouldBe SimpleJsonNumberParser.parse(-0.0f.toString)
+        }
+      }
+
+      describe("should reject") {
+        it("NaN") {
+          SimpleJsonNumberParser.fromFloat(Float.NaN) shouldBe empty
+        }
+
+        it("positive infinity") {
+          SimpleJsonNumberParser.fromFloat(Float.PositiveInfinity) shouldBe empty
+        }
+
+        it("negative infinity") {
+          SimpleJsonNumberParser.fromFloat(Float.NegativeInfinity) shouldBe empty
+        }
+      }
+    }
+
+    describe("fromBigDecimal") {
+      it("should agree with parse") {
+        forAll { (value: BigDecimal) =>
+          val result = SimpleJsonNumberParser.fromBigDecimal(value.underlying)
+
+          result shouldBe SimpleJsonNumberParser.parse(value.toString)
+        }
+      }
+
+      it("should agree with parse on 1.0") {
+        val result = SimpleJsonNumberParser.fromBigDecimal(new JavaBigDecimal("1.0"))
+
+        result shouldBe SimpleJsonNumberParser.parse("1.0")
+      }
+    }
+
+    describe("fromBigInteger") {
+      it("should agree with parse") {
+        forAll { (value: BigInt) =>
+          val result = SimpleJsonNumberParser.fromBigInteger(value.underlying)
+
+          result shouldBe SimpleJsonNumberParser.parse(value.toString)
+        }
+      }
+    }
+  }
+}

--- a/modules/testing/js/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
+++ b/modules/testing/js/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
@@ -13,5 +13,5 @@ private[testing] trait ArbitraryJsonNumberTransformer {
     Try(JSON.parse(n.toString): Any).toOption.filter {
       case x: Double => !x.isInfinite && n.toBigDecimal.exists(_ == BigDecimal(x))
       case _ => true
-    }.fold(JsonNumber.fromIntegralStringUnsafe("0"))(_ => n)
+    }.fold(JsonNumber.fromString("0").get)(_ => n)
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/FloatJsonTests.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/FloatJsonTests.scala
@@ -7,7 +7,7 @@ import io.circe.tests.CirceSuite
  */
 trait FloatJsonTests { this: CirceSuite =>
   "fromFloatOrString" should "return a Json number for valid Floats" in {
-    assert(Json.fromFloatOrString(1.1f) === Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe("1.1")))
-    assert(Json.fromFloatOrString(-1.2f) === Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe("-1.2")))
+    assert(Json.fromFloatOrString(1.1f) === Json.fromJsonNumber(JsonNumber.fromString("1.1").get))
+    assert(Json.fromFloatOrString(-1.2f) === Json.fromJsonNumber(JsonNumber.fromString("-1.2").get))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
@@ -106,8 +106,8 @@ class JsonNumberSuite extends CirceSuite {
   }
 
   val positiveZeros: List[JsonNumber] = List(
-    JsonNumber.fromIntegralStringUnsafe("0"),
-    JsonNumber.fromDecimalStringUnsafe("0.0"),
+    JsonNumber.fromString("0").get,
+    JsonNumber.fromString("0.0").get,
     Json.fromDouble(0.0).flatMap(_.asNumber).get,
     Json.fromFloat(0.0f).flatMap(_.asNumber).get,
     Json.fromLong(0).asNumber.get,
@@ -116,8 +116,8 @@ class JsonNumberSuite extends CirceSuite {
   )
 
   val negativeZeros: List[JsonNumber] = List(
-    JsonNumber.fromIntegralStringUnsafe("-0"),
-    JsonNumber.fromDecimalStringUnsafe("-0.0"),
+    JsonNumber.fromString("-0").get,
+    JsonNumber.fromString("-0.0").get,
     Json.fromDouble(-0.0).flatMap(_.asNumber).get,
     Json.fromFloat(-0.0f).flatMap(_.asNumber).get
   )

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -174,8 +174,8 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
   }
 
   it should "return JsonNumber Json values for valid Doubles" in {
-    assert(Json.fromDoubleOrString(1.1) === Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe("1.1")))
-    assert(Json.fromDoubleOrString(-1.2) === Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe("-1.2")))
+    assert(Json.fromDoubleOrString(1.1) === Json.fromJsonNumber(JsonNumber.fromString("1.1").get))
+    assert(Json.fromDoubleOrString(-1.2) === Json.fromJsonNumber(JsonNumber.fromString("-1.2").get))
   }
 
   "fromFloat" should "fail on Float.NaN" in {


### PR DESCRIPTION
This is a work-in-progress PR that aims to use the fact that jawn 0.11 can now work with `CharSequence` values instead of strings, which means that for number parsing we don't need to instantiate additional strings in many situations.

Decoding into most numeric types is currently significantly faster (like 60% more throughput for `decodeDouble` in the new number parsing benchmark, and 11% more for `decodeLong`), but in some situations parsing is slower, since we no longer create lazily parsed `JsonNumber` instances from known valid JSON number strings. This is because we want to avoid instantiating strings for every number whenever we can.

I'm not sure I'm entirely happy about this trade-off, and I'm still experimenting with different options here.