### PR TITLE
Implement Raw* classes directly in circe-jawn

### DIFF
--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -2,51 +2,51 @@ package io.circe.jawn
 
 import io.circe.{ Json, JsonNumber, JsonObject }
 import java.util.LinkedHashMap
-import jawn.{ Facade, FContext, SupportParser }
+import jawn.{ RawFacade, RawFContext, SupportParser }
 
 final object CirceSupportParser extends SupportParser[Json] {
-  implicit final val facade: Facade[Json] = new Facade[Json] {
-    final def jnull(): Json = Json.Null
-    final def jfalse(): Json = Json.False
-    final def jtrue(): Json = Json.True
-    final def jnum(s: CharSequence, decIndex: Int, expIndex: Int): Json =
+  implicit final val facade: RawFacade[Json] = new RawFacade[Json] {
+    final def jnull(index: Int): Json = Json.Null
+    final def jfalse(index: Int): Json = Json.False
+    final def jtrue(index: Int): Json = Json.True
+    final def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): Json =
       if (decIndex < 0 && expIndex < 0) {
         Json.fromJsonNumber(JsonNumber.fromIntegralStringUnsafe(s.toString))
       } else {
         Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe(s.toString))
       }
-    final def jstring(s: CharSequence): Json = Json.fromString(s.toString)
+    final def jstring(s: CharSequence, index: Int): Json = Json.fromString(s.toString)
 
-    final def singleContext(): FContext[Json] = new FContext[Json] {
+    final def singleContext(index: Int): RawFContext[Json] = new RawFContext[Json] {
       private[this] final var value: Json = null
-      final def add(s: CharSequence): Unit = { value = jstring(s.toString) }
-      final def add(v: Json): Unit =  { value = v }
-      final def finish: Json = value
+      final def add(s: CharSequence, index: Int): Unit = { value = jstring(s.toString, index) }
+      final def add(v: Json, index: Int): Unit =  { value = v }
+      final def finish(index: Int): Json = value
       final def isObj: Boolean = false
     }
 
-    final def arrayContext(): FContext[Json] = new FContext[Json] {
+    final def arrayContext(index: Int): RawFContext[Json] = new RawFContext[Json] {
       private[this] final val vs = Vector.newBuilder[Json]
-      final def add(s: CharSequence): Unit = { vs += jstring(s.toString) }
-      final def add(v: Json): Unit = { vs += v }
-      final def finish: Json = Json.fromValues(vs.result())
+      final def add(s: CharSequence, index: Int): Unit = { vs += jstring(s.toString, index) }
+      final def add(v: Json, index: Int): Unit = { vs += v }
+      final def finish(index: Int): Json = Json.fromValues(vs.result())
       final def isObj: Boolean = false
     }
 
-    def objectContext(): FContext[Json] = new FContext[Json] {
+    def objectContext(index: Int): RawFContext[Json] = new RawFContext[Json] {
       private[this] final var key: String = null
       private[this] final val m = new LinkedHashMap[String, Json]
 
-      final def add(s: CharSequence): Unit =
+      final def add(s: CharSequence, index: Int): Unit =
         if (key.eq(null)) { key = s.toString } else {
-          m.put(key, jstring(s))
+          m.put(key, jstring(s, index))
           key = null
         }
-      final def add(v: Json): Unit = {
+      final def add(v: Json, index: Int): Unit = {
         m.put(key, v)
         key = null
       }
-      final def finish: Json = Json.fromJsonObject(JsonObject.fromLinkedHashMap(m))
+      final def finish(index: Int): Json = Json.fromJsonObject(JsonObject.fromLinkedHashMap(m))
       final def isObj: Boolean = true
     }
   }


### PR DESCRIPTION
After publishing 0.10.0-M1 yesterday, I noticed that the [benchmark](https://github.com/circe/circe-benchmarks) results looked kind of bad:

```
Benchmark                        Mode  Cnt      Score     Error  Units
ReadingBenchmark.readFoosCirce  thrpt  100   3385.838 ±  27.815  ops/s
ReadingBenchmark.readIntsCirce  thrpt  100  14774.716 ± 115.221  ops/s
```

Compared to the following for 0.9.3:

```
Benchmark                        Mode  Cnt      Score     Error  Units
ReadingBenchmark.readFoosCirce  thrpt  100   3432.876 ±  33.256  ops/s
ReadingBenchmark.readIntsCirce  thrpt  100  17841.714 ± 136.597  ops/s
```

The change in this PR recovers the ~17% of throughput we lost in the integer array reading benchmark:

```
Benchmark                        Mode  Cnt      Score     Error  Units
ReadingBenchmark.readFoosCirce  thrpt  100   3461.370 ±  19.840  ops/s
ReadingBenchmark.readIntsCirce  thrpt  100  17546.385 ± 281.803  ops/s
```

I probably won't publish an M2 yet unless someone feels very strongly that they need it.