### PR TITLE
2.13 clean-up

### DIFF
--- a/modules/core/shared/src/main/scala-2.13+/io/circe/CollectionDecoders.scala
+++ b/modules/core/shared/src/main/scala-2.13+/io/circe/CollectionDecoders.scala
@@ -23,7 +23,7 @@ private[circe] trait CollectionDecoders {
    *       unless the provided [[scala.collection.Factory]] is serializable.
    * @group Collection
    */
-  implicit final def decodeTraversable[A, C[A] <: Traversable[A]](implicit
+  implicit final def decodeIterable[A, C[A] <: Iterable[A]](implicit
     decodeA: Decoder[A],
     factory: Factory[A, C[A]]
   ): Decoder[C[A]] = new SeqDecoder[A, C](decodeA) {

--- a/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
@@ -25,7 +25,7 @@ private[circe] abstract class SeqDecoder[A, C[_]](decodeA: Decoder[A]) extends D
       if (failed.eq(null)) Right(builder.result) else Left(failed)
     } else {
       if (c.value.isArray) Right(createBuilder().result) else {
-        Left(DecodingFailure("CanBuildFrom for A", c.history))
+        Left(DecodingFailure("C[A]", c.history))
       }
     }
   }
@@ -58,7 +58,7 @@ private[circe] abstract class SeqDecoder[A, C[_]](decodeA: Decoder[A]) extends D
       }
     } else {
       if (c.value.isArray) Validated.valid(createBuilder().result) else {
-        Validated.invalidNel(DecodingFailure("CanBuildFrom for A", c.history))
+        Validated.invalidNel(DecodingFailure("C[A]", c.history))
       }
     }
   }


### PR DESCRIPTION
The `decodeTraversable` on 2.13 thing was an error, and the other change is an old error message that's now both unhelpful and wrong instead of just unhelpful.