### PR TITLE
Handle null explicitly to prevent cryptic exception

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -224,6 +224,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
     final def apply(a: Option[A]): Json = a match {
       case Some(v) => e(v)
       case None => Json.Null
+      case null => Json.Null
     }
   }
 


### PR DESCRIPTION
When you for any reason get an object that contains nulls, circe just prints out cryptic exception. From my point of view:
- it should print out better exception
- handle the situation automatically

In this pull request I picked the second solution because I think that null can be always serialized to json :-)

Example of such exception:
```
null
scala.MatchError: null
	at io.circe.Encoder$$anon$28.apply(Encoder.scala:216)
	at io.circe.Encoder$$anon$28.apply(Encoder.scala:213)
```