### PR TITLE
Update Ruby versions for sbt-microsite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ cache:
 
 install:
   - pip install --user codecov
-  - rvm use 2.2.8 --install --fuzzy
+  - rvm use 2.6.0 --install --fuzzy
   - gem update --system
   - gem install sass
-  - gem install jekyll -v 3.2.1
+  - gem install jekyll -v 3.8.5
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean coverage validateJVM;


### PR DESCRIPTION
Recent builds have been failing because Travis CI's `rubygems-update` wants a newer Ruby. This should work.