### PR TITLE
Make optics laws use our Shrink instances

### DIFF
--- a/modules/optics/src/test/scala/io/circe/optics/LawsTests.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/LawsTests.scala
@@ -1,0 +1,111 @@
+package io.circe.optics
+
+import monocle.{ Lens, Optional, Prism, Traversal }
+import monocle.function.{ At, Each, FilterIndex, Index }
+import monocle.law.{ LensLaws, OptionalLaws, PrismLaws, TraversalLaws }
+import monocle.law.discipline.isEqToProp
+import org.scalacheck.{ Arbitrary, Prop, Shrink }
+import org.typelevel.discipline.Laws
+import scalaz.Equal
+import scalaz.std.list._
+import scalaz.std.option._
+
+/**
+ * We use our own implementations because Monocle's don't (currently) use non-default `Shrink`
+ * instances. If Monocle changes this we will remove this code.
+ */
+object LawsTests extends Laws {
+  def atTests[S: Arbitrary: Shrink: Equal, I: Arbitrary: Shrink, A: Arbitrary: Equal](implicit
+    evAt: At[S, I, A],
+    arbAA: Arbitrary[A => A]
+  ): RuleSet = {
+    new SimpleRuleSet("At", lensTests(At.at(_: I)).props: _*)
+  }
+
+  def indexTests[S: Arbitrary: Shrink: Equal, I: Arbitrary: Shrink, A: Arbitrary: Shrink: Equal](implicit
+    evIndex: Index[S, I, A],
+    arbAA: Arbitrary[A => A]
+  ): RuleSet = new SimpleRuleSet("Index", optionalTests(Index.index(_ : I)).props: _*)
+
+  def filterIndexTests[S: Arbitrary: Shrink: Equal, I, A: Arbitrary: Shrink: Equal](implicit
+    evFilterIndex: FilterIndex[S, I, A],
+    arbAA: Arbitrary[A => A], arbIB: Arbitrary[I => Boolean]
+  ): RuleSet = new SimpleRuleSet("FilterIndex", traversalTests(FilterIndex.filterIndex(_: I => Boolean)).props: _*)
+
+  def eachTests[S: Arbitrary: Shrink: Equal, A: Arbitrary: Shrink: Equal](implicit
+    evEach: Each[S, A],
+    arbAA: Arbitrary[A => A]
+  ): RuleSet = new SimpleRuleSet("Each", traversalTests(Each.each[S, A]).props: _*)
+
+  def lensTests[S: Arbitrary: Equal, A: Arbitrary: Shrink: Equal, I: Arbitrary: Shrink](f: I => Lens[S, A])(implicit
+    arbAA: Arbitrary[A => A]
+  ): RuleSet = {
+    def laws(i: I) = LensLaws(f(i))
+
+    new SimpleRuleSet(
+      "Lens",
+      "set what you get"  -> Prop.forAll((s: S, i: I) => laws(i).getSet(s)),
+      "get what you set"  -> Prop.forAll((s: S, a: A, i: I) => laws(i).setGet(s, a)),
+      "set idempotent"    -> Prop.forAll((s: S, a: A, i: I) => laws(i).setIdempotent(s, a)),
+      "modify id = id"    -> Prop.forAll((s: S, i: I) => laws(i).modifyIdentity(s)),
+      "compose modify"    -> Prop.forAll((s: S, g: A => A, h: A => A, i: I) => laws(i).composeModify(s, g, h)),
+      "consistent set with modify"      -> Prop.forAll((s: S, a: A, i: I) => laws(i).consistentSetModify(s, a)),
+      "consistent modify with modifyId" ->
+        Prop.forAll((s: S, g: A => A, i: I) => laws(i).consistentModifyModifyId(s, g)),
+      "consistent get with modifyId"    -> Prop.forAll((s: S, i: I) => laws(i).consistentGetModifyId(s))
+    )
+  }
+
+  def optionalTests[S: Arbitrary: Shrink: Equal, A: Arbitrary: Shrink: Equal, I: Arbitrary: Shrink](
+    f: I => Optional[S, A]
+  )(implicit arbAA: Arbitrary[A => A]): RuleSet = {
+    def laws(i: I) = OptionalLaws(f(i))
+
+    new SimpleRuleSet(
+      "Optional",
+      "set what you get"  -> Prop.forAll((s: S, i: I) => laws(i).getOptionSet(s)),
+      "get what you set"  -> Prop.forAll((s: S, a: A, i: I) => laws(i).setGetOption(s, a)),
+      "set idempotent"    -> Prop.forAll((s: S, a: A, i: I) => laws(i).setIdempotent(s, a)),
+      "modify id = id"    -> Prop.forAll((s: S, i: I) => laws(i).modifyIdentity(s)),
+      "compose modify"    -> Prop.forAll((s: S, g: A => A, h: A => A, i: I) => laws(i).composeModify(s, g, h)),
+      "consistent set with modify"         -> Prop.forAll((s: S, a: A, i: I) => laws(i).consistentSetModify(s, a)),
+      "consistent modify with modifyId"    -> Prop.forAll((s: S, g: A => A, i: I) => laws(i).consistentModifyModifyId(s, g)),
+      "consistent getOption with modifyId" -> Prop.forAll((s: S, i: I) => laws(i).consistentGetOptionModifyId(s))
+    )
+  }
+
+  def prismTests[S: Arbitrary: Shrink: Equal, A: Arbitrary: Shrink: Equal](prism: Prism[S, A])(implicit
+    arbAA: Arbitrary[A => A]
+  ): RuleSet = {
+    val laws: PrismLaws[S, A] = new PrismLaws(prism)
+
+    new SimpleRuleSet(
+      "Prism",
+      "partial round trip one way" -> Prop.forAll((s: S) => laws.partialRoundTripOneWay(s)),
+      "round trip other way" -> Prop.forAll((a: A) => laws.roundTripOtherWay(a)),
+      "modify id = id"       -> Prop.forAll((s: S) => laws.modifyIdentity(s)),
+      "compose modify"       -> Prop.forAll((s: S, f: A => A, g: A => A) => laws.composeModify(s, f, g)),
+      "consistent set with modify"         -> Prop.forAll((s: S, a: A) => laws.consistentSetModify(s, a)),
+      "consistent modify with modifyId"    -> Prop.forAll((s: S, g: A => A) => laws.consistentModifyModifyId(s, g)),
+      "consistent getOption with modifyId" -> Prop.forAll((s: S) => laws.consistentGetOptionModifyId(s))
+    )
+  }
+
+  def traversalTests[S: Arbitrary: Shrink: Equal, A: Arbitrary: Shrink: Equal](traversal: Traversal[S, A])(implicit
+    arbAA: Arbitrary[A => A]
+  ): RuleSet = traversalTests[S, A, Unit](_ => traversal)
+
+  def traversalTests[S: Arbitrary: Shrink: Equal, A: Arbitrary: Shrink: Equal, I: Arbitrary: Shrink](
+    f: I => Traversal[S, A]
+  )(implicit arbAA: Arbitrary[A => A]): RuleSet = {
+    def laws(i: I): TraversalLaws[S, A] = new TraversalLaws(f(i))
+
+    new SimpleRuleSet("Traversal",
+      "headOption"        -> Prop.forAll((s: S, i: I) => laws(i).headOption(s)),
+      "get what you set"  -> Prop.forAll((s: S, f: A => A, i: I) => laws(i).modifyGetAll(s, f)),
+      "set idempotent"    -> Prop.forAll((s: S, a: A, i: I) => laws(i).setIdempotent(s, a)),
+      "modify id = id"    -> Prop.forAll((s: S, i: I) => laws(i).modifyIdentity(s)),
+      "compose modify"    -> Prop.forAll((s: S, f: A => A, g: A => A, i: I) => laws(i).composeModify(s, f, g))
+    )
+  }
+}

--- a/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
@@ -5,10 +5,7 @@ import io.circe.optics.all._
 import io.circe.tests.CirceSuite
 import io.circe.{ Json, JsonNumber, JsonObject }
 import monocle.function.Plated.plate
-import monocle.law.discipline.function.{ AtTests, EachTests, FilterIndexTests, IndexTests }
-import monocle.law.discipline.{ PrismTests, TraversalTests }
 import monocle.syntax.all._
-
 import scalaz.Equal
 import scalaz.std.anyVal._
 import scalaz.std.math.bigDecimal._
@@ -30,33 +27,33 @@ class OpticsSuite extends CirceSuite {
     (a.isNaN && b.isNaN) || scalaz.std.anyVal.doubleInstance.equal(a, b)
   }
 
-  checkLaws("Json to Unit", PrismTests(jsonNull))
-  checkLaws("Json to Boolean", PrismTests(jsonBoolean))
-  checkLaws("Json to BigDecimal", PrismTests(jsonBigDecimal))
-  checkLaws("Json to Double", PrismTests(jsonDouble))
-  checkLaws("Json to BigInt", PrismTests(jsonBigInt))
-  checkLaws("Json to Long", PrismTests(jsonLong))
-  checkLaws("Json to Int", PrismTests(jsonInt))
-  checkLaws("Json to Short", PrismTests(jsonShort))
-  checkLaws("Json to Byte", PrismTests(jsonByte))
-  checkLaws("Json to String", PrismTests(jsonString))
-  checkLaws("Json to JsonNumber", PrismTests(jsonNumber))
-  checkLaws("Json to JsonObject", PrismTests(jsonObject))
-  checkLaws("Json to Vector[Json]", PrismTests(jsonArray))
+  checkLaws("Json to Unit", LawsTests.prismTests(jsonNull))
+  checkLaws("Json to Boolean", LawsTests.prismTests(jsonBoolean))
+  checkLaws("Json to BigDecimal", LawsTests.prismTests(jsonBigDecimal))
+  checkLaws("Json to Double", LawsTests.prismTests(jsonDouble))
+  checkLaws("Json to BigInt", LawsTests.prismTests(jsonBigInt))
+  checkLaws("Json to Long", LawsTests.prismTests(jsonLong))
+  checkLaws("Json to Int", LawsTests.prismTests(jsonInt))
+  checkLaws("Json to Short", LawsTests.prismTests(jsonShort))
+  checkLaws("Json to Byte", LawsTests.prismTests(jsonByte))
+  checkLaws("Json to String", LawsTests.prismTests(jsonString))
+  checkLaws("Json to JsonNumber", LawsTests.prismTests(jsonNumber))
+  checkLaws("Json to JsonObject", LawsTests.prismTests(jsonObject))
+  checkLaws("Json to Vector[Json]", LawsTests.prismTests(jsonArray))
 
-  checkLaws("JsonNumber to BigDecimal", PrismTests(jsonNumberBigDecimal))
-  checkLaws("JsonNumber to BigInt", PrismTests(jsonNumberBigInt))
-  checkLaws("JsonNumber to Long", PrismTests(jsonNumberLong))
-  checkLaws("JsonNumber to Int", PrismTests(jsonNumberInt))
-  checkLaws("JsonNumber to Short", PrismTests(jsonNumberShort))
-  checkLaws("JsonNumber to Byte", PrismTests(jsonNumberByte))
+  checkLaws("JsonNumber to BigDecimal", LawsTests.prismTests(jsonNumberBigDecimal))
+  checkLaws("JsonNumber to BigInt", LawsTests.prismTests(jsonNumberBigInt))
+  checkLaws("JsonNumber to Long", LawsTests.prismTests(jsonNumberLong))
+  checkLaws("JsonNumber to Int", LawsTests.prismTests(jsonNumberInt))
+  checkLaws("JsonNumber to Short", LawsTests.prismTests(jsonNumberShort))
+  checkLaws("JsonNumber to Byte", LawsTests.prismTests(jsonNumberByte))
 
-  checkLaws("plated Json", TraversalTests(plate[Json]))
+  checkLaws("plated Json", LawsTests.traversalTests(plate[Json]))
 
-  checkLaws("jsonObjectEach", EachTests[JsonObject, Json])
-  checkLaws("jsonObjectAt", AtTests[JsonObject, String, Option[Json]])
-  checkLaws("jsonObjectIndex", IndexTests[JsonObject, String, Json])
-  checkLaws("jsonObjectFilterIndex", FilterIndexTests[JsonObject, String, Json])
+  checkLaws("jsonObjectEach", LawsTests.eachTests[JsonObject, Json])
+  checkLaws("jsonObjectAt", LawsTests.atTests[JsonObject, String, Option[Json]])
+  checkLaws("jsonObjectIndex", LawsTests.indexTests[JsonObject, String, Json])
+  checkLaws("jsonObjectFilterIndex", LawsTests.filterIndexTests[JsonObject, String, Json])
 
   "jsonDouble" should "round-trip in reverse with Double.NaN" in {
     assert(jsonDouble.getOption(jsonDouble.reverseGet(Double.NaN)) === Some(Double.NaN))


### PR DESCRIPTION
I'm currently doing some work that's causing these laws to fail occasionally and the lack of shrunk failures is really annoying. This is a temporary fix, and we should revert it if [this issue](https://github.com/julien-truffaut/Monocle/issues/527) gets resolved.