### PR TITLE
Option to print JSON objects with sorted keys

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -126,6 +126,24 @@ sealed abstract class Json extends Product with Serializable {
   final def spaces4: String = Printer.spaces4.pretty(this)
 
   /**
+   * Pretty-print this JSON value to a string with no spaces, with object keys
+   * sorted alphabetically.
+   */
+  final def noSpacesSortKeys: String = Printer.noSpacesSortKeys.pretty(this)
+
+  /**
+   * Pretty-print this JSON value to a string indentation of two spaces, with
+   * object keys sorted alphabetically.
+   */
+  final def spaces2SortKeys: String = Printer.spaces2SortKeys.pretty(this)
+
+  /**
+   * Pretty-print this JSON value to a string indentation of four spaces, with
+   * object keys sorted alphabetically.
+   */
+  final def spaces4SortKeys: String = Printer.spaces4SortKeys.pretty(this)
+
+  /**
    * Perform a deep merge of this JSON value with another JSON value.
    *
    * Objects are merged by key, values from the argument JSON take

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -308,14 +308,15 @@ final object JsonObject {
       val originalDepth = folder.depth
       val p = folder.pieces(folder.depth)
       var first = true
-      val iterator = fields.entrySet.iterator
+      val iterable = if (folder.sortKeys) toIterable.toVector.sortBy(_._1) else toIterable
+      val iterator = iterable.iterator
 
       folder.writer.append(p.lBraces)
 
       while (iterator.hasNext) {
         val next = iterator.next()
-        val key = next.getKey
-        val value = next.getValue
+        val key = next._1
+        val value = next._2
 
         if (!folder.dropNullValues || !value.isNull) {
           if (!first) folder.writer.append(p.objectCommas)
@@ -417,7 +418,7 @@ final object JsonObject {
       val originalDepth = folder.depth
       val p = folder.pieces(folder.depth)
       var first = true
-      val keyIterator = orderedKeys.iterator
+      val keyIterator = if (folder.sortKeys) orderedKeys.sorted.iterator else orderedKeys.iterator
 
       folder.writer.append(p.lBraces)
 

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -71,14 +71,14 @@ final case class Printer(
 
   private[this] final class StringBuilderFolder(
     writer: StringBuilder
-  ) extends Printer.PrintingFolder(writer, pieces, dropNullValues, escapeNonAscii) {
+  ) extends Printer.PrintingFolder(writer, pieces, dropNullValues, escapeNonAscii, sortKeys) {
     final def onBoolean(value: Boolean): Unit = writer.append(value)
     final def onNumber(value: JsonNumber): Unit = value.appendToStringBuilder(writer)
   }
 
   private[this] final class AppendableByteBufferFolder(
     writer: Printer.AppendableByteBuffer
-  ) extends Printer.PrintingFolder(writer, pieces, dropNullValues, escapeNonAscii) {
+  ) extends Printer.PrintingFolder(writer, pieces, dropNullValues, escapeNonAscii, sortKeys) {
     final def onBoolean(value: Boolean): Unit = writer.append(java.lang.Boolean.toString(value))
     final def onNumber(value: JsonNumber): Unit = writer.append(value.toString)
   }
@@ -288,7 +288,8 @@ final object Printer {
     private[circe] val writer: Appendable,
     private[circe] val pieces: PiecesAtDepth,
     private[circe] val dropNullValues: Boolean,
-    private[circe] val escapeNonAscii: Boolean
+    private[circe] val escapeNonAscii: Boolean,
+    private[circe] val sortKeys: Boolean
   ) extends Json.Folder[Unit] {
     private[circe] var depth: Int = 0
 

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -220,6 +220,11 @@ final case class Printer(
 
   final def prettyByteBuffer(json: Json): ByteBuffer =
     prettyByteBuffer(json, StandardCharsets.UTF_8)
+
+  /**
+   * The same pretty-printer configuration that outputs fields in sorted order.
+   */
+  final def withSortedKeys: Printer = copy(sortKeys = true)
 }
 
 final object Printer {

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -238,7 +238,7 @@ final object Printer {
     indent = ""
   )
 
-  final val noSpacesSortedKeys: Printer = Printer(
+  final val noSpacesSortKeys: Printer = Printer(
     preserveOrder = true,
     dropNullValues = false,
     indent = "",

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -36,6 +36,7 @@ import scala.annotation.switch
  * @param predictSize Uses an adaptive size predictor to avoid grow-and-copy steps while printing
  *        into a binary output.
  * @param escapeNonAscii Unicode-escape any non-ASCII characters in strings.
+ * @param sortKeys Determines whether the fields should be sorted.
  */
 final case class Printer(
   preserveOrder: Boolean,
@@ -58,7 +59,8 @@ final case class Printer(
   colonRight: String = "",
   reuseWriters: Boolean = false,
   predictSize: Boolean = false,
-  escapeNonAscii: Boolean = false
+  escapeNonAscii: Boolean = false,
+  sortKeys: Boolean = false
 ) {
   private[this] final val openBraceText = "{"
   private[this] final val closeBraceText = "}"
@@ -231,10 +233,17 @@ final object Printer {
     indent = ""
   )
 
+  final val noSpacesSortedKeys: Printer = Printer(
+    preserveOrder = true,
+    dropNullValues = false,
+    indent = "",
+    sortKeys = true
+  )
+
   /**
    * A pretty-printer configuration that indents by the given spaces.
    */
-  final def indented(indent: String): Printer = Printer(
+  final def indented(indent: String, sortKeys: Boolean = false): Printer = Printer(
     preserveOrder = true,
     dropNullValues = false,
     indent = indent,
@@ -246,7 +255,8 @@ final object Printer {
     arrayCommaRight = "\n",
     objectCommaRight = "\n",
     colonLeft = " ",
-    colonRight = " "
+    colonRight = " ",
+    sortKeys = sortKeys
   )
 
   /**
@@ -255,9 +265,19 @@ final object Printer {
   final val spaces2: Printer = indented("  ")
 
   /**
+   * A pretty-printer configuration that indents by two spaces  and outputs fields in sorted order.
+   */
+  final val spaces2SortKeys: Printer = indented("  ", true)
+
+  /**
    * A pretty-printer configuration that indents by four spaces.
    */
   final val spaces4: Printer = indented("    ")
+
+  /**
+   * A pretty-printer configuration that indents by four spaces and outputs fields in sorted order.
+   */
+  final val spaces4SortKeys: Printer = indented("    ", true)
 
   private[circe] abstract class PrintingFolder(
     private[circe] val writer: Appendable,

--- a/modules/tests/jvm/src/test/scala/io/circe/SortedKeysSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/SortedKeysSuite.scala
@@ -1,0 +1,30 @@
+package io.circe
+import io.circe.tests.PrinterSuite
+import org.scalacheck.Prop
+import org.scalatest.prop.Checkers
+
+trait SortedKeysSuite { this: PrinterSuite =>
+  "Printer with sortKeys" should "sort the object keys (example)" in {
+    val input = Json.obj(
+      "one" -> Json.fromInt(1),
+      "two" -> Json.fromInt(2),
+      "three" -> Json.fromInt(3)
+    )
+
+    parser.parse(printer.pretty(input)).toOption.flatMap(_.asObject) match {
+      case None => fail("Cannot parse result back to an object")
+      case Some(output) =>
+        assert(output.keys.toList === List("one", "three", "two"))
+    }
+  }
+
+  "Printer with sortKeys" should "sort the object keys" in {
+    Checkers.check(Prop.forAll { value: Map[String, List[Int]] =>
+      val printed = printer.pretty(implicitly[Encoder[Map[String, List[Int]]]].apply(value))
+      val parsed = parser.parse(printed).toOption.flatMap(_.asObject).get
+      val keys = parsed.keys.toVector
+      keys.sorted === keys
+    })
+  }
+
+}

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -229,4 +229,13 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     )
     assert(actual === expected)
   }
+
+  "printer shortcuts" should "print the object" in forAll { (json: Json) =>
+    assert(json.noSpaces === Printer.noSpaces.pretty(json))
+    assert(json.spaces2 === Printer.spaces2.pretty(json))
+    assert(json.spaces4 === Printer.spaces4.pretty(json))
+    assert(json.noSpacesSortKeys === Printer.noSpacesSortKeys.pretty(json))
+    assert(json.spaces2SortKeys === Printer.spaces2SortKeys.pretty(json))
+    assert(json.spaces4SortKeys === Printer.spaces4SortKeys.pretty(json))
+  }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -41,4 +41,6 @@ class UnicodeEscapePrinterWithWriterReuseSuite
 class Spaces2SortKeysPrinterSuite extends PrinterSuite(Printer.spaces2SortKeys, parser.`package`) with SortedKeysSuite
 class Spaces4SortKeysPrinterSuite extends PrinterSuite(Printer.spaces4SortKeys, parser.`package`) with SortedKeysSuite
 class NoSpacesSortKeysPrinterSuite extends PrinterSuite(Printer.noSpacesSortKeys, parser.`package`) with SortedKeysSuite
-
+class CustomIndentWithSortKeysPrinterSuite
+    extends PrinterSuite(Printer.indented("   ").withSortedKeys, parser.`package`)
+    with SortedKeysSuite

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -40,6 +40,5 @@ class UnicodeEscapePrinterWithWriterReuseSuite
 
 class Spaces2SortKeysPrinterSuite extends PrinterSuite(Printer.spaces2SortKeys, parser.`package`) with SortedKeysSuite
 class Spaces4SortKeysPrinterSuite extends PrinterSuite(Printer.spaces4SortKeys, parser.`package`) with SortedKeysSuite
-class NoSpacesSortKeysPrinterSuite
-    extends PrinterSuite(Printer.noSpacesSortedKeys, parser.`package`)
-    with SortedKeysSuite
+class NoSpacesSortKeysPrinterSuite extends PrinterSuite(Printer.noSpacesSortKeys, parser.`package`) with SortedKeysSuite
+

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -37,3 +37,9 @@ class UnicodeEscapePrinterWithWriterReuseSuite
       Printer.noSpaces.copy(reuseWriters = true, escapeNonAscii = true),
       parser.`package`
     )
+
+class Spaces2SortKeysPrinterSuite extends PrinterSuite(Printer.spaces2SortKeys, parser.`package`) with SortedKeysSuite
+class Spaces4SortKeysPrinterSuite extends PrinterSuite(Printer.spaces4SortKeys, parser.`package`) with SortedKeysSuite
+class NoSpacesSortKeysPrinterSuite
+    extends PrinterSuite(Printer.noSpacesSortedKeys, parser.`package`)
+    with SortedKeysSuite


### PR DESCRIPTION
This fixes #1045 by adding:

* `Printer.spaces2SortKeys`, `Printer.spaces4SortKeys` and `Printer.noSpacesSortKeys` to print JSON objects with keys sorted alphabetically
* `withSortedKeys` modifier on any `Printer`

Appreciate feedback around the implementation and tests - I couldn't find a lot of examples to go on from.