### PR TITLE
Fix #849. Optimize performance for encoding/decoding when using custom transformations of member names or constructor

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
@@ -4,12 +4,11 @@ import io.circe.{AccumulatingDecoder, Decoder, HCursor}
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.extras.{ Configuration, JsonKey }
 import io.circe.generic.extras.util.RecordToMap
+import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.Map
 import shapeless.{ Annotations, Coproduct, Default, HList, LabelledGeneric, Lazy }
 import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
-
-import scala.collection.concurrent.TrieMap
 
 abstract class ConfiguredDecoder[A] extends DerivedDecoder[A]
 
@@ -27,7 +26,7 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
 
     private[this] def memberNameTransformer(value: String): String =
       memberNameCache.getOrElseUpdate(value, {
-        if(keyAnnotationMap.nonEmpty)
+        if (keyAnnotationMap.nonEmpty)
           keyAnnotationMap.getOrElse(value, config.transformMemberNames(value))
         else
           config.transformMemberNames(value)

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ConfiguredObjectEncoder.scala
@@ -3,11 +3,11 @@ package io.circe.generic.extras.encoding
 import io.circe.JsonObject
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.extras.{ Configuration, JsonKey }
+import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.Map
 import shapeless.{ Annotations, Coproduct, HList, LabelledGeneric, Lazy }
 import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
-import scala.collection.concurrent.TrieMap
 
 abstract class ConfiguredObjectEncoder[A] extends DerivedObjectEncoder[A]
 
@@ -30,7 +30,7 @@ final object ConfiguredObjectEncoder {
       }.toMap
 
     private[this] def memberNameTransformer(value: String): String = {
-      if(hasKeyAnnotations)
+      if (hasKeyAnnotations)
         keyAnnotationMap.getOrElse(value, config.transformMemberNames(value))
       else
         config.transformMemberNames(value)


### PR DESCRIPTION
Remove calling transformMemberName and transformConstructorNames of Configuration on every encoding, decoding to/from json