### PR TITLE
Post-0.9.0 clean-up

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,9 @@ lazy val baseSettings = Seq(
   scalacOptions in (Test, console) ~= {
     _.filterNot(Set("-Ywarn-unused-import", "-Yno-predef"))
   },
+  scalacOptions in Tut ~= {
+    _.filterNot(Set("-Ywarn-unused-import", "-Yno-predef"))
+  },
   scalacOptions in Test ~= {
     _.filterNot(Set("-Yno-predef"))
   },

--- a/docs/src/main/tut/quickstart.md
+++ b/docs/src/main/tut/quickstart.md
@@ -4,7 +4,7 @@ circe is published to [Maven Central][maven-central] and cross-built for Scala 2
 so you can just add the following to your build:
 
 ```scala
-val circeVersion = "0.8.0"
+val circeVersion = "0.9.0"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC12")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")


### PR DESCRIPTION
Fixes issue with warnings in the project guide and updates the version in the quick-start (both as noted by @ochrons). Will follow up with #820 as soon as possible.