### PR TITLE
Don't create a Kleisli instance for every JsonObject

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -71,8 +71,7 @@ sealed abstract class JsonObject extends Serializable {
    *
    * @group Contents
    */
-  @transient
-  final val kleisli: Kleisli[Option, String, Json] = Kleisli(apply(_))
+  final def kleisli: Kleisli[Option, String, Json] = Kleisli(apply(_))
 
   /**
    * Return all keys in insertion order.


### PR DESCRIPTION
I'm not entirely sure why this is a `val`—it's not very commonly used in my experience and instantiating a couple of extra objects for every `JsonObject` is wasteful.