### PR TITLE
Introduce "safe" JawnParser instances that fail on large inputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -479,7 +479,10 @@ lazy val hygieneJS = hygieneBase.js
 
 lazy val jawn = circeModule("jawn", mima = previousCirceVersion)
   .settings(
-    libraryDependencies += "org.typelevel" %% "jawn-parser" % jawnVersion
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % scalaTestVersionFor(scalaVersion.value) % Test,
+      "org.typelevel" %% "jawn-parser" % jawnVersion
+    )
   )
   .dependsOn(core)
 

--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -4,18 +4,18 @@ import io.circe.{ Json, JsonNumber, JsonObject }
 import java.util.LinkedHashMap
 import org.typelevel.jawn.{ RawFacade, RawFContext, SupportParser }
 
-final object CirceSupportParser extends SupportParser[Json] {
-  implicit final val facade: RawFacade[Json] = new RawFacade[Json] {
+final object CirceSupportParser extends CirceSupportParser(None)
+
+class CirceSupportParser(maxValueSize: Option[Int]) extends SupportParser[Json] {
+  implicit final val facade: RawFacade[Json] = maxValueSize match {
+    case Some(size) => new LimitedFacade(size)
+    case None       => new UnlimitedFacade
+  }
+
+  private[this] abstract class BaseFacade extends RawFacade[Json] {
     final def jnull(index: Int): Json = Json.Null
     final def jfalse(index: Int): Json = Json.False
     final def jtrue(index: Int): Json = Json.True
-    final def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): Json =
-      if (decIndex < 0 && expIndex < 0) {
-        Json.fromJsonNumber(JsonNumber.fromIntegralStringUnsafe(s.toString))
-      } else {
-        Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe(s.toString))
-      }
-    final def jstring(s: CharSequence, index: Int): Json = Json.fromString(s.toString)
 
     final def singleContext(index: Int): RawFContext[Json] = new RawFContext[Json] {
       private[this] final var value: Json = null
@@ -32,8 +32,59 @@ final object CirceSupportParser extends SupportParser[Json] {
       final def finish(index: Int): Json = Json.fromValues(vs.result())
       final def isObj: Boolean = false
     }
+  }
 
-    def objectContext(index: Int): RawFContext[Json] = new RawFContext[Json] {
+  private[this] final class LimitedFacade(maxValueSize: Int) extends BaseFacade {
+    final def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): Json =
+      if (s.length > maxValueSize) {
+        throw new IllegalArgumentException(s"JSON number length (${s.length}) exceeds limit ($maxValueSize)")
+      } else {
+        if (decIndex < 0 && expIndex < 0) {
+          Json.fromJsonNumber(JsonNumber.fromIntegralStringUnsafe(s.toString))
+        } else {
+          Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe(s.toString))
+        }
+      }
+    final def jstring(s: CharSequence, index: Int): Json = if (s.length > maxValueSize) {
+      throw new IllegalArgumentException(s"JSON string length (${s.length}) exceeds limit ($maxValueSize)")
+    } else {
+      Json.fromString(s.toString)
+    }
+
+    final def objectContext(index: Int): RawFContext[Json] = new RawFContext[Json] {
+      private[this] final var key: String = null
+      private[this] final val m = new LinkedHashMap[String, Json]
+
+      final def add(s: CharSequence, index: Int): Unit =
+        if (key.eq(null)) {
+          if (s.length > maxValueSize) {
+            throw new IllegalArgumentException(s"JSON key length (${s.length}) exceeds limit ($maxValueSize)")
+          } else {
+            key = s.toString
+          }
+        } else {
+          m.put(key, jstring(s, index))
+          key = null
+        }
+      final def add(v: Json, index: Int): Unit = {
+        m.put(key, v)
+        key = null
+      }
+      final def finish(index: Int): Json = Json.fromJsonObject(JsonObject.fromLinkedHashMap(m))
+      final def isObj: Boolean = true
+    }
+  }
+
+  private[this] final class UnlimitedFacade extends BaseFacade {
+    final def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): Json =
+      if (decIndex < 0 && expIndex < 0) {
+        Json.fromJsonNumber(JsonNumber.fromIntegralStringUnsafe(s.toString))
+      } else {
+        Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe(s.toString))
+      }
+    final def jstring(s: CharSequence, index: Int): Json = Json.fromString(s.toString)
+
+    final def objectContext(index: Int): RawFContext[Json] = new RawFContext[Json] {
       private[this] final var key: String = null
       private[this] final val m = new LinkedHashMap[String, Json]
 
@@ -52,4 +103,5 @@ final object CirceSupportParser extends SupportParser[Json] {
       final def isObj: Boolean = true
     }
   }
+
 }

--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -1,18 +1,19 @@
 package io.circe.jawn
 
 import io.circe.{ Json, JsonNumber, JsonObject }
+import java.io.Serializable
 import java.util.LinkedHashMap
 import org.typelevel.jawn.{ RawFacade, RawFContext, SupportParser }
 
 final object CirceSupportParser extends CirceSupportParser(None)
 
-class CirceSupportParser(maxValueSize: Option[Int]) extends SupportParser[Json] {
+class CirceSupportParser(maxValueSize: Option[Int]) extends SupportParser[Json] with Serializable {
   implicit final val facade: RawFacade[Json] = maxValueSize match {
     case Some(size) => new LimitedFacade(size)
     case None       => new UnlimitedFacade
   }
 
-  private[this] abstract class BaseFacade extends RawFacade[Json] {
+  private[this] abstract class BaseFacade extends RawFacade[Json] with Serializable {
     final def jnull(index: Int): Json = Json.Null
     final def jfalse(index: Int): Json = Json.False
     final def jtrue(index: Int): Json = Json.True

--- a/modules/jawn/src/test/scala/io/circe/jawn/JawnParserSuite.scala
+++ b/modules/jawn/src/test/scala/io/circe/jawn/JawnParserSuite.scala
@@ -1,0 +1,39 @@
+package io.circe.jawn
+
+import org.scalatest.{ FunSpec, Matchers }
+
+class JawnParserSuite extends FunSpec with Matchers {
+  describe("JawnParser") {
+    it("should respect maxValueSize for numbers") {
+      val parser = JawnParser(10)
+
+      parser.parse("1000000000").isLeft shouldBe false
+      parser.parse("[1000000000]").isLeft shouldBe false
+      parser.parse("""{ "foo": 1000000000 }""").isLeft shouldBe false
+
+      parser.parse("10000000000").isLeft shouldBe true
+      parser.parse("[10000000000]").isLeft shouldBe true
+      parser.parse("""{ "foo": 10000000000 }""").isLeft shouldBe true
+    }
+
+    it("should respect maxValueSize for strings") {
+      val parser = JawnParser(10)
+
+      parser.parse("\"1000000000\"").isLeft shouldBe false
+      parser.parse("[\"1000000000\"]").isLeft shouldBe false
+      parser.parse("""{ "foo": "1000000000" }""").isLeft shouldBe false
+
+      parser.parse("\"10000000000\"").isLeft shouldBe true
+      parser.parse("[\"10000000000\"]").isLeft shouldBe true
+      parser.parse("""{ "foo": "10000000000" }""").isLeft shouldBe true
+    }
+
+    it("should respect maxValueSize for object keys") {
+      val parser = JawnParser(10)
+
+      parser.parse("""{ "1000000000": "foo" }""").isLeft shouldBe false
+
+      parser.parse("""{ "10000000000": "foo" }""").isLeft shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
This is an attempt to address #1040. Note that I'm not personally convinced #1040 is a terrifying security liability—it's not like [this issue](https://github.com/argonaut-io/argonaut/issues/211), for example, where a few twelve-character strings in user input could set your web service on fire. If your JVM web service is accepting multi-megabyte JSON strings from users without some kind of timeout on processing, you're likely to be exposed to a wide range of problems like this in many of the libraries you use, including the Java and Scala standard libraries.

I'm not offering that as an excuse, and circe can and will do better here, but in my view the biggest problem in "I let a malicious user post a JSON number with a million characters to my web service and it took 14 seconds to parse and my web service fell over" isn't the "and it took 14 seconds to parse" part.

The underlying problem in #1040 is that the string constructor for Java's `BigInteger` is [quadratic](https://stackoverflow.com/q/14757086/334519), and `BiggerDecimal`—circe's representation of JSON numbers—is built on `BigInteger`. In some specific cases we can avoid constructing a `BiggerDecimal` at all during decoding (see #1056 for `Double`), but allowing e.g. `Long` decoding to skip `BiggerDecimal` and fail fast on very large inputs will require an overhaul to number handling that will have to wait (probably until someone wants to pay me or someone else to do it).

In the meantime, if you're concerned about denial-of-service attacks, this PR introduces a new `JawnParser` constructor that allows you to put a maximum size on both strings and numbers in the incoming JSON. For example, the following takes about nine seconds on my machine:

```scala
scala> val badNumber = "9" * 1000000
badNumber: String = 9999...

scala> io.circe.jawn.decode[BigDecimal](badNumber)
res0: Either[io.circe.Error,BigDecimal] = Right(9999...)
```

After this PR, we could do the following instead:

```scala
scala> import io.circe.jawn.JawnParser
import io.circe.jawn.JawnParser

scala> val parser = JawnParser(100000)
parser: io.circe.jawn.JawnParser = io.circe.jawn.JawnParser@47d22f64

scala> parser.decode[BigDecimal](badNumber)
res1: Either[io.circe.Error,BigDecimal] = Left(io.circe.ParsingFailure: JSON number length (1000000) exceeds limit (100000))
```
…where the failure is instantaneous.

The change is verified by MiMa to be binary compatible, and to my eye it's source compatible. I'll publish it as 0.11.1 tomorrow or over the weekend if there are no objections.

(Note that I wasn't sure what exactly to make the underlying failure—I didn't really want to use `org.typelevel.jawn.ParseException`, both since it's not really a parse exception and because I don't have the row and column at that point. I chose `IllegalArgumentException` because it seemed to fit best, and I don't think it matters all that much, since most users will only see the `io.circe.ParsingFailure`, but I'm open to alternative suggestions.)
