### PR TITLE
Deprecate truncateToX methods

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -71,6 +71,7 @@ sealed abstract class JsonNumber extends Serializable {
    * Truncation means that we round toward zero to the closest valid [[scala.Byte]]. If the number
    * is `1e99`, for example, this will return `Byte.MaxValue`.
    */
+  @deprecated("Use toBigDecimal", "0.9.0")
   final def truncateToByte: Byte = {
     val asLong: Long = truncateToLong
     if (asLong > Byte.MaxValue) {
@@ -86,6 +87,7 @@ sealed abstract class JsonNumber extends Serializable {
    * Truncation means that we round toward zero to the closest valid [[scala.Short]]. If the number
    * is `1e99`, for example, this will return `Short.MaxValue`.
    */
+  @deprecated("Use toBigDecimal", "0.9.0")
   final def truncateToShort: Short = {
     val asLong: Long = truncateToLong
     if (asLong > Short.MaxValue) {
@@ -101,6 +103,7 @@ sealed abstract class JsonNumber extends Serializable {
    * Truncation means that we round toward zero to the closest valid [[scala.Int]]. If the number is
    * `1e99`, for example, this will return `Int.MaxValue`.
    */
+  @deprecated("Use toBigDecimal", "0.9.0")
   final def truncateToInt: Int = {
     val asLong: Long = truncateToLong
     if (asLong > Int.MaxValue) {
@@ -116,6 +119,7 @@ sealed abstract class JsonNumber extends Serializable {
    * Truncation means that we round toward zero to the closest valid [[scala.Long]]. If the number
    * is `1e99`, for example, this will return `Long.MaxValue`.
    */
+  @deprecated("Use toBigDecimal", "0.9.0")
   def truncateToLong: Long
 
   /**

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -64,6 +64,7 @@ sealed abstract class BiggerDecimal extends Serializable {
   /**
    * Convert to the nearest [[scala.Long]].
    */
+  @deprecated("Use toBigDecimal", "0.9.0")
   def truncateToLong: Long
 
   private[circe] def appendToStringBuilder(builder: StringBuilder): Unit


### PR DESCRIPTION
These methods are an inheritance from Argonaut and ever since #83 we don't use them internally. I'd like to get rid of them before 1.0.

It seems a little odd to provide this specific operation but not other forms of rounding, and I think the ideal situation would be to leave this whole matter entirely up to users—i.e. there are the `toLong`, etc. methods for cases where exact conversions are possible, but for non-exact integral conversions users will need to convert to `BigDecimal` and manage the conversion themselves. They already have to do this if they don't want truncation, and I don't see it as an unreasonable inconvenience.