### PR TITLE
Use blackbox macros whenever possible

### DIFF
--- a/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/DerivationMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/DerivationMacros.scala
@@ -5,13 +5,13 @@ import io.circe.generic.decoding.ReprDecoder
 import macrocompat.bundle
 import scala.annotation.tailrec
 import scala.collection.immutable.Map
-import scala.reflect.macros.whitebox
+import scala.reflect.macros.blackbox
 import shapeless.{ CNil, Coproduct, HList, HNil, Lazy }
 import shapeless.labelled.KeyTag
 
 @bundle
 abstract class DerivationMacros[RD[_], RE[_], DD[_], DE[_]] {
-  val c: whitebox.Context
+  val c: blackbox.Context
 
   import c.universe._
 

--- a/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/ExportMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/ExportMacros.scala
@@ -5,10 +5,10 @@ import io.circe.export.Exported
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
 import macrocompat.bundle
-import scala.reflect.macros.whitebox
+import scala.reflect.macros.blackbox
 
 @bundle
-class ExportMacros(val c: whitebox.Context) {
+class ExportMacros(val c: blackbox.Context) {
   import c.universe._
 
   final def exportDecoder[D[x] <: DerivedDecoder[x], A](implicit


### PR DESCRIPTION
Minor change but we might as well do it (I thought we should be able to change the `Deriver` ones as well but that hangs forever on 2.12 and fails on 2.11).