### PR TITLE
Move target and source type parameters to the front of the line

### DIFF
--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -109,7 +109,7 @@ package examples {
     )
 
     val decodeBam: Decoder[Bam] = Decoder.forProduct2("w", "d")(Bam.apply)(Wub.decodeWub, implicitly)
-    val encodeBam: Encoder[Bam] = Encoder.forProduct2[Wub, Double, Bam]("w", "d") {
+    val encodeBam: Encoder[Bam] = Encoder.forProduct2[Bam, Wub, Double]("w", "d") {
       case Bam(w, d) => (w, d)
     }(Wub.encodeWub, implicitly)
   }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -231,7 +231,7 @@ object Boilerplate {
         -  /**
         -   * @group Product
         -   */
-        -  final def forProduct$arity[${`A..N`}, Target]($memberNames)(f: (${`A..N`}) => Target)(implicit
+        -  final def forProduct$arity[Target, ${`A..N`}]($memberNames)(f: (${`A..N`}) => Target)(implicit
         -    $instances
         -  ): Decoder[Target] =
         -    new Decoder[Target] {
@@ -269,7 +269,7 @@ object Boilerplate {
         -  /**
         -   * @group Product
         -   */
-        -  final def forProduct$arity[${`A..N`}, Source]($memberNames)(f: Source => $outputType)(implicit
+        -  final def forProduct$arity[Source, ${`A..N`}]($memberNames)(f: Source => $outputType)(implicit
         -    $instances
         -  ): ObjectEncoder[Source] =
         -    new ObjectEncoder[Source] {


### PR DESCRIPTION
This throws me off every time I have to write these out. Originally I'd followed what Argonaut did for `casecodecN`, `codecN`, `jdecodeN`, etc. (but _not_ `jencodeN`), but I think consistently putting the parameter first feels more natural.

I know this is going to be an annoying thing to migrate, but I don't want 1.0 to be stuck with bad API decisions because of some minor migration pain.