### PR TITLE
update to cats 1.0.0-MF

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val compilerOptions = Seq(
   "-Yno-predef"
 )
 
-lazy val catsVersion = "0.9.0"
+lazy val catsVersion = "1.0.0-MF"
 lazy val jawnVersion = "0.11.0"
 lazy val shapelessVersion = "2.3.2"
 lazy val refinedVersion = "0.8.2"

--- a/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
@@ -54,7 +54,7 @@ final object AccumulatingDecoder {
     NonEmptyList.catsDataSemigroupForNonEmptyList[DecodingFailure]
 
   final val resultInstance: ApplicativeError[Result, NonEmptyList[DecodingFailure]] =
-    Validated.catsDataInstancesForValidated[NonEmptyList[DecodingFailure]](failureNelInstance)
+    Validated.catsDataApplicativeErrorForValidated[NonEmptyList[DecodingFailure]](failureNelInstance)
 
   /**
    * Return an instance for a given type.


### PR DESCRIPTION
since the MF version should be API compliant this seems like a reasonable time to start porting over. It all went nearly seamlessly for a release noted for breaking changes. The only thing the least work was the `traverseU` -> `traverse` To do that I created a shim type that converts `Either[ParserException,Json]` to `Shim[Json]` This seems to trick the compiler into agreeing that the type fits the definition of `traverse` (where the `S => G[B]` has a `G` of only one slot) I honestly don't know if it's a good or bad way of fixing the issue but it works.