### PR TITLE
Fix stateful decoding of optional fields

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -978,6 +978,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       val field = c.downField(k)
 
       field.as[A] match {
+        case Right(a) if field.failed => Right((c, a))
         case Right(a) => Right((field.delete, a))
         case l @ Left(_) => l.asInstanceOf[Result[(ACursor, A)]]
       }


### PR DESCRIPTION
This fixes #708 

It is the simplest solution I could come up with that should work with all decoders that do not consume json. 
If a decoder succeeds even tough the field was non-existent we just use the initial cursor state. 
