### PR TITLE
Fix ensure

### DIFF
--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -360,6 +360,15 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     assert(decodePositiveOddInt.decodeAccumulating(Json.fromInt(i).hcursor) === expected)
   }
 
+  it should "not include failures it hasn't checked for" in {
+    val decodePositiveInt: Decoder[Int] =
+      Decoder[Int].ensure(_ > 0, "Not positive!")
+
+    val expected = Validated.invalidNel(DecodingFailure("Int", Nil))
+
+    assert(decodePositiveInt.decodeAccumulating(Json.Null.hcursor) === expected)
+  }
+
   "validate" should "fail appropriately on invalid input in fail-fast mode" in forAll { (i: Int) =>
     val message = "Not positive!"
 

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -336,7 +336,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     val oddMessage = "Not odd!"
 
     val decodePositiveOddInt: Decoder[Int] =
-      Decoder[Int].ensure(_ > 0, positiveMessage).ensure(_ % 2 == 1, oddMessage)
+      Decoder[Int].ensure(_ > 0, positiveMessage).ensure(_ % 2 != 0, oddMessage)
 
     val expected = if (i > 0) {
       if (i % 2 == 1) {
@@ -345,7 +345,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
         Validated.invalidNel(DecodingFailure(oddMessage, Nil))
       }
     } else {
-      if (i % 2 == 1) {
+      if (i % 2 != 0) {
         Validated.invalidNel(DecodingFailure(positiveMessage, Nil))
       } else {
         Validated.invalid(

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -368,9 +368,10 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     val oddMessage = "Not odd!"
 
     val decodePositiveOddInt: Decoder[Int] =
-      Decoder[Int].ensure(i =>
-        (if (isPositive(i)) Nil else List(positiveMessage)) ++
-        (if (isOdd(i)) Nil else List(oddMessage))
+      Decoder[Int].ensure(
+        i =>
+          (if (isPositive(i)) Nil else List(positiveMessage)) ++
+            (if (isOdd(i)) Nil else List(oddMessage))
       )
 
     val expected = if (isPositive(i)) {


### PR DESCRIPTION
In the [0.10.0] release we introduced a new `Decoder#ensure` method that was semantically kind of weird and included some behavior that (when used together with error accumulation) was definitely buggy:

```scala
scala> import io.circe.{ Decoder, Json }
import io.circe.{Decoder, Json}

scala> val decodePos: Decoder[Int] = Decoder[Int].ensure(_ > 0, "not positive")
decodePos: io.circe.Decoder[Int] = io.circe.Decoder$$anon$25@5b9070e3

scala> decodePos.accumulating(Json.Null.hcursor)
res0: io.circe.AccumulatingDecoder.Result[Int] = Invalid(NonEmptyList(DecodingFailure(Int, List()), DecodingFailure(not positive, List())))
```

Thanks to @ylaurent for noticing and [reporting this](https://gitter.im/circe/circe?at=5bfdf97dcfa682348d961433).

The tests would have caught this bug, but the relevant test was itself buggy, containing a check for oddness that said e.g. `-1` was not odd.

I've changed the documentation for the previous version of `ensure` to state explicitly that `dec.ensure(p1, "p1").ensure(p2, "p2")` will only provide the first failure, and have added a new, more powerful `ensure` method that allows the user to provide multiple errors that depend on the decoded value.

@pfcoperez, I was thinking we might be able to add a similar `HCursor => List[String]` variant for `validate` that would accommodate the use case supported by your #1020, and that would keep these two methods consistent. What do you think?