### PR TITLE
Make JavaTimeEncoders/Decoders public

### DIFF
--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
@@ -57,7 +57,7 @@ private[time] abstract class StandardJavaTimeDecoder[A](name: String)
   protected final def formatMessage(input: String, message: String): String = message
 }
 
-private[time] trait JavaTimeDecoders {
+trait JavaTimeDecoders {
   /**
    * @group Time
    */

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
@@ -31,7 +31,7 @@ private[time] abstract class JavaTimeEncoder[A <: TemporalAccessor] extends Enco
   final def apply(a: A): Json = Json.fromString(format.format(a))
 }
 
-private[time] trait JavaTimeEncoders {
+trait JavaTimeEncoders {
   /**
    * @group Time
    */


### PR DESCRIPTION
So that they can be extended by custom helper objects.

See #976