### PR TITLE
Add Decoder#either

### DIFF
--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -298,15 +298,13 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     assert(Decoder[Int].validate(_ => true, "whatever").apply(Json.fromInt(i).hcursor) === Right(i))
   }
 
-  "either" should "return the correct disjunct" in {
-    forAll { (decodeString: Decoder[String], decodeBoolean: Decoder[Boolean], value: Either[String, Boolean]) =>
-      val json = value match {
-        case Left(s) => Json.fromString(s)
-        case Right(b) => Json.fromBoolean(b)
-      }
-
-      assert(decodeString.either(decodeBoolean).decodeJson(json) === Right(value))
+  "either" should "return the correct disjunct" in forAll { (value: Either[String, Boolean]) =>
+    val json = value match {
+      case Left(s) => Json.fromString(s)
+      case Right(b) => Json.fromBoolean(b)
     }
+
+    assert(Decoder[String].either(Decoder[Boolean]).decodeJson(json) === Right(value))
   }
 
   private[this] val stateful = {

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -298,6 +298,17 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     assert(Decoder[Int].validate(_ => true, "whatever").apply(Json.fromInt(i).hcursor) === Right(i))
   }
 
+  "either" should "return the correct disjunct" in {
+    forAll { (decodeString: Decoder[String], decodeBoolean: Decoder[Boolean], value: Either[String, Boolean]) =>
+      val json = value match {
+        case Left(s) => Json.fromString(s)
+        case Right(b) => Json.fromBoolean(b)
+      }
+
+      assert(decodeString.either(decodeBoolean).decodeJson(json) === Right(value))
+    }
+  }
+
   private[this] val stateful = {
     import Decoder.state._
     Decoder.fromState(for {


### PR DESCRIPTION
This is a convenience method that allows you to rewrite this fairly common idiom:

```scala
import cats.syntax.either._
import io.circe.Decoder

val decoder1 =
  Decoder[String].map(_.asLeft[Boolean]).or(Decoder[Boolean].map(_.asRight[String]))
```

Like this:

```scala
import io.circe.Decoder

val decoder2 = Decoder[String].either(Decoder[Boolean])
```

The two will always produce the same results. Note that like `or`, `either` will not accumulate errors if both sides fail.