### PR TITLE
Introduce size predictor for binary printers

### DIFF
--- a/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -14,8 +14,8 @@ class PrinterSuite(val printer: Printer, val parser: Parser) extends CirceSuite 
   checkLaws("Printing Int", PrinterTests[Int].printer(printer, parser))
   checkLaws("Printing Map", PrinterTests[Map[String, List[Int]]].printer(printer, parser))
 
-  "prettyByteBuffer" should "match pretty" in forAll { (json: Json) =>
-    val buffer = printer.prettyByteBuffer(json)
+  "prettyByteBuffer" should "match pretty" in forAll { (json: Json, predictSize: Boolean) =>
+    val buffer = printer.copy(predictSize = predictSize).prettyByteBuffer(json)
 
     val bytes = new Array[Byte](buffer.limit)
     buffer.get(bytes)


### PR DESCRIPTION
Fixes #738.

This uses an `AdaptiveSizePredictor` (highly inspired by Netty's `AdaptiveRecvByteBufAllocator `) to avoid (as much as possible) grow-and-copy iterations while printing into binary outputs.

Here is how it works:

```scala
scala> val p = new Printer.AdaptiveSizePredictor()
p: io.circe.Printer.AdaptiveSizePredictor = io.circe.Printer$AdaptiveSizePredictor@1fa326f1

scala> p.predictSize
res0: Int = 32

scala> p.recordSize(100)

scala> p.predictSize
res3: Int = 96

scala> p.recordSize(100)

scala> p.predictSize
res7: Int = 160

scala> p.recordSize(100)

scala> p.predictSize
res13: Int = 144

scala> p.recordSize(100)

scala> p.predictSize
res17: Int = 128

scala> p.recordSize(180)

scala> p.predictSize
res25: Int = 192

scala> p.recordSize(18)

scala> p.predictSize
res37: Int = 176

scala> p.recordSize(200)

scala> p.predictSize
res39: Int = 240
```

Here are the benchmark results:

```
DISABLED:

[info] Benchmark                                       Mode  Cnt         Score         Error  Units
[info] PrintingBenchmark.printBooleansToByteBuffer    thrpt   10     62659.276 ±   13033.734  ops/s
[info] PrintingBenchmark.printFoosToByteBuffer        thrpt   10      7058.193 ±    1184.226  ops/s
[info] PrintingBenchmark.printHelloWorldToByteBuffer  thrpt   10   8317040.969 ± 1550537.465  ops/s
[info] PrintingBenchmark.printIntsToByteBuffer        thrpt   10     40473.038 ±    3536.389  ops/s

ENABLED:

[info] Benchmark                                       Mode  Cnt         Score         Error  Units
[info] PrintingBenchmark.printBooleansToByteBuffer    thrpt   10     72777.471 ±    4885.230  ops/s
[info] PrintingBenchmark.printFoosToByteBuffer        thrpt   10      7837.513 ±     447.322  ops/s
[info] PrintingBenchmark.printHelloWorldToByteBuffer  thrpt   10   8681652.481 ± 1189307.704  ops/s
[info] PrintingBenchmark.printIntsToByteBuffer        thrpt   10     42408.372 ±    3911.829  ops/s
```