### PR TITLE
Make optional decoders fail with Left at the top-level for non-nulls

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -748,7 +748,6 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     case c: HCursor =>
       if (c.value.isNull) rightNone else d(c) match {
         case Right(a) => Right(Some(a))
-        case Left(df) if df.history.isEmpty => rightNone
         case Left(df) => Left(df)
       }
     case c: FailedCursor =>

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -169,6 +169,23 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     }
   }
 
+  "An optional top-level decoder" should "fail appropriately" in {
+    val decoder: Decoder[Option[String]] = Decoder.instance(_.as[Option[String]])
+
+    forAll { (json: Json) =>
+      val result = decoder.apply(json.hcursor)
+
+      assert(
+        if (json.isNull) {
+          result === Right(None)
+        } else json.asString match {
+          case Some(str) => result === Right(Some(str))
+          case None => result.isLeft
+        }
+      )
+    }
+  }
+
   "instanceTry" should "provide instances that succeed or fail appropriately" in forAll { (json: Json) =>
     val exception = new Exception("Not an Int")
     val expected = json.hcursor.as[Int].leftMap(_ => DecodingFailure.fromThrowable(exception, Nil))


### PR DESCRIPTION
This addresses #851.

I think I've implemented the change correctly, so that only `null` at the top level decodes as `Right(None)` and decoding failures from the inner decoder are otherwise passed through. If this wasn't quite what you had in mind please let me know, I'm more than happy to fix it up.