### PR TITLE
Revert "Add FiniteDuration codec"

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -18,11 +18,9 @@ import cats.kernel.Order
 import io.circe.export.Exported
 import java.io.Serializable
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 import scala.collection.immutable.{ Map => ImmutableMap, Set, SortedMap, SortedSet }
 import scala.collection.mutable.Builder
-import scala.concurrent.duration.FiniteDuration
 import scala.util.{ Failure, Success, Try }
 
 trait Decoder[A] extends Serializable { self =>
@@ -789,22 +787,6 @@ final object Decoder
       case _ => fail(c)
     }
   }
-
-  /**
-   * @group Decoding
-   */
-  implicit final val finiteDurationDecoder: Decoder[FiniteDuration] =
-    new Decoder[FiniteDuration] {
-      def apply(c: HCursor): Result[FiniteDuration] = for {
-        length <- c.downField("length").as[Long].right
-        unitString <- c.downField("unit").as[String].right
-        unit <- (try {
-          Right(TimeUnit.valueOf(unitString))
-        } catch {
-          case _: IllegalArgumentException => Left(DecodingFailure("FiniteDuration", c.history))
-        }).right
-      } yield FiniteDuration(length, unit)
-    }
 
   private[this] final val rightNone: Either[DecodingFailure, Option[Nothing]] = Right(None)
 

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -8,7 +8,6 @@ import java.util.UUID
 import scala.Predef._
 import scala.collection.Map
 import scala.collection.immutable.{ Map => ImmutableMap, Set }
-import scala.concurrent.duration.FiniteDuration
 
 /**
  * A type class that provides a conversion from a value of type `A` to a [[Json]] value.
@@ -270,14 +269,6 @@ final object Encoder extends TupleEncoders with ProductEncoders with JavaTimeEnc
    */
   implicit final val encodeUUID: Encoder[UUID] = new Encoder[UUID] {
     final def apply(a: UUID): Json = Json.fromString(a.toString)
-  }
-
-  /**
-   * @group Encoding
-   */
-  implicit final val finiteDurationEncoder: Encoder[FiniteDuration] = new Encoder[FiniteDuration] {
-    final def apply(a: FiniteDuration): Json =
-      Json.fromJsonObject(JsonObject("length" -> Json.fromLong(a.length), "unit" -> Json.fromString(a.unit.name)))
   }
 
   /**

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -16,11 +16,9 @@ import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
 import io.circe.tests.examples.Foo
 import java.util.UUID
-import java.util.concurrent.TimeUnit._
 import org.scalacheck.{ Arbitrary, Gen }
 import scala.collection.immutable.SortedMap
 import scala.collection.mutable.HashMap
-import scala.concurrent.duration.FiniteDuration
 
 trait SpecialEqForFloatAndDouble {
 
@@ -86,25 +84,6 @@ class StdLibCodecSuite extends CirceSuite with ArrayFactoryInstance {
 
   implicit val arbitraryUUID: Arbitrary[UUID] = Arbitrary(Gen.uuid)
 
-  implicit val arbitraryDuration: Arbitrary[FiniteDuration] = {
-    // max range is +/- 292 years, but we give ourselves some extra headroom
-    // to ensure that we can add these things up. they crash on overflow.
-    val n = (292L * 365) / 50
-    Arbitrary(
-      Gen.oneOf(
-        Gen.choose(-n, n).map(FiniteDuration(_, DAYS)),
-        Gen.choose(-n * 24L, n * 24L).map(FiniteDuration(_, HOURS)),
-        Gen.choose(-n * 1440L, n * 1440L).map(FiniteDuration(_, MINUTES)),
-        Gen.choose(-n * 86400L, n * 86400L).map(FiniteDuration(_, SECONDS)),
-        Gen.choose(-n * 86400000L, n * 86400000L).map(FiniteDuration(_, MILLISECONDS)),
-        Gen.choose(-n * 86400000000L, n * 86400000000L).map(FiniteDuration(_, MICROSECONDS)),
-        Gen.choose(-n * 86400000000000L, n * 86400000000000L).map(FiniteDuration(_, NANOSECONDS))
-      )
-    )
-  }
-
-  implicit val eqFiniteDuration: Eq[FiniteDuration] = Eq.fromUniversalEquals
-
   checkLaws("Codec[String]", CodecTests[String].codec)
   checkLaws("Codec[BigInt]", CodecTests[BigInt].codec)
   checkLaws("Codec[BigDecimal]", CodecTests[BigDecimal].codec)
@@ -125,7 +104,6 @@ class StdLibCodecSuite extends CirceSuite with ArrayFactoryInstance {
   checkLaws("Codec[SortedMap[Long, Int]]", CodecTests[SortedMap[Long, Int]].unserializableCodec)
   checkLaws("Codec[Set[Int]]", CodecTests[Set[Int]].codec)
   checkLaws("Codec[Array[String]]", CodecTests[Array[String]].codec)
-  checkLaws("Codec[FiniteDuration]", CodecTests[FiniteDuration].codec)
 
   "A tuple encoder" should "return a JSON array" in forAll { (t: (Int, String, Char)) =>
     val json = Encoder[(Int, String, Char)].apply(t)


### PR DESCRIPTION
This reverts commit e73328882f38dd74483f31a6032a4011a5a56f7e from #978. I've been thinking about this some more in preparation for 0.11, @LukaJCB, and I think this is just too far from our general principle of "don't do anything that can be done more than one way". We could consider a `io.circe.durationCodecs` object (on the model of `io.circe.disjunctionCodecs`)—would you find that useful?