### PR TITLE
Update to Cats 1.0.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val compilerOptions = Seq(
   "-Yno-predef"
 )
 
-lazy val catsVersion = "1.0.0-MF"
+lazy val catsVersion = "1.0.0-RC1"
 lazy val jawnVersion = "0.11.0"
 lazy val shapelessVersion = "2.3.2"
 lazy val refinedVersion = "0.8.4"

--- a/modules/core/shared/src/main/scala/io/circe/ArrayEncoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ArrayEncoder.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.functor.Contravariant
+import cats.Contravariant
 
 /**
  * A type class that provides a conversion from a value of type `A` to a JSON

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -1,8 +1,7 @@
 package io.circe
 
-import cats.Foldable
+import cats.{ Contravariant, Foldable }
 import cats.data.{ NonEmptyList, NonEmptyVector, OneAnd, Validated }
-import cats.functor.Contravariant
 import io.circe.export.Exported
 import java.io.Serializable
 import java.util.UUID

--- a/modules/core/shared/src/main/scala/io/circe/KeyEncoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyEncoder.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.functor.Contravariant
+import cats.Contravariant
 import java.io.Serializable
 import java.util.UUID
 

--- a/modules/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.functor.Contravariant
+import cats.Contravariant
 import io.circe.export.Exported
 
 /**

--- a/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
@@ -2,6 +2,7 @@ package io.circe.testing
 
 import cats.instances.either._
 import cats.kernel.Eq
+import cats.kernel.laws.SerializableLaws
 import cats.laws._
 import cats.laws.discipline._
 import io.circe.{ Decoder, Encoder, Json }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
@@ -2,6 +2,7 @@ package io.circe.testing
 
 import cats.data.{ Validated, ValidatedNel }
 import cats.instances.either._
+import cats.kernel.laws.SerializableLaws
 import cats.laws._
 import cats.laws.discipline._
 import io.circe.{ Error, Json, Parser, ParsingFailure }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
@@ -2,6 +2,7 @@ package io.circe.testing
 
 import cats.instances.option._
 import cats.kernel.Eq
+import cats.kernel.laws.SerializableLaws
 import cats.laws._
 import cats.laws.discipline._
 import io.circe.{ Decoder, Encoder, Parser, Printer }

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -52,7 +52,6 @@ class StdLibCodecSuite extends CirceSuite {
     }
 
   implicit def eqHashMap[Long, Int]: Eq[HashMap[Long, Int]] = Eq.fromUniversalEquals
-  implicit def eqSortedMap[Long, Int]: Eq[SortedMap[Long, Int]] = Eq.fromUniversalEquals
 
   implicit val arbitraryUUID: Arbitrary[UUID] = Arbitrary(Gen.uuid)
 

--- a/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
@@ -1,7 +1,7 @@
 package io.circe
 
-import cats.laws.SerializableLaws
 import cats.laws.discipline.SerializableTests
+import cats.kernel.laws.SerializableLaws
 import io.circe.tests.CirceSuite
 
 class SerializableSuite extends CirceSuite {


### PR DESCRIPTION
I want to wait to publish until we have an iteratee.io release for Cats 1.0.0-RC1 (see [this issue](https://github.com/travisbrown/iteratee/pull/218)), but this seems to compile.