### PR TITLE
Stop serializing the 'kleisli' val on 'JsonObject'

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -71,6 +71,7 @@ sealed abstract class JsonObject extends Serializable {
    *
    * @group Contents
    */
+  @transient
   final val kleisli: Kleisli[Option, String, Json] = Kleisli(apply(_))
 
   /**


### PR DESCRIPTION
Currently, if you attempt to serialize a `JsonObject` it will include the [kleisli](https://github.com/circe/circe/blob/master/modules/core/shared/src/main/scala/io/circe/JsonObject.scala#L74) field. This is probably not necessary for serialization as it can be reconstructed when it is deserialized. In use cases where serialized JsonObjects are being shipped over the network this adds (probably) unwanted overhead.

If there are objections to the use of `@transient`, it could also be turned back into a `def`.

## Example
If you run the following:
```
import java.io._
import io.circe._
val file = new FileOutputStream("foo.txt")
val out = new ObjectOutputStream(file)
val json = JsonObject("foo" -> Json.fromString("bar"))
out.writeObject(json)
```
You will get an object that includes the serialized Kleisli: https://gist.github.com/rpless/dab329897ebf54e85518db09bcd89477#file-kleisli-serialized
and this with this pull request you will not: https://gist.github.com/rpless/dab329897ebf54e85518db09bcd89477#file-without-kleisli

We originally found this issue with Kryo serialization, because the upgrade from 0.8.0 to 0.9.1 will break on the standard Kryo serializers. We fixed our issue by including a `ClosureSerializer` which means we are doing roughly the same as above but with Kryo.