### PR TITLE
Close #979 by adding encoders and decoders for MonthDay, Year, and ZoneOffset

### DIFF
--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
@@ -8,11 +8,14 @@ import java.time.{
   LocalDate,
   LocalDateTime,
   LocalTime,
+  MonthDay,
   OffsetDateTime,
   OffsetTime,
   Period,
+  Year,
   YearMonth,
   ZonedDateTime,
+  ZoneOffset,
   ZoneId
 }
 import java.time.format.DateTimeFormatter
@@ -127,6 +130,15 @@ private[time] trait JavaTimeDecoders {
   /**
    * @group Time
    */
+  final def decodeMonthDayWithFormatter(formatter: DateTimeFormatter): Decoder[MonthDay] =
+    new StandardJavaTimeDecoder[MonthDay]("MonthDay") {
+      protected final def parseUnsafe(input: String): MonthDay =
+        MonthDay.parse(input, formatter)
+    }
+
+  /**
+   * @group Time
+   */
   final def decodeOffsetTimeWithFormatter(formatter: DateTimeFormatter): Decoder[OffsetTime] =
     new StandardJavaTimeDecoder[OffsetTime]("OffsetTime") {
       protected final def parseUnsafe(input: String): OffsetTime =
@@ -145,10 +157,10 @@ private[time] trait JavaTimeDecoders {
   /**
    * @group Time
    */
-  final def decodeZonedDateTimeWithFormatter(formatter: DateTimeFormatter): Decoder[ZonedDateTime] =
-    new StandardJavaTimeDecoder[ZonedDateTime]("ZonedDateTime") {
-      protected final def parseUnsafe(input: String): ZonedDateTime =
-        ZonedDateTime.parse(input, formatter)
+  final def decodeYearWithFormatter(formatter: DateTimeFormatter): Decoder[Year] =
+    new StandardJavaTimeDecoder[Year]("Year") {
+      protected final def parseUnsafe(input: String): Year =
+        Year.parse(input, formatter)
     }
 
   /**
@@ -158,6 +170,24 @@ private[time] trait JavaTimeDecoders {
     new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
       protected final def parseUnsafe(input: String): YearMonth =
         YearMonth.parse(input, formatter)
+    }
+
+  /**
+   * @group Time
+   */
+  final def decodeZonedDateTimeWithFormatter(formatter: DateTimeFormatter): Decoder[ZonedDateTime] =
+    new StandardJavaTimeDecoder[ZonedDateTime]("ZonedDateTime") {
+      protected final def parseUnsafe(input: String): ZonedDateTime =
+        ZonedDateTime.parse(input, formatter)
+    }
+
+  /**
+   * @group Time
+   */
+  final def decodeZoneOffsetWithFormatter(formatter: DateTimeFormatter): Decoder[ZoneOffset] =
+    new StandardJavaTimeDecoder[ZoneOffset]("ZoneOffset") {
+      protected final def parseUnsafe(input: String): ZoneOffset =
+        ZoneOffset.parse(input, formatter)
     }
 
   /**
@@ -190,6 +220,15 @@ private[time] trait JavaTimeDecoders {
   /**
    * @group Time
    */
+  implicit final val decodeMonthDay: Decoder[MonthDay] =
+    new StandardJavaTimeDecoder[MonthDay]("MonthDay") {
+      protected final def parseUnsafe(input: String): MonthDay =
+        MonthDay.parse(input, ISO_LOCAL_DATE_TIME)
+    }
+
+  /**
+   * @group Time
+   */
   implicit final val decodeOffsetTime: Decoder[OffsetTime] =
     new StandardJavaTimeDecoder[OffsetTime]("OffsetTime") {
       protected final def parseUnsafe(input: String): OffsetTime =
@@ -208,6 +247,24 @@ private[time] trait JavaTimeDecoders {
   /**
    * @group Time
    */
+  implicit final val decodeYear: Decoder[Year] =
+    new StandardJavaTimeDecoder[YearMonth]("Year") {
+      protected final def parseUnsafe(input: String): YearMonth =
+        Year.parse(input)
+    }
+
+  /**
+   * @group Time
+   */
+  implicit final val decodeYearMonth: Decoder[YearMonth] =
+    new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
+      protected final def parseUnsafe(input: String): YearMonth =
+        YearMonth.parse(input)
+    }
+
+  /**
+   * @group Time
+   */
   implicit final val decodeZonedDateTime: Decoder[ZonedDateTime] =
     new StandardJavaTimeDecoder[ZonedDateTime]("ZonedDateTime") {
       protected final def parseUnsafe(input: String): ZonedDateTime =
@@ -217,9 +274,8 @@ private[time] trait JavaTimeDecoders {
   /**
    * @group Time
    */
-  implicit final val decodeYearMonth: Decoder[YearMonth] =
-    new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
-      protected final def parseUnsafe(input: String): YearMonth =
-        YearMonth.parse(input, DateTimeFormatter.ofPattern("yyyy-MM"))
+  implicit final val decodeZoneOffset: Decoder[ZoneOffset] =
+    new StandardJavaTimeDecoder[ZoneOffset]("ZoneOffset") {
+      protected final def parseUnsafe(input: String): ZoneOffset = ZoneOffset.of(input)
     }
 }

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
@@ -87,6 +87,14 @@ private[time] trait JavaTimeEncoders {
   /**
    * @group Time
    */
+  final def encodeMonthDayWithFormatter(formatter: DateTimeFormatter): Encoder[MonthDay] =
+    new JavaTimeEncoder[MonthDay] {
+      protected final def format: DateTimeFormatter = formatter
+    }
+
+  /**
+   * @group Time
+   */
   final def encodeOffsetTimeWithFormatter(formatter: DateTimeFormatter): Encoder[OffsetTime] =
     new JavaTimeEncoder[OffsetTime] {
       protected final def format: DateTimeFormatter = formatter
@@ -101,6 +109,22 @@ private[time] trait JavaTimeEncoders {
     }
 
   /**
+    * @group Time
+    */
+  final def encodeYearWithFormatter(formatter: DateTimeFormatter): Encoder[Year] =
+    new JavaTimeEncoder[Year] {
+      protected final def format: DateTimeFormatter = formatter
+    }
+
+  /**
+    * @group Time
+    */
+  final def encodeYearMonthWithFormatter(formatter: DateTimeFormatter): Encoder[YearMonth] =
+    new JavaTimeEncoder[YearMonth] {
+      protected final def format: DateTimeFormatter = formatter
+    }
+
+  /**
    * @group Time
    */
   final def encodeZonedDateTimeWithFormatter(formatter: DateTimeFormatter): Encoder[ZonedDateTime] =
@@ -111,8 +135,8 @@ private[time] trait JavaTimeEncoders {
   /**
    * @group Time
    */
-  final def encodeYearMonthWithFormatter(formatter: DateTimeFormatter): Encoder[YearMonth] =
-    new JavaTimeEncoder[YearMonth] {
+  final def encodeZoneOffsetWithFormatter(formatter: DateTimeFormatter): Encoder[ZoneOffset] =
+    new JavaTimeEncoder[ZoneOffset] {
       protected final def format: DateTimeFormatter = formatter
     }
 
@@ -141,6 +165,13 @@ private[time] trait JavaTimeEncoders {
     }
 
   /**
+    * @group Time
+    */
+  implicit final val encodeMonthDay: Encoder[MonthDay] = Encoder.instance(monthDay =>
+    Json.fromString(monthDay.toString)
+  )
+
+  /**
    * @group Time
    */
   implicit final val encodeOffsetTime: Encoder[OffsetTime] =
@@ -157,6 +188,20 @@ private[time] trait JavaTimeEncoders {
     }
 
   /**
+    * @group Time
+    */
+  implicit final val encodeYear: Encoder[Year] = Encoder.instance(year =>
+    Json.fromString(year.toString)
+  )
+
+  /**
+    * @group Time
+    */
+  implicit final val encodeYearMonth: Encoder[YearMonth] = Encoder.instance(yearMonth =>
+    Json.fromString(yearMonth.toString)
+  )
+
+  /**
    * @group Time
    */
   implicit final val encodeZonedDateTime: Encoder[ZonedDateTime] =
@@ -165,10 +210,9 @@ private[time] trait JavaTimeEncoders {
     }
 
   /**
-   * @group Time
-   */
-  implicit final val encodeYearMonth: Encoder[YearMonth] =
-    new JavaTimeEncoder[YearMonth] {
-      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM")
-    }
+    * @group Time
+    */
+  implicit final val encodeZoneOffset: Encoder[ZoneOffset] = Encoder.instance(zoneOffset =>
+    Json.fromString(zoneOffset.toString)
+  )
 }

--- a/modules/java8/src/test/scala/io/circe/java8/time/JavaTimeCodecSuite.scala
+++ b/modules/java8/src/test/scala/io/circe/java8/time/JavaTimeCodecSuite.scala
@@ -1,23 +1,11 @@
 package io.circe.java8.time
 
 import cats.kernel.Eq
-import io.circe.{ Decoder, Encoder, Json, ObjectEncoder }
+import io.circe.{Decoder, Encoder, Json, ObjectEncoder}
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
-import java.time.{
-  Duration,
-  Instant,
-  LocalDate,
-  LocalDateTime,
-  LocalTime,
-  OffsetDateTime,
-  OffsetTime,
-  Period,
-  YearMonth,
-  ZonedDateTime,
-  ZoneId
-}
-import org.scalacheck.{ Arbitrary, Gen }
+import java.time._
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 import scala.collection.JavaConverters._
 
@@ -78,10 +66,19 @@ class JavaTimeCodecSuite extends CirceSuite {
 
   implicit val arbitraryLocalTime: Arbitrary[LocalTime] = Arbitrary(arbitrary[LocalDateTime].map(_.toLocalTime))
 
+  implicit val arbitraryMonthDay: Arbitrary[MonthDay] = Arbitrary(arbitrary[MonthDay].map(
+    ldt => MonthDay.of(ldt.getMonth, ldt.getDayOfMonth)))
+
   implicit val arbitraryOffsetTime: Arbitrary[OffsetTime] = Arbitrary(arbitrary[OffsetDateTime].map(_.toOffsetTime))
+
+  implicit val arbitraryYear: Arbitrary[Year] = Arbitrary(arbitrary[LocalDateTime].map(
+    ldt => Year.of(ldt.getYear)))
 
   implicit val arbitraryYearMonth: Arbitrary[YearMonth] = Arbitrary(arbitrary[LocalDateTime].map(
     ldt => YearMonth.of(ldt.getYear, ldt.getMonth)))
+
+  implicit val arbitraryZoneOffset: Arbitrary[ZoneOffset] =
+    Gen.choose(-18 * 60 * 60, 18 * 60 * 60).map(ZoneOffset.ofTotalSeconds)
 
   implicit val arbitraryDuration: Arbitrary[Duration] = Arbitrary(
     for {
@@ -104,11 +101,14 @@ class JavaTimeCodecSuite extends CirceSuite {
   implicit val eqOffsetDateTime: Eq[OffsetDateTime] = Eq.fromUniversalEquals
   implicit val eqLocalDate: Eq[LocalDate] = Eq.fromUniversalEquals
   implicit val eqLocalTime: Eq[LocalTime] = Eq.fromUniversalEquals
+  implicit val eqMonthDay: Eq[MonthDay] = Eq.fromUniversalEquals
   implicit val eqOffsetTime: Eq[OffsetTime] = Eq.fromUniversalEquals
   implicit val eqPeriod: Eq[Period] = Eq.fromUniversalEquals
+  implicit val eqYear: Eq[Year] = Eq.fromUniversalEquals
   implicit val eqYearMonth: Eq[YearMonth] = Eq.fromUniversalEquals
   implicit val eqDuration: Eq[Duration] = Eq.fromUniversalEquals
   implicit val eqZoneId: Eq[ZoneId] = Eq.fromUniversalEquals
+  implicit val eqZoneOffset: Eq[ZoneOffset] = Eq.fromUniversalEquals
   implicit val eqJavaTimeCaseClass: Eq[JavaTimeCaseClass] = Eq.fromUniversalEquals
 
   checkLaws("Codec[Instant]", CodecTests[Instant].codec)
@@ -117,11 +117,14 @@ class JavaTimeCodecSuite extends CirceSuite {
   checkLaws("Codec[OffsetDateTime]", CodecTests[OffsetDateTime].codec)
   checkLaws("Codec[LocalDate]", CodecTests[LocalDate].codec)
   checkLaws("Codec[LocalTime]", CodecTests[LocalTime].codec)
+  checkLaws("Codec[MonthDay]", CodecTests[MonthDay].codec)
   checkLaws("Codec[OffsetTime]", CodecTests[OffsetTime].codec)
   checkLaws("Codec[Period]", CodecTests[Period].codec)
+  checkLaws("Codec[Year]", CodecTests[Year].codec)
   checkLaws("Codec[YearMonth]", CodecTests[YearMonth].codec)
   checkLaws("Codec[Duration]", CodecTests[Duration].codec)
   checkLaws("Codec[ZoneId]", CodecTests[ZoneId].codec)
+  checkLaws("Codec[ZoneOffset]", CodecTests[ZoneOffset].codec)
   checkLaws("Codec[JavaTimeCaseClass]", CodecTests[JavaTimeCaseClass].codec)
 
   val invalidText: String = "abc"
@@ -183,6 +186,13 @@ class JavaTimeCodecSuite extends CirceSuite {
     assert(decodingResult.left.get.message.contains(parseExceptionMessage))
   }
 
+  "Decoder[MonthDay]" should "fail on invalid values" in {
+    val decodingResult = Decoder[MonthDay].apply(invalidJson.hcursor)
+
+    assert(decodingResult.isLeft)
+    assert(decodingResult.left.get.message.contains(parseExceptionMessage))
+  }
+
   "Decoder[OffsetTime]" should "fail on invalid values" in {
     val decodingResult = Decoder[OffsetTime].apply(invalidJson.hcursor)
 
@@ -197,6 +207,13 @@ class JavaTimeCodecSuite extends CirceSuite {
     assert(decodingResult.left.get.message.contains(s"Text '$invalidText' cannot be parsed to a Period"))
   }
 
+  "Decoder[Year]" should "fail on invalid values" in {
+    val decodingResult = Decoder[Year].apply(invalidJson.hcursor)
+
+    assert(decodingResult.isLeft)
+    assert(decodingResult.left.get.message.contains(parseExceptionMessage))
+  }
+
   "Decoder[YearMonth]" should "fail on invalid values" in {
     val decodingResult = Decoder[YearMonth].apply(invalidJson.hcursor)
 
@@ -209,5 +226,12 @@ class JavaTimeCodecSuite extends CirceSuite {
 
     assert(decodingResult.isLeft)
     assert(decodingResult.left.get.message.contains(s"Text '$invalidText' cannot be parsed to a Duration"))
+  }
+
+  "Decoder[ZoneOffset]" should "fail on invalid values" in {
+    val decodingResult = Decoder[ZoneOffset].apply(invalidJson.hcursor)
+
+    assert(decodingResult.isLeft)
+    assert(decodingResult.left.get.message.contains(parseExceptionMessage))
   }
 }


### PR DESCRIPTION
...and improve throughput of parsing and serialization of YearMonth values, by using build-in parser and formatter