### PR TITLE
Allow companion objects used in JsonCodecMacros to have access modifiers

### DIFF
--- a/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/JsonCodecMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/JsonCodecMacros.scala
@@ -23,11 +23,11 @@ abstract class JsonCodecMacros {
        """
     case List(
       clsDef: ClassDef,
-      q"object $objName extends { ..$objEarlyDefs } with ..$objParents { $objSelf => ..$objDefs }"
+      q"..$mods object $objName extends { ..$objEarlyDefs } with ..$objParents { $objSelf => ..$objDefs }"
     ) if isCaseClassOrSealed(clsDef) =>
       q"""
        $clsDef
-       object $objName extends { ..$objEarlyDefs } with ..$objParents { $objSelf =>
+       $mods object $objName extends { ..$objEarlyDefs } with ..$objParents { $objSelf =>
          ..$objDefs
          ..${ codec(clsDef) }
        }

--- a/modules/generic/shared/src/test/scala-2.12-/io/circe/generic/JsonCodecMacrosSuite.scala
+++ b/modules/generic/shared/src/test/scala-2.12-/io/circe/generic/JsonCodecMacrosSuite.scala
@@ -77,6 +77,21 @@ package jsoncodecmacrossuiteaux {
       )
   }
 
+  // Access modifier
+
+  @JsonCodec private[circe] final case class AccessModifier(a: Int)
+
+  private[circe] object AccessModifier {
+    implicit def eqAccessModifier: Eq[AccessModifier] = Eq.fromUniversalEquals
+
+    implicit def arbitraryAccessModifier: Arbitrary[AccessModifier] =
+      Arbitrary(
+        for {
+          a <- Arbitrary.arbitrary[Int]
+        } yield AccessModifier(a)
+      )
+  }
+
   // Hierarchy
 
   @JsonCodec sealed trait Hierarchy
@@ -143,6 +158,7 @@ class JsonCodecMacrosSuite extends CirceSuite {
   checkLaws("Codec[Single]", CodecTests[Single].codec)
   checkLaws("Codec[Typed1[Int]]", CodecTests[Typed1[Int]].codec)
   checkLaws("Codec[Typed2[Int, Long]]", CodecTests[Typed2[Int, Long]].codec)
+  checkLaws("Codec[AccessModifier]", CodecTests[AccessModifier].codec)
   checkLaws("Codec[Hierarchy]", CodecTests[Hierarchy].codec)
   checkLaws("Codec[RecursiveHierarchy]", CodecTests[RecursiveHierarchy].codec)
   checkLaws("Codec[SelfRecursiveWithOption]", CodecTests[SelfRecursiveWithOption].codec)
@@ -152,6 +168,7 @@ class JsonCodecMacrosSuite extends CirceSuite {
     ObjectEncoder[Single]
     ObjectEncoder[Typed1[Int]]
     ObjectEncoder[Typed2[Int, Long]]
+    ObjectEncoder[AccessModifier]
     ObjectEncoder[Hierarchy]
     ObjectEncoder[RecursiveHierarchy]
     ObjectEncoder[SelfRecursiveWithOption]


### PR DESCRIPTION
There is a case where if the companion object of a case class has an access modifier the code will not compile.  The error raised in the current version is ` "Invalid annotation target: must be a case class or a sealed trait/class"`, which is not true as shown below.

Examples:

Previously would not compile (Does with the code changes in this PR):
```SCALA
@JsonCodec private[circe] final case class AccessModifier(a: Int)
private[circe] object AccessModifier { ... }
```

Previously would compile (And still does, as this is the format of the other examples):
```SCALA
@JsonCodec private[circe] final case class AccessModifier(a: Int)
object AccessModifier { ... }
```