### PR TITLE
Extend ':=' operator any type with a KeyEncoder instance

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/io/circe/syntax/package.scala
@@ -9,7 +9,7 @@ package object syntax {
     final def asJsonObject(implicit encoder: ObjectEncoder[A]): JsonObject =
       encoder.encodeObject(wrappedEncodeable)
   }
-  implicit final class StringOps(val value: String) extends AnyVal {
-    final def :=[A: Encoder](a: A): (String, Json) = (value, a.asJson)
+  implicit final class KeyOps[K](val key: K) extends AnyVal {
+    final def :=[A: Encoder](a: A)(implicit keyEncoder: KeyEncoder[K]): (String, Json) = (keyEncoder(key), a.asJson)
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/syntax/SyntaxSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/syntax/SyntaxSuite.scala
@@ -1,6 +1,6 @@
 package io.circe.syntax
 
-import io.circe.{ Encoder, Json }
+import io.circe.{Encoder, Json, KeyEncoder}
 import io.circe.tests.CirceSuite
 
 class SyntaxSuite extends CirceSuite {
@@ -10,5 +10,35 @@ class SyntaxSuite extends CirceSuite {
 
   "asJsonObject" should "be available and work appropriately" in forAll { (m: Map[String, Int]) =>
     assert(m.asJsonObject === Encoder[Map[String, Int]].apply(m).asObject.get)
+  }
+
+  ":=" should "be available and work with String keys" in {
+    forAll { (key: String, m: Map[String, Int], aNumber: Int, aString: String, aBoolean: Boolean) =>
+      assert((key := m) === (key, m.asJson))
+      assert((key := aNumber) === (key, aNumber.asJson))
+      assert((key := aString) === (key, aString.asJson))
+      assert((key := aBoolean) === (key, aBoolean.asJson))
+    }
+  }
+
+  ":=" should "be available and work with non-String keys that have a KeyEncoder instance" in {
+    case class CustomKey(componentOne: String, componentTwo: Int)
+    implicit val keyEncoder: KeyEncoder[CustomKey] =
+      KeyEncoder[String].contramap(k => s"${k.componentOne}_${k.componentTwo}")
+
+    forAll { (
+      m: Map[String, Int],
+      aNumber: Int,
+      aString: String,
+      aBoolean: Boolean
+    ) => {
+      val key = CustomKey("keyComponentOne", 2)
+      val keyStringRepresentation = "keyComponentOne_2"
+      assert((key := m) === (keyStringRepresentation, m.asJson))
+      assert((key := aNumber) === (keyStringRepresentation, aNumber.asJson))
+      assert((key := aString) === (keyStringRepresentation, aString.asJson))
+      assert((key := aBoolean) === (keyStringRepresentation, aBoolean.asJson))
+    }
+    }
   }
 }


### PR DESCRIPTION
In the cases where JSON keys have a richer type
than plain strings, it is handy to have the ':='
operator work seamlessly. As circe already has
'KeyEncoder' abstraction, the assignment operator
can work off the same abstraction. This is also
backwards compatible with the 'String' based
implementation.