### PR TITLE
Scala.js test fix for 2.10

### DIFF
--- a/modules/tests/js/src/test/scala/io/circe/scalajs/ScalaJsSuite.scala
+++ b/modules/tests/js/src/test/scala/io/circe/scalajs/ScalaJsSuite.scala
@@ -36,7 +36,7 @@ class ScalaJsSuite extends CirceSuite {
   }
 
   it should "handle defined js.UndefOr when decoding js.Object" in forAll { (s: String) =>
-    assert(decodeJs[UndefOrExample](Dynamic.literal(name = s)).map(_.name.get) === Right(s))
+    assert(decodeJs[UndefOrExample](Dynamic.literal(name = s)).map(_.name.toOption.get) === Right(s))
   }
 
   "asJsAny" should "encode to js.Object" in forAll { (s: String) =>


### PR DESCRIPTION
Test compilation had been failing on 2.10 with this message:

```scala
[error] .../circe/modules/tests/js/src/test/scala/io/circe/scalajs/ScalaJsSuite.scala:39: could not find implicit value for parameter tc: cats.Foldable[scala.scalajs.js.UndefOr]
[error]     assert(decodeJs[UndefOrExample](Dynamic.literal(name = s)).map(_.name.get) === Right(s))
[error]                                                                      ^
[error] one error found
```