### PR TITLE
Parser#decodeAccumulating does not accumulate errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ val compilerOptions = Seq(
   "-Ywarn-numeric-widen",
   "-Xfuture",
   "-Yno-predef",
-  "-Ywarn-unused-import"
+  "-Ywarn-unused-import",
+  "-Ypartial-unification"
 )
 
 val catsVersion = "1.1.0"

--- a/modules/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
@@ -1,6 +1,9 @@
 package io.circe.parser
 
-import io.circe.Json
+import cats.data.Validated.Invalid
+import cats.syntax.apply._
+import cats.syntax.either._
+import io.circe.{AccumulatingDecoder, Json}
 import io.circe.testing.ParserTests
 import io.circe.tests.CirceSuite
 
@@ -11,5 +14,19 @@ class ParserSuite extends CirceSuite {
     assert(parse(s"Not JSON $s").isLeft)
     assert(decode[Json](s"Not JSON $s").isLeft)
     assert(decodeAccumulating[Json](s"Not JSON $s").isInvalid)
+  }
+
+  "decodeAccumulating" should "returns all errors on invalid input" in {
+    case class Sample(a: String, b: String)
+    implicit val decoder: AccumulatingDecoder[Sample] = AccumulatingDecoder.instance {
+      cursor => (
+        cursor.get[String]("a").toValidatedNel,
+        cursor.get[String]("b").toValidatedNel
+      ).mapN(Sample.apply)
+    }
+    decodeAccumulating[Sample]("{}") match {
+      case Invalid(errs) => assert(errs.length == 2)
+      case _ => fail("Parser#decodeAccumulating returns Valid on invalid input")
+    }
   }
 }


### PR DESCRIPTION
I found that Parser#decodeAccumulating doesn't accumulate errors.

```
import cats.syntax.apply._
import cats.syntax.either._

import io.circe._
import io.circe.parser._

case class Foo(name: String, age: Int)

object FooDecoder {

  implicit val decoder: Decoder[Foo] = Decoder.instance {
    cursor => for {
      name <- cursor.get[String]("name")
      age <- cursor.get[Int]("age")
    } yield Foo(name, age)
  }
}

object FooAccumulatingDecoder {

  implicit val accDecoder: AccumulatingDecoder[Foo] = AccumulatingDecoder.instance {
    cursor => (
      cursor.get[String]("name").toValidatedNel,
      cursor.get[Int]("age").toValidatedNel
    ).mapN(Foo.apply)
  }
}

// cannot use AccumulatingDecoder here...
println(decodeAccumulating("{}")(FooDecoder.decoder)) 
```

This produces the following result:
```
Invalid(NonEmptyList(DecodingFailure(Attempt to decode value on failed cursor, List(DownField(name)))))
```

My expectation from its name was:
```
Invalid(NonEmptyList(DecodingFailure(Attempt to decode value on failed cursor, List(DownField(name))), DecodingFailure(Attempt to decode value on failed cursor, List(DownField(age)))))
```

I think a problem here is that `decodeAccumulating` takes `Decoder` that is fail-fast implementation so I replace it with `AccumulatingDecoder`.
