### PR TITLE
Printer support for escaping non-ASCII chars

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -35,6 +35,7 @@ import scala.annotation.switch
  *        storage.
  * @param predictSize Uses an adaptive size predictor to avoid grow-and-copy steps while printing
  *        into a binary output.
+ * @param escapeNonAscii Unicode-escape any non-ASCII characters in strings.
  */
 final case class Printer(
   preserveOrder: Boolean,

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -5,7 +5,7 @@ import io.circe.tests.PrinterSuite
 class Spaces2PrinterSuite extends PrinterSuite(Printer.spaces2, parser.`package`) with Spaces2PrinterExample
 class Spaces4PrinterSuite extends PrinterSuite(Printer.spaces4, parser.`package`)
 class NoSpacesPrinterSuite extends PrinterSuite(Printer.noSpaces, parser.`package`)
-class UnicodeEscapePrinterSuite extends PrinterSuite(Printer.noSpaces.escapeUnicode, parser.`package`) {
+class UnicodeEscapePrinterSuite extends PrinterSuite(Printer.noSpaces.copy(escapeNonAscii = true), parser.`package`) {
   import io.circe.syntax._
   "Printing object" should "unicode-escape all non-ASCII chars" in {
     val actual = Json.obj("0 ℃" := "32 ℉").pretty(printer)
@@ -30,6 +30,6 @@ class NoSpacesPrinterWithWriterReuseSuite extends PrinterSuite(
 )
 
 class UnicodeEscapePrinterWithWriterReuseSuite extends PrinterSuite(
-  Printer.noSpaces.escapeUnicode.copy(reuseWriters = true),
+  Printer.noSpaces.copy(reuseWriters = true, escapeNonAscii = true),
   parser.`package`
 )

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -5,6 +5,14 @@ import io.circe.tests.PrinterSuite
 class Spaces2PrinterSuite extends PrinterSuite(Printer.spaces2, parser.`package`) with Spaces2PrinterExample
 class Spaces4PrinterSuite extends PrinterSuite(Printer.spaces4, parser.`package`)
 class NoSpacesPrinterSuite extends PrinterSuite(Printer.noSpaces, parser.`package`)
+class UnicodeEscapePrinterSuite extends PrinterSuite(Printer.noSpaces.escapeUnicode, parser.`package`) {
+  import io.circe.syntax._
+  "Printing object" should "unicode-escape all non-ASCII chars" in {
+    val actual = Json.obj("0 ℃" := "32 ℉").pretty(printer)
+    val expected = "{\"0 \\u2103\":\"32 \\u2109\"}"
+    assert(actual === expected)
+  }
+}
 
 class Spaces2PrinterWithWriterReuseSuite extends PrinterSuite(
   Printer.spaces2.copy(reuseWriters = true),
@@ -18,5 +26,10 @@ class Spaces4PrinterWithWriterReuseSuite extends PrinterSuite(
 
 class NoSpacesPrinterWithWriterReuseSuite extends PrinterSuite(
   Printer.noSpaces.copy(reuseWriters = true),
+  parser.`package`
+)
+
+class UnicodeEscapePrinterWithWriterReuseSuite extends PrinterSuite(
+  Printer.noSpaces.escapeUnicode.copy(reuseWriters = true),
   parser.`package`
 )


### PR DESCRIPTION
Adds Printer support for having all non-ASCII chars in strings \u-escaped.

This can be useful when generating JSON that is to be used on a transport layer that is not unicode safe (e.g. in an HTTP header).