### PR TITLE
[generic-extra] Decode default value on Option if key is missing.

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -808,6 +808,8 @@ final object Decoder
 
   private[this] final val rightNone: Either[DecodingFailure, Option[Nothing]] = Right(None)
 
+  private[circe] final val keyMissingNone: Either[DecodingFailure, Option[Nothing]] = Right(None)
+
   /**
    * @group Decoding
    */
@@ -820,7 +822,7 @@ final object Decoder
           case Left(df) => Left(df)
         }
     case c: FailedCursor =>
-      if (!c.incorrectFocus) rightNone else Left(DecodingFailure("[A]Option[A]", c.history))
+      if (!c.incorrectFocus) keyMissingNone else Left(DecodingFailure("[A]Option[A]", c.history))
   }
 
   /**

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
@@ -34,11 +34,11 @@ abstract class ReprDecoder[A] extends Decoder[A] {
     name: String,
     defaults: Map[String, Any]
   ): Decoder.Result[B] = result match {
-    case r @ Right(_) => r
-    case l @ Left(_) =>
+    case r @ Right(_) if r ne Decoder.keyMissingNone => r
+    case _ =>
       defaults.get(name) match {
         case Some(d: B @unchecked) => Right(d)
-        case _                     => l
+        case _                     => result
       }
   }
 

--- a/modules/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/modules/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -90,6 +90,40 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
     }
   }
 
+  {
+    case class FooWithDefault(a: Option[Int] = Some(0), b: String = "b")
+    object FooWithDefault {
+      implicit val eqConfigExampleFoo: Eq[FooWithDefault] = Eq.fromUniversalEquals
+    }
+
+    case class FooNoDefault(a: Option[Int], b: String = "b")
+    object FooNoDefault {
+      implicit val eqConfigExampleFoo: Eq[FooNoDefault] = Eq.fromUniversalEquals
+    }
+
+    implicit val customConfig: Configuration = Configuration.default.withDefaults
+
+    "Option[T] without default" should "be None if null decoded" in {
+      val json = json"""{ "a": null }"""
+      assert(Decoder[FooNoDefault].decodeJson(json) === Right(FooNoDefault(None, "b")))
+    }
+
+    "Option[T] without default" should "be None if missing key decoded" in {
+      val json = json"""{}"""
+      assert(Decoder[FooNoDefault].decodeJson(json) === Right(FooNoDefault(None, "b")))
+    }
+
+    "Option[T] with default" should "be None if null decoded" in {
+      val json = json"""{ "a": null }"""
+      assert(Decoder[FooWithDefault].decodeJson(json) === Right(FooWithDefault(None, "b")))
+    }
+
+    "Option[T] with default" should "be default value if missing key decoded" in {
+      val json = json"""{}"""
+      assert(Decoder[FooWithDefault].decodeJson(json) === Right(FooWithDefault(Some(0), "b")))
+    }
+  }
+
   "Configuration#discriminator" should "support a field indicating constructor" in {
     forAll { foo: ConfigExampleFoo =>
       implicit val withDefaultsConfig: Configuration = Configuration.default.withDiscriminator("type")


### PR DESCRIPTION
Closes #878 


| |  without default <br>`Foo(a: Option[Int])` | with default <br>`Foo(a: Option[Int]=Some(0))` |
|---|---|---|
| **null given <br> `{"a":null}`** | `Foo(None)` | `Foo(None)` |
| **key missing <br> `{}`** | `Foo(None)` | right now: `Foo(None)`<br>This PR: `Foo(Some(0))` |