### PR TITLE
Add key codecs for refined types

### DIFF
--- a/modules/refined/shared/src/main/scala/io/circe/refined/package.scala
+++ b/modules/refined/shared/src/main/scala/io/circe/refined/package.scala
@@ -41,4 +41,19 @@ package object refined {
     refType: RefType[F]
   ): Encoder[F[T, P]] =
     underlying.contramap(refType.unwrap)
+
+  implicit final def refinedKeyDecoder[T, P, F[_, _]](implicit
+    underlying: KeyDecoder[T],
+    validate: Validate[T, P],
+    refType: RefType[F]
+  ): KeyDecoder[F[T, P]] =
+    KeyDecoder.instance { str =>
+      underlying(str).flatMap(t => refType.refine(t).toOption)
+    }
+
+  implicit final def refinedKeyEncoder[T, P, F[_, _]](implicit
+    underlying: KeyEncoder[T],
+    refType: RefType[F]
+  ): KeyEncoder[F[T, P]] =
+    underlying.contramap(refType.unwrap)
 }

--- a/modules/refined/shared/src/main/scala/io/circe/refined/package.scala
+++ b/modules/refined/shared/src/main/scala/io/circe/refined/package.scala
@@ -48,7 +48,12 @@ package object refined {
     refType: RefType[F]
   ): KeyDecoder[F[T, P]] =
     KeyDecoder.instance { str =>
-      underlying(str).flatMap(t => refType.refine(t).toOption)
+      underlying(str) flatMap { t0 =>
+        refType.refine(t0) match {
+          case Left(_) => None
+          case Right(t) => Some(t)
+        }
+      }
     }
 
   implicit final def refinedKeyEncoder[T, P, F[_, _]](implicit


### PR DESCRIPTION
Should be useful for stuff like `Map[NonEmptyString, Whatever]`.