### PR TITLE
Added implicit method to find paths to key on Json value

### DIFF
--- a/modules/optics/src/main/scala/io/circe/optics/implicits/package.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/implicits/package.scala
@@ -8,14 +8,63 @@ package object implicits {
 
   final implicit class JsonImplicits(json: Json) {
 
+    /** Finds all JsonPath's to fields with the specified key.
+      *
+      * @param key the field to search for
+      * @return a sequence of all possible JsonPath's that lead to fields with the name of the key
+      */
     def findPathsToKey(key: String): Seq[JsonPath] =
-      findPathsToKeyR(json, key, new KeyPathMarker())
+      findPathsToKeyR(json, key, KeyPathMarker())
 
+    /** Finds all JsonPath's to fields with the specified key but returns
+      * the path to the parent JSON of the found field.
+      *
+      * For example, in:
+      *
+      * {{{
+      * { "top":
+      *   { "child": 42 }
+      * }
+      * }}}
+      *
+      * `findParentPathsToKey("child")` would return `{ "child": 42 }`.
+      *
+      * @param key the field to search for
+      * @return a sequence of all possible JsonPath's that lead to the parent JSON value
+      *         containing the field with the name of the key
+      */
     def findParentPathsToKey(key: String): Seq[JsonPath] =
-      findPathsToKeyR(json, key, new ParentPathMarker())
+      findPathsToKeyR(json, key, ParentPathMarker())
 
+    /** Finds all JsonPath's to fields with the specified key. However, all found JsonPath's
+      * will only traverse as far as `maxDepth` levels deep towards the target key.
+      *
+      * If the found JsonPath traverses a level that is `<= maxDepth`, then the returned path
+      * will lead directly to the target JSON value. If the found JsonPath traverses to a level
+      * that is `> maxDepth`, then the JsonPath returned will stop at the `maxDepth` level.
+      *
+      * Consider the following:
+      *
+      * {{{
+      * { "top":
+      *   { "child":
+      *     { "bottom": 42 }
+      *   }
+      * }
+      * }}}
+      *
+      * `findPathsToKey("bottom", 2)` would return `42`.
+      *
+      * `findPathsToKey("bottom", 1)` would return `{ "bottom": 42 }`.
+      *
+      * `findPathsToKey("bottom", 0)` would return `{ "child" : { "bottom": 42 } }`.
+      *
+      * @param key the field to search for
+      * @param maxDepth the maximum depth that any path should traverse
+      * @return a sequence of all possible JsonPath's that lead to fields with the name of the key
+      */
     def findPathsToKey(key: String, maxDepth: Int): Seq[JsonPath] =
-      findPathsToKeyR(json, key, new MaxDepthPathMarker(maxDepth))
+      findPathsToKeyR(json, key, MaxDepthPathMarker(maxDepth))
 
     private case class PathStep(curPath: JsonPath, atField: String, atDepth: Int)
     sealed trait PathMarker {
@@ -37,7 +86,11 @@ package object implicits {
       override def mark(step: PathStep): JsonPath =
         maxStep.fold(step.curPath.selectDynamic(step.atField))(s => s.curPath.selectDynamic(s.atField))
       override def update(step: PathStep): PathMarker =
-        if (step.atDepth == maxDepth) MaxDepthPathMarker(maxDepth, Some(step)) else MaxDepthPathMarker(maxDepth)
+        if (step.atDepth == maxDepth) {
+          MaxDepthPathMarker(maxDepth, Some(step))
+        } else {
+          MaxDepthPathMarker(maxDepth, maxStep)
+        }
     }
 
     private def findPathsToKeyR[T](json: Json, key: String, marker: PathMarker,

--- a/modules/optics/src/main/scala/io/circe/optics/implicits/package.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/implicits/package.scala
@@ -1,0 +1,60 @@
+package io.circe.optics
+
+import io.circe.Json
+import io.circe.Json.{ JArray, JObject }
+import io.circe.optics.JsonPath.root
+
+package object implicits {
+
+  final implicit class JsonImplicits(json: Json) {
+
+    def findPathsToKey(key: String): Seq[JsonPath] =
+      findPathsToKeyR(json, key, new KeyPathMarker())
+
+    def findParentPathsToKey(key: String): Seq[JsonPath] =
+      findPathsToKeyR(json, key, new ParentPathMarker())
+
+    def findPathsToKey(key: String, maxDepth: Int): Seq[JsonPath] =
+      findPathsToKeyR(json, key, new MaxDepthPathMarker(maxDepth))
+
+    private case class PathStep(curPath: JsonPath, atField: String, atDepth: Int)
+    trait PathMarker {
+      def mark(step: PathStep): JsonPath
+      def update(step: PathStep): PathMarker
+    }
+
+    private class KeyPathMarker() extends PathMarker {
+      override def mark(step: PathStep): JsonPath = step.curPath.selectDynamic(step.atField)
+      override def update(step: PathStep): PathMarker = this
+    }
+
+    private class ParentPathMarker() extends KeyPathMarker {
+      override def mark(step: PathStep): JsonPath = step.curPath
+    }
+
+    private class MaxDepthPathMarker(maxDepth: Int, maxStep: Option[PathStep] = None) extends PathMarker {
+      override def mark(step: PathStep): JsonPath =
+        maxStep.fold(step.curPath.selectDynamic(step.atField))(s => s.curPath.selectDynamic(s.atField))
+      override def update(step: PathStep): PathMarker =
+        if (step.atDepth == maxDepth) new MaxDepthPathMarker(maxDepth, Some(step)) else this
+    }
+
+    private def findPathsToKeyR[T](json: Json, key: String, marker: PathMarker,
+                                  path: JsonPath = root, depth: Int = 0): Seq[JsonPath] = {
+      json match {
+        case JObject(obj) =>
+          obj.toList.flatMap({
+            case (field, js) =>
+              val step = PathStep(path, field, depth)
+              val seq = if (field == key) Seq(marker.mark(step)) else Nil
+              seq ++ findPathsToKeyR(js, key, marker.update(step), path.selectDynamic(field), depth + 1)
+          })
+        case JArray(elems) =>
+          elems.zipWithIndex.flatMap({
+            case (js, idx) => findPathsToKeyR(js, key, marker, path.index(idx), depth)
+          })
+        case _ => Nil
+      }
+    }
+  }
+}

--- a/modules/optics/src/test/scala/io/circe/optics/implicits/JsonImplicitsSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/implicits/JsonImplicitsSuite.scala
@@ -1,0 +1,144 @@
+package io.circe.optics.implicits
+
+import io.circe.Json
+import io.circe.optics.JsonPath._
+import io.circe.syntax._
+import io.circe.tests.CirceSuite
+
+class JsonImplicitsSuite extends CirceSuite {
+
+  import io.circe.optics.implicits._
+
+  "findPathsToKey" should "find paths" in {
+    forAll { (key1: String, key2: String, value1: String, value2: String) =>
+      whenever(key1 != key2) {
+        val js = Json.obj(
+          key1 -> value1.asJson,
+          key2 -> value2.asJson,
+        )
+
+        assert(js.findPathsToKey(key1).size == 1)
+        assert(js.findPathsToKey(key1).head.json.getOption(js).get == value1.asJson)
+
+        assert(js.findPathsToKey(key2).size == 1)
+        assert(js.findPathsToKey(key2).head.json.getOption(js).get == value2.asJson)
+      }
+    }
+  }
+
+  it should "find nested paths" in {
+    forAll { (key1: String, key2: String, value1: String, value2: String) =>
+      whenever(key1 != key2) {
+        val js = Json.obj(
+          key1 -> Json.obj(
+            key1 -> value1.asJson,
+            key2 -> value2.asJson
+          ),
+          key2 -> value2.asJson
+        )
+
+        assert(js.findPathsToKey(key1).size == 2)
+        assert(js.findPathsToKey(key1).head.json.getOption(js).get == Json.obj(key1 -> value1.asJson, key2 -> value2.asJson))
+        assert(js.findPathsToKey(key1)(1).json.getOption(js).get == value1.asJson)
+
+        assert(js.findPathsToKey(key2).size == 2)
+        assert(js.findPathsToKey(key2).head.json.getOption(js).get == value2.asJson)
+        assert(js.findPathsToKey(key2)(1).json.getOption(js).get == value2.asJson)
+      }
+    }
+  }
+
+  it should "find nested paths in arrays" in {
+    forAll { (arrayName: String, key1: String, key2: String, value1: String) =>
+      whenever(Set(arrayName, key1, key2).size == 3) {
+        val jsObj = Json.obj(
+          key1 -> value1.asJson,
+          arrayName -> Json.arr(
+            Json.obj(
+              key1 -> "array1".asJson,
+              key2 -> "array2".asJson
+            ),
+            Json.obj(
+              key2 -> "array3".asJson
+            )
+          )
+        )
+
+        assert(jsObj.findPathsToKey(key1).size == 2)
+        assert(jsObj.findPathsToKey(key1).head.json.getOption(jsObj).get == value1.asJson)
+        assert(jsObj.findPathsToKey(key1)(1).json.getOption(jsObj).get == "array1".asJson)
+
+        assert(jsObj.findPathsToKey(key2).size == 2)
+        assert(jsObj.findPathsToKey(key2).head.json.getOption(jsObj).get == "array2".asJson)
+        assert(jsObj.findPathsToKey(key2)(1).json.getOption(jsObj).get == "array3".asJson)
+
+        val jsArray = Json.arr(
+          Json.obj(
+            key1 -> "array1".asJson,
+            key2 -> "array2".asJson
+          ),
+          Json.obj(
+            key2 -> "array3".asJson
+          )
+        )
+
+        assert(jsArray.findPathsToKey(key1).size == 1)
+        assert(jsArray.findPathsToKey(key1).head.json.getOption(jsArray).get == "array1".asJson)
+
+        assert(jsArray.findPathsToKey(key2).size == 2)
+        assert(jsArray.findPathsToKey(key2).head.json.getOption(jsArray).get == "array2".asJson)
+        assert(jsArray.findPathsToKey(key2)(1).json.getOption(jsArray).get == "array3".asJson)
+      }
+    }
+  }
+
+  "findParentPathsToKey" should "create paths to just the parent" in {
+    forAll { (key1: String, key2: String, value: String) =>
+      whenever(key1 != key2) {
+        val js = Json.obj(
+          key1 -> Json.obj(
+            key2 -> value.asJson
+          ),
+          "array" -> Json.arr(
+            Json.obj(
+              "arrayKey" -> value.asJson
+            )
+          )
+        )
+
+        assert(js.findParentPathsToKey(key2).size == 1)
+        assert(js.findParentPathsToKey(key2).head.json.getOption(js).get == Json.obj(key2 -> value.asJson))
+
+        assert(js.findParentPathsToKey(key1).head.json.getOption(js).get == js)
+
+        assert(js.findParentPathsToKey("array").head.json.getOption(js).get == js)
+        assert(js.findParentPathsToKey("arrayKey").head.json.getOption(js).get == Json.obj("arrayKey" -> value.asJson))
+      }
+    }
+  }
+
+  "findPathsToKey with a max depth" should "traverse only to the max depth" in {
+    forAll { (key: String, randomDepth: Int) =>
+      whenever(randomDepth >= 0 && randomDepth <= 1024) {
+
+        def key(i: Int) = s"key-$i"
+
+        var path = root
+        var json = Json.obj()
+        (0 to randomDepth).foreach(i => {
+          json = path.json.modify(js => Json.obj(key(i) -> i.asJson))(json)
+          path = path.selectDynamic(key(i))
+        })
+
+        assert(json.findPathsToKey(key(randomDepth), randomDepth).head.json.getOption(json).get == randomDepth.asJson)
+        if (randomDepth > 0) {
+          assert(json.findPathsToKey(key(randomDepth), randomDepth - 1).head.json.getOption(json).get ==
+            Json.obj(
+              key(randomDepth) -> randomDepth.asJson
+            )
+          )
+        }
+      }
+    }
+  }
+}

--- a/modules/optics/src/test/scala/io/circe/optics/implicits/JsonImplicitsSuite.scala
+++ b/modules/optics/src/test/scala/io/circe/optics/implicits/JsonImplicitsSuite.scala
@@ -119,7 +119,7 @@ class JsonImplicitsSuite extends CirceSuite {
     }
   }
 
-  val RandomDepth = Gen.Choose.chooseInt.choose(0, 1024).suchThat(_ >= 0)
+  val RandomDepth = Gen.Choose.chooseInt.choose(0, 256).suchThat(_ >= 0)
   "findPathsToKey with a max depth" should "traverse various depths" in {
     forAll(RandomDepth) { (randomDepth: Int) =>
 


### PR DESCRIPTION
Borrowing the logic from `Json.findAllByKey`, this PR provides implicit methods on `Json` to find `JsonPath`'s that lead to Json values based on a given key name.

The main motivation for this was that in addition to recursive search capabilities on a `Json` value, I needed the `JsonPath`'s for search results so that I could use Monocle methods like `modify`.

The method is not stack-safe; I did try to add trampolining, but that was a bit of dead-end for me. If there is any suggestions for doing this (or rewriting using tailrec), I'm happy to modify the code.