### PR TITLE
Keep wrapped instance's decodeAccumulating method in Decoder.validate

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -126,6 +126,8 @@ trait Decoder[A] extends Serializable { self =>
   final def validate(pred: HCursor => Boolean, message: => String): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] =
       if (pred(c)) self(c) else Left(DecodingFailure(message, c.history))
+
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] = self.decodeAccumulating(c)
   }
 
   /**


### PR DESCRIPTION
Fixes #837