### PR TITLE
avoid confusion of Int => T with IndexedSeq[T] under -Yparital-unification

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -701,11 +701,21 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    *       unless the provided [[scala.collection.generic.CanBuildFrom]] is serializable.
    * @group Collection
    */
-  implicit final def decodeCanBuildFrom[A, C[_]](implicit
+  implicit final def decodeTraversable[A, C[A] <: Traversable[A]](implicit
     decodeA: Decoder[A],
     cbf: CanBuildFrom[Nothing, A, C[A]]
   ): Decoder[C[A]] = new SeqDecoder[A, C](decodeA) {
     final protected def createBuilder(): Builder[A, C[A]] = cbf.apply()
+  }
+
+  /**
+   * @group Collection
+   */
+  implicit final def decodeArray[A](implicit
+    decodeA: Decoder[A],
+    cbf: CanBuildFrom[Nothing, A, Array[A]]
+  ): Decoder[Array[A]] = new SeqDecoder[A, Array](decodeA) {
+    final protected def createBuilder(): Builder[A, Array[A]] = cbf.apply()
   }
 
   /**


### PR DESCRIPTION
I did further investigation of test failures related to `-Ypartial-unification` discovered in #724. Here are my findings:

1) Summoning the partial `Decoder` directly yields nonsensical result while summoning an `Exported[Decoder[...]]` yields correct result because `importedDecoder` is located in `LowerPriorityDecoder`, so `decodeCanBuildFrom` implicit has higher priority.

2) `decodeCanBuildFrom` is tried because under `-Ypartial-unification` `Int => Qux[String]` is partially unapplied as `[T]Int => T` to fit into `C[_]` shape of second parameter to `def decodeCanBuildFrom[A, C[_]]`.

3) `decodeCanBuildFrom` succeeds because an instance of `CanBuildFrom[Nothing, Qux[String], Int => Qux[String]]` exists. The instance, as it usually happens, is helpfully provided by `scala.Predef`: `implicit def fallbackStringCanBuildFrom[T]: CanBuildFrom[String, T, immutable.IndexedSeq[T]]`. `CanBuildFrom` has variance of `[-,-,+]` so the types align nicely.

This means that the problem is limited to partial decoders with `Int` typed hole, but it's also means it's easy to remedy by adding a constraint on `decodeCanBuildFrom` parameter to ensure it actually a collection, not an `Int => _`. I've used `Traversable`, which in turn required adding separate case for `Array` that is not a `Traversable` but needs a `CanBuildFrom` to handle.

This patch does not turn on `-Ypartial-unification`, but I've verified that all the tests pass with and without this option on Scala 2.11 and 2.12