### PR TITLE
Preserve iteration order when encoding maps

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -225,7 +225,10 @@ final object JsonObject {
    *
    * Note that the order of the fields is arbitrary.
    */
-  final def fromMap(map: Map[String, Json]): JsonObject = new MapAndVectorJsonObject(map, map.keys.toVector)
+  final def fromMap(map: Map[String, Json]): JsonObject = fromMapAndVector(map, map.keys.toVector)
+
+  private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject =
+    new MapAndVectorJsonObject(map, keys)
 
   private[circe] final def fromLinkedHashMap(map: LinkedHashMap[String, Json]): JsonObject =
     new LinkedHashMapJsonObject(map)

--- a/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
@@ -3,6 +3,8 @@ package io.circe
 import cats.laws.discipline.ContravariantTests
 import io.circe.syntax._
 import io.circe.tests.CirceSuite
+import org.scalacheck.Arbitrary
+import scala.collection.SortedMap
 
 class EncoderSuite extends CirceSuite {
   checkLaws("Encoder[Int]", ContravariantTests[Encoder].contravariant[Int, Int, Int])
@@ -34,6 +36,25 @@ class EncoderSuite extends CirceSuite {
   "encodeList" should "match sequence encoders" in forAll { (xs: List[Int]) =>
     assert(Encoder.encodeList[Int].apply(xs) === Encoder[Seq[Int]].apply(xs))
   }
+
+  case class MyString(value: String)
+
+  object MyString {
+    implicit val myStringOrdering: Ordering[MyString] = Ordering.by[MyString, String](_.value).reverse
+    implicit val myStringKeyEncoder: KeyEncoder[MyString] = KeyEncoder.instance(_.value)
+    implicit val myStringArbitrary: Arbitrary[MyString] = Arbitrary(
+      Arbitrary.arbitrary[String].map(MyString(_))
+    )
+  }
+
+  "encodeMap" should "preserve insertion order" in forAll { (m: SortedMap[MyString, String]) =>
+    val Some(asJsonObject) = m.asJson.asObject
+    val expected = m.toList.map {
+      case (k, v) => MyString.myStringKeyEncoder(k) -> Json.fromString(v)
+    }
+
+    assert(asJsonObject.toList === expected)
+  } 
 
   "encodeVector" should "match sequence encoders" in forAll { (xs: Vector[Int]) =>
     assert(Encoder.encodeVector[Int].apply(xs) === Encoder[Seq[Int]].apply(xs))


### PR DESCRIPTION
This seems at least bug-like to me:

```scala
scala> import io.circe.syntax._, scala.collection.SortedMap
import io.circe.syntax._
import scala.collection.SortedMap

scala> val m = SortedMap("z" -> 100, "a" -> 1, "b" -> 2, "c" -> 3, "d" -> 4)
m: scala.collection.SortedMap[String,Int] = Map(a -> 1, b -> 2, c -> 3, d -> 4, z -> 100)

scala> m.asJson.noSpaces
res0: String = {"a":1,"b":2,"c":3,"z":100,"d":4}
```

I don't believe we've really specified the behavior here, but I thought (and have told people) that the default map encoders preserve iteration order ([e.g.](https://gitter.im/circe/circe?at=5b852a35cff55e561770be92)).

The change here gives the order we expect:
```scala
scala>  import io.circe.syntax._, scala.collection.SortedMap
import io.circe.syntax._
import scala.collection.SortedMap

scala> val m = SortedMap("z" -> 100, "a" -> 1, "b" -> 2, "c" -> 3, "d" -> 4)
m: scala.collection.SortedMap[String,Int] = Map(a -> 1, b -> 2, c -> 3, d -> 4, z -> 100)

scala> m.asJson.noSpaces
res0: String = {"a":1,"b":2,"c":3,"d":4,"z":100}
```

Because this is essentially unspecified, and because 0.10.0 is not far off, I'm not planning to publish an 0.9.4 just for this fix, but I guess I can if anyone really, really needs it.

Thanks @asakaev for pointing out the issue.