### PR TITLE
`Decoder#validate` allowing building the message from the trigger `HCursor`

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -163,7 +163,7 @@ trait Decoder[A] extends Serializable { self =>
    * (instead only the error of the last failing `validate` in the chain will be
    * returned).
    */
-  final def validate(pred: HCursor => Boolean, message: HCursor => String): Decoder[A] = new Decoder[A] {
+  final def validate(pred: HCursor => Boolean)(message: HCursor => String): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] =
       if (pred(c)) self(c) else Left(DecodingFailure(message(c), c.history))
 
@@ -172,17 +172,17 @@ trait Decoder[A] extends Serializable { self =>
   }
 
   /**
-    * Build a new instance that fails if the condition does not hold for the
-    * input.
-    *
-    * Note that this condition is checked before decoding with the current
-    * decoder, and if it does not hold, decoding does not continue. This means
-    * that if you chain calls to this method, errors will not be accumulated
-    * (instead only the error of the last failing `validate` in the chain will be
-    * returned).
-    */
+   * Build a new instance that fails if the condition does not hold for the
+   * input.
+   *
+   * Note that this condition is checked before decoding with the current
+   * decoder, and if it does not hold, decoding does not continue. This means
+   * that if you chain calls to this method, errors will not be accumulated
+   * (instead only the error of the last failing `validate` in the chain will be
+   * returned).
+   */
   final def validate(pred: HCursor => Boolean, message: => String): Decoder[A] =
-    validate(pred, _ => message)
+    validate(pred)(_ => message)
 
   /**
    * Convert to a Kleisli arrow.

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -155,7 +155,7 @@ trait Decoder[A] extends Serializable { self =>
 
   /**
    * Build a new instance that fails if the condition does not hold for the
-   * input.
+   * input, producing a message from the cursor.
    *
    * Note that this condition is checked before decoding with the current
    * decoder, and if it does not hold, decoding does not continue. This means
@@ -163,13 +163,26 @@ trait Decoder[A] extends Serializable { self =>
    * (instead only the error of the last failing `validate` in the chain will be
    * returned).
    */
-  final def validate(pred: HCursor => Boolean, message: => String): Decoder[A] = new Decoder[A] {
+  final def validate(pred: HCursor => Boolean, message: HCursor => String): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] =
-      if (pred(c)) self(c) else Left(DecodingFailure(message, c.history))
+      if (pred(c)) self(c) else Left(DecodingFailure(message(c), c.history))
 
     override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
-      if (pred(c)) self.decodeAccumulating(c) else Validated.invalidNel(DecodingFailure(message, c.history))
+      if (pred(c)) self.decodeAccumulating(c) else Validated.invalidNel(DecodingFailure(message(c), c.history))
   }
+
+  /**
+    * Build a new instance that fails if the condition does not hold for the
+    * input.
+    *
+    * Note that this condition is checked before decoding with the current
+    * decoder, and if it does not hold, decoding does not continue. This means
+    * that if you chain calls to this method, errors will not be accumulated
+    * (instead only the error of the last failing `validate` in the chain will be
+    * returned).
+    */
+  final def validate(pred: HCursor => Boolean, message: => String): Decoder[A] =
+    validate(pred, _ => message)
 
   /**
    * Convert to a Kleisli arrow.

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -407,15 +407,13 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
   it should "generate error messages from HCursor when a function is passed" in {
     case class Foo(x: Int, y: String)
 
-    val errorFunction: HCursor => String = { c =>
+    val decoder: Decoder[Foo] = Decoder.const(Foo(42, "meaning")).validate(_ => false) { c =>
       val maybeFieldsStr = for {
         json <- c.focus
         jsonKeys <- json.hcursor.keys
       } yield jsonKeys.mkString(",")
       maybeFieldsStr.getOrElse("")
     }
-
-    val decoder: Decoder[Foo] = Decoder.const(Foo(42, "meaning")).validate(_ => false, errorFunction)
 
     val Right(fooJson) = parse("""{"x":42, "y": "meaning"}""")
 

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -404,6 +404,24 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     assert(validatingDecoder.decodeAccumulating(Json.True.hcursor).isInvalid)
   }
 
+  it should "generate error messages from HCursor when a function is passed" in {
+    case class Foo(x: Int, y: String)
+
+    val errorFunction: HCursor => String = { c =>
+      val maybeFieldsStr = for {
+        json <- c.focus
+        jsonKeys <- json.hcursor.keys
+      } yield jsonKeys.mkString(",")
+      maybeFieldsStr.getOrElse("")
+    }
+
+    val decoder: Decoder[Foo] = Decoder.const(Foo(42, "meaning")).validate(_ => false, errorFunction)
+
+    val Right(fooJson) = parse("""{"x":42, "y": "meaning"}""")
+
+    assert(decoder.decodeJson(fooJson).left.get.message == "x,y")
+  }
+
   "either" should "return the correct disjunct" in forAll { (value: Either[String, Boolean]) =>
     val json = value match {
       case Left(s)  => Json.fromString(s)


### PR DESCRIPTION
Resolves https://github.com/circe/circe/issues/1019

This PR pretends to enable generating `validate` messages from the `HCursor` value which triggered the failure by satisfying the passed predicate.

It overloads the original `validate` method which now gets implemented by invoking this new implementation.