### PR TITLE
Add support for scalaz-deriving

### DIFF
--- a/modules/generic/shared/src/main/resources/deriving.conf
+++ b/modules/generic/shared/src/main/resources/deriving.conf
@@ -1,0 +1,2 @@
+io.circe.ObjectEncoder=io.circe.generic.semiauto.deriveEncoder
+io.circe.Decoder=io.circe.generic.semiauto.deriveDecoder


### PR DESCRIPTION
This is a tiny addition of a file `scalaz-deriving.conf` to the `circe-generic` module.
With this file, it is possible to use [scalaz-deriving](https://gitlab.com/fommil/scalaz-deriving) for derivation of circe `Encoder` and `Decoder` instances.
The code would look similar to the following:

```scala
import io.circe.{ Decoder, Encoder }

import scalaz._
import Scalaz._

// Derive circe Decoder/Encoder as well as scalaz Equal/Show
@deriving(Decoder, Encoder, Equal, Show)
final case class Foo(
  a: String,
  b: Int,
  c: List[String]
)
```

I understand that this is basically what circe's semi-automatic derivation does (and as a matter of fact, that is exactly what is used).
It would, however, be nice to support `scalaz-deriving` to have circe support a framework that can be used to derive instances beyond just circe itself.
Given the minimal impact this has (adding one file to the resources of the `generic` module), I hope this PR will be considered. 