### PR TITLE
Encoders/Decoders for Java boxed types

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -466,6 +466,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   }
 
   /**
+    * Decode a JSON value into a [[java.lang.Boolean]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaBoolean(implicit d: Decoder[Boolean]): Decoder[java.lang.Boolean] =
+    d.map(java.lang.Boolean.valueOf)
+
+  /**
    * @group Decoding
    */
   implicit final val decodeChar: Decoder[Char] = new Decoder[Char] {
@@ -474,6 +482,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       case _ => Left(DecodingFailure("Char", c.history))
     }
   }
+
+  /**
+    * Decode a JSON value into a [[java.lang.Character]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaCharacter(implicit d: Decoder[Char]): Decoder[java.lang.Character] =
+    d.map(java.lang.Character.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Float]].
@@ -493,6 +509,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       case _ => fail(c)
     }
   }
+
+  /**
+    * Decode a JSON value into a [[java.lang.Float]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaFloat(implicit d: Decoder[Float]): Decoder[java.lang.Float] =
+    d.map(java.lang.Float.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Double]].
@@ -516,6 +540,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   }
 
   /**
+    * Decode a JSON value into a [[java.lang.Double]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaDouble(implicit d: Decoder[Double]): Decoder[java.lang.Double] =
+    d.map(java.lang.Double.valueOf)
+
+  /**
    * Decode a JSON value into a [[scala.Byte]].
    *
    * See [[decodeLong]] for discussion of the approach taken for integral decoding.
@@ -535,6 +567,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       case _ => fail(c)
     }
   }
+
+  /**
+    * Decode a JSON value into a [[java.lang.Byte]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaByte(implicit d: Decoder[Byte]): Decoder[java.lang.Byte] =
+    d.map(java.lang.Byte.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Short]].
@@ -558,12 +598,20 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   }
 
   /**
-   * Decode a JSON value into a [[scala.Int]].
-   *
-   * See [[decodeLong]] for discussion of the approach taken for integral decoding.
-   *
-   * @group Decoding
-   */
+    * Decode a JSON value into a [[java.lang.Short]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaShort(implicit d: Decoder[Short]): Decoder[java.lang.Short] =
+    d.map(java.lang.Short.valueOf)
+
+  /**
+    * Decode a JSON value into a [[scala.Int]].
+    *
+    * See [[decodeLong]] for discussion of the approach taken for integral decoding.
+    *
+    * @group Decoding
+    */
   implicit final val decodeInt: Decoder[Int] = new DecoderWithFailure[Int]("Int") {
     final def apply(c: HCursor): Result[Int] = c.value match {
       case Json.JNumber(number) => number.toInt match {
@@ -577,6 +625,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       case _ => fail(c)
     }
   }
+
+  /**
+    * Decode a JSON value into a [[java.lang.Integer]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaInteger(implicit d: Decoder[Int]): Decoder[java.lang.Integer] =
+    d.map(java.lang.Integer.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Long]].
@@ -603,6 +659,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   }
 
   /**
+    * Decode a JSON value into a [[java.lang.Long]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaLong(implicit d: Decoder[Long]): Decoder[java.lang.Long] =
+    d.map(java.lang.Long.valueOf)
+
+  /**
    * Decode a JSON value into a [[scala.math.BigInt]].
    *
    * Note that decoding will fail if the number has a large number of digits (the limit is currently
@@ -625,6 +689,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       case _ => fail(c)
     }
   }
+
+  /**
+    * Decode a JSON value into a [[java.math.BigInteger]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaBigInteger(implicit d: Decoder[BigInt]): Decoder[java.math.BigInteger] =
+    d.map(_.bigInteger)
 
   /**
    * Decode a JSON value into a [[scala.math.BigDecimal]].
@@ -652,6 +724,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       case _ => fail(c)
     }
   }
+
+  /**
+    * Decode a JSON value into a [[java.math.BigDecimal]].
+    *
+    * @group Decoding
+    */
+  implicit final def decodeJavaBigDecimal(implicit d: Decoder[BigDecimal]): Decoder[java.math.BigDecimal] =
+    d.map(_.bigDecimal)
 
   /**
    * @group Decoding

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -470,8 +470,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaBoolean(implicit d: Decoder[Boolean]): Decoder[java.lang.Boolean] =
-    d.map(java.lang.Boolean.valueOf)
+  implicit final val decodeJavaBoolean: Decoder[java.lang.Boolean] = decodeBoolean.map(java.lang.Boolean.valueOf)
 
   /**
    * @group Decoding
@@ -488,8 +487,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaCharacter(implicit d: Decoder[Char]): Decoder[java.lang.Character] =
-    d.map(java.lang.Character.valueOf)
+  implicit final val decodeJavaCharacter: Decoder[java.lang.Character] = decodeChar.map(java.lang.Character.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Float]].
@@ -515,8 +513,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaFloat(implicit d: Decoder[Float]): Decoder[java.lang.Float] =
-    d.map(java.lang.Float.valueOf)
+  implicit final val decodeJavaFloat: Decoder[java.lang.Float] = decodeFloat.map(java.lang.Float.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Double]].
@@ -544,8 +541,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaDouble(implicit d: Decoder[Double]): Decoder[java.lang.Double] =
-    d.map(java.lang.Double.valueOf)
+  implicit final val decodeJavaDouble: Decoder[java.lang.Double] = decodeDouble.map(java.lang.Double.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Byte]].
@@ -573,8 +569,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaByte(implicit d: Decoder[Byte]): Decoder[java.lang.Byte] =
-    d.map(java.lang.Byte.valueOf)
+  implicit final val decodeJavaByte: Decoder[java.lang.Byte] = decodeByte.map(java.lang.Byte.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Short]].
@@ -602,8 +597,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaShort(implicit d: Decoder[Short]): Decoder[java.lang.Short] =
-    d.map(java.lang.Short.valueOf)
+  implicit final val decodeJavaShort: Decoder[java.lang.Short] = decodeShort.map(java.lang.Short.valueOf)
 
   /**
     * Decode a JSON value into a [[scala.Int]].
@@ -631,8 +625,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaInteger(implicit d: Decoder[Int]): Decoder[java.lang.Integer] =
-    d.map(java.lang.Integer.valueOf)
+  implicit final val decodeJavaInteger: Decoder[java.lang.Integer] = decodeInt.map(java.lang.Integer.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Long]].
@@ -663,8 +656,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaLong(implicit d: Decoder[Long]): Decoder[java.lang.Long] =
-    d.map(java.lang.Long.valueOf)
+  implicit final val decodeJavaLong: Decoder[java.lang.Long] = decodeLong.map(java.lang.Long.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.math.BigInt]].
@@ -695,8 +687,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaBigInteger(implicit d: Decoder[BigInt]): Decoder[java.math.BigInteger] =
-    d.map(_.bigInteger)
+  implicit final val decodeJavaBigInteger: Decoder[java.math.BigInteger] = decodeBigInt.map(_.bigInteger)
 
   /**
    * Decode a JSON value into a [[scala.math.BigDecimal]].
@@ -730,8 +721,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *
     * @group Decoding
     */
-  implicit final def decodeJavaBigDecimal(implicit d: Decoder[BigDecimal]): Decoder[java.math.BigDecimal] =
-    d.map(_.bigDecimal)
+  implicit final val decodeJavaBigDecimal: Decoder[java.math.BigDecimal] = decodeBigDecimal.map(_.bigDecimal)
 
   /**
    * @group Decoding

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -227,8 +227,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaInteger(implicit e: Encoder[Integer]): Encoder[java.lang.Integer] =
-    e.contramap(_.intValue())
+  implicit final val encodeJavaInteger: Encoder[java.lang.Integer] = encodeInt.contramap(_.intValue())
 
   /**
    * @group Encoding

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -158,8 +158,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaCharacter(implicit e: Encoder[Character]): Encoder[java.lang.Character] =
-    e.contramap(_.charValue())
+  implicit final val encodeJavaCharacter: Encoder[java.lang.Character] = encodeChar.contramap(_.charValue())
 
   /**
    * Note that on Scala.js the encoding of `Float` values is subject to the

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -145,8 +145,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaBoolean(implicit e: Encoder[Boolean]): Encoder[java.lang.Boolean] =
-    e.contramap(_.booleanValue())
+  implicit final val encodeJavaBoolean: Encoder[java.lang.Boolean] = encodeBoolean.contramap(_.booleanValue())
 
   /**
    * @group Encoding
@@ -174,8 +173,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaFloat(implicit e: Encoder[Float]): Encoder[java.lang.Float] =
-    e.contramap(_.floatValue())
+  implicit final val encodeJavaFloat: Encoder[java.lang.Float] = encodeFloat.contramap(_.floatValue())
 
   /**
    * @group Encoding
@@ -187,8 +185,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaDouble(implicit e: Encoder[Double]): Encoder[java.lang.Double] =
-    e.contramap(_.doubleValue())
+  implicit final val encodeJavaDouble: Encoder[java.lang.Double] = encodeDouble.contramap(_.doubleValue())
 
   /**
    * @group Encoding
@@ -200,8 +197,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaByte(implicit e: Encoder[Byte]): Encoder[java.lang.Byte] =
-    e.contramap(_.byteValue())
+  implicit final val encodeJavaByte: Encoder[java.lang.Byte] = encodeByte.contramap(_.byteValue())
 
   /**
    * @group Encoding
@@ -213,8 +209,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaShort(implicit e: Encoder[Short]): Encoder[java.lang.Short] =
-    e.contramap(_.shortValue())
+  implicit final val encodeJavaShort: Encoder[java.lang.Short] = encodeShort.contramap(_.shortValue())
 
   /**
    * @group Encoding
@@ -238,8 +233,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaLong(implicit e: Encoder[Long]): Encoder[java.lang.Long] =
-    e.contramap(_.longValue())
+  implicit final val encodeJavaLong: Encoder[java.lang.Long] = encodeLong.contramap(_.longValue())
 
   /**
    * @group Encoding
@@ -251,8 +245,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaBigInteger(implicit e: Encoder[BigInt]): Encoder[java.math.BigInteger] =
-    e.contramap(BigInt.apply)
+  implicit final val encodeJavaBigInteger: Encoder[java.math.BigInteger] = encodeBigInt.contramap(BigInt.apply)
 
   /**
    * @group Encoding
@@ -264,8 +257,7 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
     * @group Encoding
     */
-  implicit final def encodeJavaBigDecimal(implicit e: Encoder[BigDecimal]): Encoder[java.math.BigDecimal] =
-    e.contramap(BigDecimal.apply)
+  implicit final val encodeJavaBigDecimal: Encoder[java.math.BigDecimal] = encodeBigDecimal.contramap(BigDecimal.apply)
 
 
   /**

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -136,11 +136,17 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
-   * @group Encoding
-   */
+    * @group Encoding
+    */
   implicit final val encodeBoolean: Encoder[Boolean] = new Encoder[Boolean] {
     final def apply(a: Boolean): Json = Json.fromBoolean(a)
   }
+
+  /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaBoolean(implicit e: Encoder[Boolean]): Encoder[java.lang.Boolean] =
+    e.contramap(_.booleanValue())
 
   /**
    * @group Encoding
@@ -148,6 +154,12 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   implicit final val encodeChar: Encoder[Char] = new Encoder[Char] {
     final def apply(a: Char): Json = Json.fromString(a.toString)
   }
+
+  /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaCharacter(implicit e: Encoder[Character]): Encoder[java.lang.Character] =
+    e.contramap(_.charValue())
 
   /**
    * Note that on Scala.js the encoding of `Float` values is subject to the
@@ -161,11 +173,23 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaFloat(implicit e: Encoder[Float]): Encoder[java.lang.Float] =
+    e.contramap(_.floatValue())
+
+  /**
    * @group Encoding
    */
   implicit final val encodeDouble: Encoder[Double] = new Encoder[Double] {
     final def apply(a: Double): Json = Json.fromDoubleOrNull(a)
   }
+
+  /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaDouble(implicit e: Encoder[Double]): Encoder[java.lang.Double] =
+    e.contramap(_.doubleValue())
 
   /**
    * @group Encoding
@@ -175,11 +199,23 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaByte(implicit e: Encoder[Byte]): Encoder[java.lang.Byte] =
+    e.contramap(_.byteValue())
+
+  /**
    * @group Encoding
    */
   implicit final val encodeShort: Encoder[Short] = new Encoder[Short] {
     final def apply(a: Short): Json = Json.fromInt(a.toInt)
   }
+
+  /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaShort(implicit e: Encoder[Short]): Encoder[java.lang.Short] =
+    e.contramap(_.shortValue())
 
   /**
    * @group Encoding
@@ -189,11 +225,23 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaInteger(implicit e: Encoder[Integer]): Encoder[java.lang.Integer] =
+    e.contramap(_.intValue())
+
+  /**
    * @group Encoding
    */
   implicit final val encodeLong: Encoder[Long] = new Encoder[Long] {
     final def apply(a: Long): Json = Json.fromLong(a)
   }
+
+  /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaLong(implicit e: Encoder[Long]): Encoder[java.lang.Long] =
+    e.contramap(_.longValue())
 
   /**
    * @group Encoding
@@ -203,11 +251,24 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   }
 
   /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaBigInteger(implicit e: Encoder[BigInt]): Encoder[java.math.BigInteger] =
+    e.contramap(BigInt.apply)
+
+  /**
    * @group Encoding
    */
   implicit final val encodeBigDecimal: Encoder[BigDecimal] = new Encoder[BigDecimal] {
     final def apply(a: BigDecimal): Json = Json.fromBigDecimal(a)
   }
+
+  /**
+    * @group Encoding
+    */
+  implicit final def encodeJavaBigDecimal(implicit e: Encoder[BigDecimal]): Encoder[java.math.BigDecimal] =
+    e.contramap(BigDecimal.apply)
+
 
   /**
    * @group Encoding

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -52,18 +52,21 @@ class JavaBoxedCodecSuite extends CirceSuite {
   implicit val arbJavaShort: Arbitrary[java.lang.Short] = javaLangArb(java.lang.Short.valueOf(_: Short))
   implicit val arbJavaLong: Arbitrary[java.lang.Long] = javaLangArb(java.lang.Long.valueOf(_: Long))
   implicit val arbJavaInteger: Arbitrary[java.lang.Integer] = javaLangArb(java.lang.Integer.valueOf(_: Int))
+  implicit val arbJavaCharacter: Arbitrary[java.lang.Character] = javaLangArb(java.lang.Character.valueOf(_: Char))
 
   implicit val eqJavaBoolean: Eq[java.lang.Boolean] = Eq.fromUniversalEquals
   implicit val eqJavaByte: Eq[java.lang.Byte] = Eq.fromUniversalEquals
   implicit val eqJavaShort: Eq[java.lang.Short] = Eq.fromUniversalEquals
   implicit val eqJavaLong: Eq[java.lang.Long] = Eq.fromUniversalEquals
   implicit val eqJavaInteger: Eq[java.lang.Integer] = Eq.fromUniversalEquals
+  implicit val eqJavaCharacter: Eq[java.lang.Character] = Eq.fromUniversalEquals
 
   checkLaws("Codec[java.lang.Boolean]", CodecTests[java.lang.Boolean].codec)
   checkLaws("Codec[java.lang.Byte]", CodecTests[java.lang.Byte].codec)
   checkLaws("Codec[java.lang.Short]", CodecTests[java.lang.Short].codec)
   checkLaws("Codec[java.lang.Long]", CodecTests[java.lang.Long].codec)
   checkLaws("Codec[java.lang.Integer]", CodecTests[java.lang.Integer].codec)
+  checkLaws("Codec[java.lang.Character]", CodecTests[java.lang.Character].codec)
 }
 
 class StdLibCodecSuite extends CirceSuite {

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -41,6 +41,28 @@ class AnyValCodecSuite extends CirceSuite {
   checkLaws("Codec[Long]", CodecTests[Long].codec)
 }
 
+class JavaBoxedCodecSuite extends CirceSuite {
+
+  private def javaLangArb[ScalaPrimitive, JavaBoxed](wrap: ScalaPrimitive => JavaBoxed)
+                                                    (implicit scalaArb: Arbitrary[ScalaPrimitive]) =
+    Arbitrary(scalaArb.arbitrary.map(wrap))
+
+  implicit val arbJavaBoolean: Arbitrary[java.lang.Boolean] = javaLangArb(java.lang.Boolean.valueOf(_: Boolean))
+  implicit val arbJavaByte: Arbitrary[java.lang.Byte] = javaLangArb(java.lang.Byte.valueOf(_: Byte))
+  implicit val arbJavaShort: Arbitrary[java.lang.Short] = javaLangArb(java.lang.Short.valueOf(_: Short))
+  implicit val arbJavaLong: Arbitrary[java.lang.Long] = javaLangArb(java.lang.Long.valueOf(_: Long))
+
+  implicit val eqJavaBoolean: Eq[java.lang.Boolean] = Eq.fromUniversalEquals
+  implicit val eqJavaByte: Eq[java.lang.Byte] = Eq.fromUniversalEquals
+  implicit val eqJavaShort: Eq[java.lang.Short] = Eq.fromUniversalEquals
+  implicit val eqJavaLong: Eq[java.lang.Long] = Eq.fromUniversalEquals
+
+  checkLaws("Codec[java.lang.Boolean]", CodecTests[java.lang.Boolean].codec)
+  checkLaws("Codec[java.lang.Byte]", CodecTests[java.lang.Byte].codec)
+  checkLaws("Codec[java.lang.Short]", CodecTests[java.lang.Short].codec)
+  checkLaws("Codec[java.lang.Long]", CodecTests[java.lang.Long].codec)
+}
+
 class StdLibCodecSuite extends CirceSuite {
   /**
    * We need serializable `CanBuildFrom` instances for arrays for our `Array` codec tests.

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -43,35 +43,21 @@ class AnyValCodecSuite extends CirceSuite with SpecialEqForFloatAndDouble {
 }
 
 class JavaBoxedCodecSuite extends CirceSuite with SpecialEqForFloatAndDouble {
+  import java.{lang => jl}
 
-  private def javaLangArb[ScalaPrimitive, JavaBoxed](wrap: ScalaPrimitive => JavaBoxed)
-                                                    (implicit scalaArb: Arbitrary[ScalaPrimitive]) =
-    Arbitrary(scalaArb.arbitrary.map(wrap))
+  private def JavaCodecTests[ScalaPrimitive, JavaBoxed]
+    (wrap: ScalaPrimitive => JavaBoxed, unwrap: JavaBoxed => ScalaPrimitive, eq: Eq[JavaBoxed])
+    (implicit scalaArb: Arbitrary[ScalaPrimitive], decoder: Decoder[JavaBoxed], encoder: Encoder[JavaBoxed]) =
+    CodecTests[JavaBoxed].codec(Arbitrary(scalaArb.arbitrary.map(wrap)), implicitly, eq, implicitly, implicitly)
 
-  implicit val arbJavaBoolean: Arbitrary[java.lang.Boolean] = javaLangArb(java.lang.Boolean.valueOf(_: Boolean))
-  implicit val arbJavaByte: Arbitrary[java.lang.Byte] = javaLangArb(java.lang.Byte.valueOf(_: Byte))
-  implicit val arbJavaShort: Arbitrary[java.lang.Short] = javaLangArb(java.lang.Short.valueOf(_: Short))
-  implicit val arbJavaLong: Arbitrary[java.lang.Long] = javaLangArb(java.lang.Long.valueOf(_: Long))
-  implicit val arbJavaInteger: Arbitrary[java.lang.Integer] = javaLangArb(java.lang.Integer.valueOf(_: Int))
-  implicit val arbJavaCharacter: Arbitrary[java.lang.Character] = javaLangArb(java.lang.Character.valueOf(_: Char))
-  implicit val arbJavaDouble: Arbitrary[java.lang.Double] = javaLangArb(java.lang.Double.valueOf(_: Double))
-  implicit val arbJavaFloat: Arbitrary[java.lang.Float] = javaLangArb(java.lang.Float.valueOf(_: Float))
-
-  implicit val eqJavaBoolean: Eq[java.lang.Boolean] = Eq.fromUniversalEquals
-  implicit val eqJavaByte: Eq[java.lang.Byte] = Eq.fromUniversalEquals
-  implicit val eqJavaShort: Eq[java.lang.Short] = Eq.fromUniversalEquals
-  implicit val eqJavaLong: Eq[java.lang.Long] = Eq.fromUniversalEquals
-  implicit val eqJavaInteger: Eq[java.lang.Integer] = Eq.fromUniversalEquals
-  implicit val eqJavaCharacter: Eq[java.lang.Character] = Eq.fromUniversalEquals
-
-  checkLaws("Codec[java.lang.Boolean]", CodecTests[java.lang.Boolean].codec)
-  checkLaws("Codec[java.lang.Byte]", CodecTests[java.lang.Byte].codec)
-  checkLaws("Codec[java.lang.Short]", CodecTests[java.lang.Short].codec)
-  checkLaws("Codec[java.lang.Long]", CodecTests[java.lang.Long].codec)
-  checkLaws("Codec[java.lang.Integer]", CodecTests[java.lang.Integer].codec)
-  checkLaws("Codec[java.lang.Character]", CodecTests[java.lang.Character].codec)
-  checkLaws("Codec[java.lang.Double]", CodecTests[java.lang.Double].codec(implicitly, implicitly, eqDouble.contramap(_.doubleValue()), implicitly, implicitly))
-  checkLaws("Codec[java.lang.Float]", CodecTests[java.lang.Float].codec(implicitly, implicitly, eqFloat.contramap(_.floatValue()), implicitly, implicitly))
+  checkLaws("Codec[java.lang.Boolean]", JavaCodecTests[Boolean, jl.Boolean](jl.Boolean.valueOf, _.booleanValue(), Eq.fromUniversalEquals))
+  checkLaws("Codec[java.lang.Byte]", JavaCodecTests[Byte, jl.Byte](jl.Byte.valueOf, _.byteValue(), Eq.fromUniversalEquals))
+  checkLaws("Codec[java.lang.Short]", JavaCodecTests[Short, jl.Short](jl.Short.valueOf, _.shortValue(), Eq.fromUniversalEquals))
+  checkLaws("Codec[java.lang.Long]", JavaCodecTests[Long, jl.Long](jl.Long.valueOf, _.longValue(), Eq.fromUniversalEquals))
+  checkLaws("Codec[java.lang.Integer]", JavaCodecTests[Int, jl.Integer](jl.Integer.valueOf, _.intValue(), Eq.fromUniversalEquals))
+  checkLaws("Codec[java.lang.Character]", JavaCodecTests[Char, jl.Character](jl.Character.valueOf, _.charValue(), Eq.fromUniversalEquals))
+  checkLaws("Codec[java.lang.Double]", JavaCodecTests[Double, jl.Double](jl.Double.valueOf, _.doubleValue(), eqDouble.contramap(_.doubleValue())))
+  checkLaws("Codec[java.lang.Float]", JavaCodecTests[Float, jl.Float](jl.Float.valueOf, _.floatValue(), eqFloat.contramap(_.floatValue())))
 }
 
 class StdLibCodecSuite extends CirceSuite {

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -51,16 +51,19 @@ class JavaBoxedCodecSuite extends CirceSuite {
   implicit val arbJavaByte: Arbitrary[java.lang.Byte] = javaLangArb(java.lang.Byte.valueOf(_: Byte))
   implicit val arbJavaShort: Arbitrary[java.lang.Short] = javaLangArb(java.lang.Short.valueOf(_: Short))
   implicit val arbJavaLong: Arbitrary[java.lang.Long] = javaLangArb(java.lang.Long.valueOf(_: Long))
+  implicit val arbJavaInteger: Arbitrary[java.lang.Integer] = javaLangArb(java.lang.Integer.valueOf(_: Int))
 
   implicit val eqJavaBoolean: Eq[java.lang.Boolean] = Eq.fromUniversalEquals
   implicit val eqJavaByte: Eq[java.lang.Byte] = Eq.fromUniversalEquals
   implicit val eqJavaShort: Eq[java.lang.Short] = Eq.fromUniversalEquals
   implicit val eqJavaLong: Eq[java.lang.Long] = Eq.fromUniversalEquals
+  implicit val eqJavaInteger: Eq[java.lang.Integer] = Eq.fromUniversalEquals
 
   checkLaws("Codec[java.lang.Boolean]", CodecTests[java.lang.Boolean].codec)
   checkLaws("Codec[java.lang.Byte]", CodecTests[java.lang.Byte].codec)
   checkLaws("Codec[java.lang.Short]", CodecTests[java.lang.Short].codec)
   checkLaws("Codec[java.lang.Long]", CodecTests[java.lang.Long].codec)
+  checkLaws("Codec[java.lang.Integer]", CodecTests[java.lang.Integer].codec)
 }
 
 class StdLibCodecSuite extends CirceSuite {

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -44,20 +44,23 @@ class AnyValCodecSuite extends CirceSuite with SpecialEqForFloatAndDouble {
 
 class JavaBoxedCodecSuite extends CirceSuite with SpecialEqForFloatAndDouble {
   import java.{lang => jl}
+  import java.{math => jm}
 
   private def JavaCodecTests[ScalaPrimitive, JavaBoxed]
-    (wrap: ScalaPrimitive => JavaBoxed, unwrap: JavaBoxed => ScalaPrimitive, eq: Eq[JavaBoxed])
+    (wrap: ScalaPrimitive => JavaBoxed, unwrap: JavaBoxed => ScalaPrimitive, eq: Eq[JavaBoxed] = Eq.fromUniversalEquals[JavaBoxed])
     (implicit scalaArb: Arbitrary[ScalaPrimitive], decoder: Decoder[JavaBoxed], encoder: Encoder[JavaBoxed]) =
     CodecTests[JavaBoxed].codec(Arbitrary(scalaArb.arbitrary.map(wrap)), implicitly, eq, implicitly, implicitly)
 
-  checkLaws("Codec[java.lang.Boolean]", JavaCodecTests[Boolean, jl.Boolean](jl.Boolean.valueOf, _.booleanValue(), Eq.fromUniversalEquals))
-  checkLaws("Codec[java.lang.Byte]", JavaCodecTests[Byte, jl.Byte](jl.Byte.valueOf, _.byteValue(), Eq.fromUniversalEquals))
-  checkLaws("Codec[java.lang.Short]", JavaCodecTests[Short, jl.Short](jl.Short.valueOf, _.shortValue(), Eq.fromUniversalEquals))
-  checkLaws("Codec[java.lang.Long]", JavaCodecTests[Long, jl.Long](jl.Long.valueOf, _.longValue(), Eq.fromUniversalEquals))
-  checkLaws("Codec[java.lang.Integer]", JavaCodecTests[Int, jl.Integer](jl.Integer.valueOf, _.intValue(), Eq.fromUniversalEquals))
-  checkLaws("Codec[java.lang.Character]", JavaCodecTests[Char, jl.Character](jl.Character.valueOf, _.charValue(), Eq.fromUniversalEquals))
-  checkLaws("Codec[java.lang.Double]", JavaCodecTests[Double, jl.Double](jl.Double.valueOf, _.doubleValue(), eqDouble.contramap(_.doubleValue())))
+  checkLaws("Codec[java.lang.Boolean]", JavaCodecTests[Boolean, jl.Boolean](jl.Boolean.valueOf, _.booleanValue()))
+  checkLaws("Codec[java.lang.Character]", JavaCodecTests[Char, jl.Character](jl.Character.valueOf, _.charValue()))
   checkLaws("Codec[java.lang.Float]", JavaCodecTests[Float, jl.Float](jl.Float.valueOf, _.floatValue(), eqFloat.contramap(_.floatValue())))
+  checkLaws("Codec[java.lang.Double]", JavaCodecTests[Double, jl.Double](jl.Double.valueOf, _.doubleValue(), eqDouble.contramap(_.doubleValue())))
+  checkLaws("Codec[java.lang.Byte]", JavaCodecTests[Byte, jl.Byte](jl.Byte.valueOf, _.byteValue()))
+  checkLaws("Codec[java.lang.Short]", JavaCodecTests[Short, jl.Short](jl.Short.valueOf, _.shortValue()))
+  checkLaws("Codec[java.lang.Long]", JavaCodecTests[Long, jl.Long](jl.Long.valueOf, _.longValue()))
+  checkLaws("Codec[java.lang.Integer]", JavaCodecTests[Int, jl.Integer](jl.Integer.valueOf, _.intValue()))
+  checkLaws("Codec[java.math.BigDecimal]", JavaCodecTests[BigDecimal, jm.BigDecimal](_.bigDecimal, BigDecimal.apply))
+  checkLaws("Codec[java.math.BigInteger]", JavaCodecTests[BigInt, jm.BigInteger](_.bigInteger, BigInt.apply))
 }
 
 class StdLibCodecSuite extends CirceSuite {


### PR DESCRIPTION
Adds support for decoding/encoding in Java's boxed types. I wasn't sure:

- Where/if to add some tests - I couldn't find existing tests for the Decoder/Encoder of Scala's value types apart from specific ones around out-of-range values
- Whether the new instances should pick up the ones for Scala's value types implicitly or just directly