### PR TITLE
Fix #1060

### DIFF
--- a/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeDecoders.scala
+++ b/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeDecoders.scala
@@ -14,8 +14,8 @@ import java.time.{
   Year,
   YearMonth,
   ZonedDateTime,
-  ZoneOffset,
-  ZoneId
+  ZoneId,
+  ZoneOffset
 }
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatter.{

--- a/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeDecoders.scala
+++ b/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeDecoders.scala
@@ -223,11 +223,8 @@ private[circe] trait JavaTimeDecoders {
    */
   implicit final val decodeMonthDay: Decoder[MonthDay] =
     new StandardJavaTimeDecoder[MonthDay]("MonthDay") {
-      private[this] final def monthDayFormatter: DateTimeFormatter =
-        DateTimeFormatter.ofPattern("--MM-dd")
-
       protected final def parseUnsafe(input: String): MonthDay =
-        MonthDay.parse(input, monthDayFormatter)
+        MonthDay.parse(input)
     }
 
   /**
@@ -263,7 +260,7 @@ private[circe] trait JavaTimeDecoders {
   implicit final val decodeYearMonth: Decoder[YearMonth] =
     new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
       protected final def parseUnsafe(input: String): YearMonth =
-        YearMonth.parse(input, DateTimeFormatter.ofPattern("uuuu-MM"))
+        YearMonth.parse(input)
     }
 
   /**

--- a/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeDecoders.scala
+++ b/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeDecoders.scala
@@ -7,11 +7,14 @@ import java.time.{
   LocalDate,
   LocalDateTime,
   LocalTime,
+  MonthDay,
   OffsetDateTime,
   OffsetTime,
   Period,
+  Year,
   YearMonth,
   ZonedDateTime,
+  ZoneOffset,
   ZoneId
 }
 import java.time.format.DateTimeFormatter
@@ -128,6 +131,15 @@ private[circe] trait JavaTimeDecoders {
   /**
    * @group Time
    */
+  final def decodeMonthDayWithFormatter(formatter: DateTimeFormatter): Decoder[MonthDay] =
+    new StandardJavaTimeDecoder[MonthDay]("MonthDay") {
+      protected final def parseUnsafe(input: String): MonthDay =
+        MonthDay.parse(input, formatter)
+    }
+
+  /**
+   * @group Time
+   */
   final def decodeOffsetTimeWithFormatter(formatter: DateTimeFormatter): Decoder[OffsetTime] =
     new StandardJavaTimeDecoder[OffsetTime]("OffsetTime") {
       protected final def parseUnsafe(input: String): OffsetTime =
@@ -146,10 +158,10 @@ private[circe] trait JavaTimeDecoders {
   /**
    * @group Time
    */
-  final def decodeZonedDateTimeWithFormatter(formatter: DateTimeFormatter): Decoder[ZonedDateTime] =
-    new StandardJavaTimeDecoder[ZonedDateTime]("ZonedDateTime") {
-      protected final def parseUnsafe(input: String): ZonedDateTime =
-        ZonedDateTime.parse(input, formatter)
+  final def decodeYearWithFormatter(formatter: DateTimeFormatter): Decoder[Year] =
+    new StandardJavaTimeDecoder[Year]("Year") {
+      protected final def parseUnsafe(input: String): Year =
+        Year.parse(input, formatter)
     }
 
   /**
@@ -159,6 +171,24 @@ private[circe] trait JavaTimeDecoders {
     new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
       protected final def parseUnsafe(input: String): YearMonth =
         YearMonth.parse(input, formatter)
+    }
+
+  /**
+   * @group Time
+   */
+  final def decodeZonedDateTimeWithFormatter(formatter: DateTimeFormatter): Decoder[ZonedDateTime] =
+    new StandardJavaTimeDecoder[ZonedDateTime]("ZonedDateTime") {
+      protected final def parseUnsafe(input: String): ZonedDateTime =
+        ZonedDateTime.parse(input, formatter)
+    }
+
+  /**
+   * @group Time
+   */
+  final def decodeZoneOffsetWithFormatter(formatter: DateTimeFormatter): Decoder[ZoneOffset] =
+    new StandardJavaTimeDecoder[ZoneOffset]("ZoneOffset") {
+      protected final def parseUnsafe(input: String): ZoneOffset =
+        ZoneOffset.of(input)
     }
 
   /**
@@ -191,6 +221,18 @@ private[circe] trait JavaTimeDecoders {
   /**
    * @group Time
    */
+  implicit final val decodeMonthDay: Decoder[MonthDay] =
+    new StandardJavaTimeDecoder[MonthDay]("MonthDay") {
+      private[this] final def monthDayFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("--MM-dd")
+
+      protected final def parseUnsafe(input: String): MonthDay =
+        MonthDay.parse(input, monthDayFormatter)
+    }
+
+  /**
+   * @group Time
+   */
   implicit final val decodeOffsetTime: Decoder[OffsetTime] =
     new StandardJavaTimeDecoder[OffsetTime]("OffsetTime") {
       protected final def parseUnsafe(input: String): OffsetTime =
@@ -209,6 +251,24 @@ private[circe] trait JavaTimeDecoders {
   /**
    * @group Time
    */
+  implicit final val decodeYear: Decoder[Year] =
+    new StandardJavaTimeDecoder[Year]("Year") {
+      protected final def parseUnsafe(input: String): Year =
+        Year.parse(input)
+    }
+
+  /**
+   * @group Time
+   */
+  implicit final val decodeYearMonth: Decoder[YearMonth] =
+    new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
+      protected final def parseUnsafe(input: String): YearMonth =
+        YearMonth.parse(input, DateTimeFormatter.ofPattern("uuuu-MM"))
+    }
+
+  /**
+   * @group Time
+   */
   implicit final val decodeZonedDateTime: Decoder[ZonedDateTime] =
     new StandardJavaTimeDecoder[ZonedDateTime]("ZonedDateTime") {
       protected final def parseUnsafe(input: String): ZonedDateTime =
@@ -218,9 +278,8 @@ private[circe] trait JavaTimeDecoders {
   /**
    * @group Time
    */
-  implicit final val decodeYearMonth: Decoder[YearMonth] =
-    new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
-      protected final def parseUnsafe(input: String): YearMonth =
-        YearMonth.parse(input, DateTimeFormatter.ofPattern("yyyy-MM"))
+  implicit final val decodeZoneOffset: Decoder[ZoneOffset] =
+    new StandardJavaTimeDecoder[ZoneOffset]("ZoneOffset") {
+      protected final def parseUnsafe(input: String): ZoneOffset = ZoneOffset.of(input)
     }
 }

--- a/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeEncoders.scala
+++ b/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeEncoders.scala
@@ -164,9 +164,7 @@ private[circe] trait JavaTimeEncoders {
    * @group Time
    */
   implicit final val encodeMonthDay: Encoder[MonthDay] =
-    new JavaTimeEncoder[MonthDay] {
-      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("--MM-dd")
-    }
+    Encoder.instance(monthDay => Json.fromString(monthDay.toString))
 
   /**
    * @group Time
@@ -193,9 +191,7 @@ private[circe] trait JavaTimeEncoders {
    * @group Time
    */
   implicit final val encodeYearMonth: Encoder[YearMonth] =
-    new JavaTimeEncoder[YearMonth] {
-      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM")
-    }
+    Encoder.instance(yearMonth => Json.fromString(yearMonth.toString))
 
   /**
    * @group Time

--- a/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeEncoders.scala
+++ b/modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeEncoders.scala
@@ -6,12 +6,15 @@ import java.time.{
   LocalDate,
   LocalDateTime,
   LocalTime,
+  MonthDay,
   OffsetDateTime,
   OffsetTime,
   Period,
+  Year,
   YearMonth,
   ZonedDateTime,
-  ZoneId
+  ZoneId,
+  ZoneOffset
 }
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatter.{
@@ -80,6 +83,14 @@ private[circe] trait JavaTimeEncoders {
   /**
    * @group Time
    */
+  final def encodeMonthDayWithFormatter(formatter: DateTimeFormatter): Encoder[MonthDay] =
+    new JavaTimeEncoder[MonthDay] {
+      protected final def format: DateTimeFormatter = formatter
+    }
+
+  /**
+   * @group Time
+   */
   final def encodeOffsetTimeWithFormatter(formatter: DateTimeFormatter): Encoder[OffsetTime] =
     new JavaTimeEncoder[OffsetTime] {
       protected final def format: DateTimeFormatter = formatter
@@ -96,8 +107,8 @@ private[circe] trait JavaTimeEncoders {
   /**
    * @group Time
    */
-  final def encodeZonedDateTimeWithFormatter(formatter: DateTimeFormatter): Encoder[ZonedDateTime] =
-    new JavaTimeEncoder[ZonedDateTime] {
+  final def encodeYearWithFormatter(formatter: DateTimeFormatter): Encoder[Year] =
+    new JavaTimeEncoder[Year] {
       protected final def format: DateTimeFormatter = formatter
     }
 
@@ -106,6 +117,22 @@ private[circe] trait JavaTimeEncoders {
    */
   final def encodeYearMonthWithFormatter(formatter: DateTimeFormatter): Encoder[YearMonth] =
     new JavaTimeEncoder[YearMonth] {
+      protected final def format: DateTimeFormatter = formatter
+    }
+
+  /**
+   * @group Time
+   */
+  final def encodeZonedDateTimeWithFormatter(formatter: DateTimeFormatter): Encoder[ZonedDateTime] =
+    new JavaTimeEncoder[ZonedDateTime] {
+      protected final def format: DateTimeFormatter = formatter
+    }
+
+  /**
+   * @group Time
+   */
+  final def encodeZoneOffsetWithFormatter(formatter: DateTimeFormatter): Encoder[ZoneOffset] =
+    new JavaTimeEncoder[ZoneOffset] {
       protected final def format: DateTimeFormatter = formatter
     }
 
@@ -136,6 +163,14 @@ private[circe] trait JavaTimeEncoders {
   /**
    * @group Time
    */
+  implicit final val encodeMonthDay: Encoder[MonthDay] =
+    new JavaTimeEncoder[MonthDay] {
+      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("--MM-dd")
+    }
+
+  /**
+   * @group Time
+   */
   implicit final val encodeOffsetTime: Encoder[OffsetTime] =
     new JavaTimeEncoder[OffsetTime] {
       protected final def format: DateTimeFormatter = ISO_OFFSET_TIME
@@ -152,6 +187,19 @@ private[circe] trait JavaTimeEncoders {
   /**
    * @group Time
    */
+  implicit final val encodeYear: Encoder[Year] = Encoder.instance(year => Json.fromString(year.toString))
+
+  /**
+   * @group Time
+   */
+  implicit final val encodeYearMonth: Encoder[YearMonth] =
+    new JavaTimeEncoder[YearMonth] {
+      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM")
+    }
+
+  /**
+   * @group Time
+   */
   implicit final val encodeZonedDateTime: Encoder[ZonedDateTime] =
     new JavaTimeEncoder[ZonedDateTime] {
       protected final def format: DateTimeFormatter = ISO_ZONED_DATE_TIME
@@ -160,8 +208,6 @@ private[circe] trait JavaTimeEncoders {
   /**
    * @group Time
    */
-  implicit final val encodeYearMonth: Encoder[YearMonth] =
-    new JavaTimeEncoder[YearMonth] {
-      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM")
-    }
+  implicit final val encodeZoneOffset: Encoder[ZoneOffset] =
+    Encoder.instance(zoneOffset => Json.fromString(zoneOffset.toString))
 }

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
@@ -15,8 +15,8 @@ import java.time.{
   Year,
   YearMonth,
   ZonedDateTime,
-  ZoneOffset,
-  ZoneId
+  ZoneId,
+  ZoneOffset
 }
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatter.{

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
@@ -264,7 +264,7 @@ trait JavaTimeDecoders {
   implicit final val decodeYearMonth: Decoder[YearMonth] =
     new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
       protected final def parseUnsafe(input: String): YearMonth =
-        YearMonth.parse(input)
+        YearMonth.parse(input, DateTimeFormatter.ofPattern("uuuu-MM"))
     }
 
   /**

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
@@ -224,11 +224,8 @@ trait JavaTimeDecoders {
    */
   implicit final val decodeMonthDay: Decoder[MonthDay] =
     new StandardJavaTimeDecoder[MonthDay]("MonthDay") {
-      private[this] final def monthDayFormatter: DateTimeFormatter =
-        DateTimeFormatter.ofPattern("--MM-dd")
-
       protected final def parseUnsafe(input: String): MonthDay =
-        MonthDay.parse(input, monthDayFormatter)
+        MonthDay.parse(input)
     }
 
   /**
@@ -264,7 +261,7 @@ trait JavaTimeDecoders {
   implicit final val decodeYearMonth: Decoder[YearMonth] =
     new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
       protected final def parseUnsafe(input: String): YearMonth =
-        YearMonth.parse(input, DateTimeFormatter.ofPattern("uuuu-MM"))
+        YearMonth.parse(input)
     }
 
   /**

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala
@@ -38,11 +38,13 @@ private[time] abstract class JavaTimeDecoder[A](name: String) extends Decoder[A]
 
   final def apply(c: HCursor): Decoder.Result[A] = c.value match {
     case Json.JString(string) =>
-      try Right(parseUnsafe(string)) catch {
+      try Right(parseUnsafe(string))
+      catch {
         case e: DateTimeException =>
           val message = e.getMessage
 
-          if (message.eq(null)) Left(DecodingFailure(name, c.history)) else {
+          if (message.eq(null)) Left(DecodingFailure(name, c.history))
+          else {
             val newMessage = formatMessage(string, message)
             Left(DecodingFailure(s"$name ($newMessage)", c.history))
           }
@@ -51,13 +53,13 @@ private[time] abstract class JavaTimeDecoder[A](name: String) extends Decoder[A]
   }
 }
 
-private[time] abstract class StandardJavaTimeDecoder[A](name: String)
-    extends JavaTimeDecoder[A](name) {
+private[time] abstract class StandardJavaTimeDecoder[A](name: String) extends JavaTimeDecoder[A](name) {
 
   protected final def formatMessage(input: String, message: String): String = message
 }
 
 trait JavaTimeDecoders {
+
   /**
    * @group Time
    */

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
@@ -165,9 +165,7 @@ trait JavaTimeEncoders {
    * @group Time
    */
   implicit final val encodeMonthDay: Encoder[MonthDay] =
-    new JavaTimeEncoder[MonthDay] {
-      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("--MM-dd")
-    }
+    Encoder.instance(monthDay => Json.fromString(monthDay.toString))
 
   /**
    * @group Time
@@ -194,9 +192,7 @@ trait JavaTimeEncoders {
    * @group Time
    */
   implicit final val encodeYearMonth: Encoder[YearMonth] =
-    new JavaTimeEncoder[YearMonth] {
-      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM")
-    }
+    Encoder.instance(yearMonth => Json.fromString(yearMonth.toString))
 
   /**
    * @group Time

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
@@ -194,7 +194,9 @@ trait JavaTimeEncoders {
    * @group Time
    */
   implicit final val encodeYearMonth: Encoder[YearMonth] =
-    Encoder.instance(yearMonth => Json.fromString(yearMonth.toString))
+    new JavaTimeEncoder[YearMonth] {
+      protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM")
+    }
 
   /**
    * @group Time

--- a/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala
@@ -35,33 +35,27 @@ private[time] abstract class JavaTimeEncoder[A <: TemporalAccessor] extends Enco
 }
 
 trait JavaTimeEncoders {
-  /**
-   * @group Time
-   */
-  implicit final val encodeDuration: Encoder[Duration] = Encoder.instance(duration =>
-    Json.fromString(duration.toString)
-  )
 
   /**
    * @group Time
    */
-  implicit final val encodeInstant: Encoder[Instant] = Encoder.instance(time =>
-    Json.fromString(time.toString)
-  )
+  implicit final val encodeDuration: Encoder[Duration] =
+    Encoder.instance(duration => Json.fromString(duration.toString))
 
   /**
    * @group Time
    */
-  implicit final val encodePeriod: Encoder[Period] = Encoder.instance(period =>
-    Json.fromString(period.toString)
-  )
+  implicit final val encodeInstant: Encoder[Instant] = Encoder.instance(time => Json.fromString(time.toString))
 
   /**
    * @group Time
    */
-  implicit final val encodeZoneId: Encoder[ZoneId] = Encoder.instance(zoneId =>
-    Json.fromString(zoneId.getId)
-  )
+  implicit final val encodePeriod: Encoder[Period] = Encoder.instance(period => Json.fromString(period.toString))
+
+  /**
+   * @group Time
+   */
+  implicit final val encodeZoneId: Encoder[ZoneId] = Encoder.instance(zoneId => Json.fromString(zoneId.getId))
 
   /**
    * @group Time
@@ -112,16 +106,16 @@ trait JavaTimeEncoders {
     }
 
   /**
-    * @group Time
-    */
+   * @group Time
+   */
   final def encodeYearWithFormatter(formatter: DateTimeFormatter): Encoder[Year] =
     new JavaTimeEncoder[Year] {
       protected final def format: DateTimeFormatter = formatter
     }
 
   /**
-    * @group Time
-    */
+   * @group Time
+   */
   final def encodeYearMonthWithFormatter(formatter: DateTimeFormatter): Encoder[YearMonth] =
     new JavaTimeEncoder[YearMonth] {
       protected final def format: DateTimeFormatter = formatter
@@ -168,8 +162,8 @@ trait JavaTimeEncoders {
     }
 
   /**
-    * @group Time
-    */
+   * @group Time
+   */
   implicit final val encodeMonthDay: Encoder[MonthDay] =
     new JavaTimeEncoder[MonthDay] {
       protected final def format: DateTimeFormatter = DateTimeFormatter.ofPattern("--MM-dd")
@@ -192,18 +186,15 @@ trait JavaTimeEncoders {
     }
 
   /**
-    * @group Time
-    */
-  implicit final val encodeYear: Encoder[Year] = Encoder.instance(year =>
-    Json.fromString(year.toString)
-  )
+   * @group Time
+   */
+  implicit final val encodeYear: Encoder[Year] = Encoder.instance(year => Json.fromString(year.toString))
 
   /**
-    * @group Time
-    */
-  implicit final val encodeYearMonth: Encoder[YearMonth] = Encoder.instance(yearMonth =>
-    Json.fromString(yearMonth.toString)
-  )
+   * @group Time
+   */
+  implicit final val encodeYearMonth: Encoder[YearMonth] =
+    Encoder.instance(yearMonth => Json.fromString(yearMonth.toString))
 
   /**
    * @group Time
@@ -214,9 +205,8 @@ trait JavaTimeEncoders {
     }
 
   /**
-    * @group Time
-    */
-  implicit final val encodeZoneOffset: Encoder[ZoneOffset] = Encoder.instance(zoneOffset =>
-    Json.fromString(zoneOffset.toString)
-  )
+   * @group Time
+   */
+  implicit final val encodeZoneOffset: Encoder[ZoneOffset] =
+    Encoder.instance(zoneOffset => Json.fromString(zoneOffset.toString))
 }

--- a/modules/java8/src/test/scala/io/circe/java8/time/JavaTimeCodecSuite.scala
+++ b/modules/java8/src/test/scala/io/circe/java8/time/JavaTimeCodecSuite.scala
@@ -1,11 +1,11 @@
 package io.circe.java8.time
 
 import cats.kernel.Eq
-import io.circe.{Decoder, Encoder, Json, ObjectEncoder}
+import io.circe.{ Decoder, Encoder, Json, ObjectEncoder }
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
 import java.time._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary.arbitrary
 import scala.collection.JavaConverters._
 
@@ -44,21 +44,21 @@ class JavaTimeCodecSuite extends CirceSuite {
   implicit val arbitraryLocalDateTime: Arbitrary[LocalDateTime] = Arbitrary(
     for {
       instant <- arbitrary[Instant]
-      zoneId  <- arbitrary[ZoneId]
+      zoneId <- arbitrary[ZoneId]
     } yield LocalDateTime.ofInstant(instant, zoneId)
   )
 
   implicit val arbitraryZonedDateTime: Arbitrary[ZonedDateTime] = Arbitrary(
     for {
       instant <- arbitrary[Instant]
-      zoneId  <- arbitrary[ZoneId].suchThat(_ != ZoneId.of("GMT0")) // #280 - avoid JDK-8138664
+      zoneId <- arbitrary[ZoneId].suchThat(_ != ZoneId.of("GMT0")) // #280 - avoid JDK-8138664
     } yield ZonedDateTime.ofInstant(instant, zoneId)
   )
 
   implicit val arbitraryOffsetDateTime: Arbitrary[OffsetDateTime] = Arbitrary(
     for {
       instant <- arbitrary[Instant]
-      zoneId  <- arbitrary[ZoneId]
+      zoneId <- arbitrary[ZoneId]
     } yield OffsetDateTime.ofInstant(instant, zoneId)
   )
 
@@ -66,16 +66,17 @@ class JavaTimeCodecSuite extends CirceSuite {
 
   implicit val arbitraryLocalTime: Arbitrary[LocalTime] = Arbitrary(arbitrary[LocalDateTime].map(_.toLocalTime))
 
-  implicit val arbitraryMonthDay: Arbitrary[MonthDay] = Arbitrary(arbitrary[LocalDateTime].map(
-    ldt => MonthDay.of(ldt.getMonth, ldt.getDayOfMonth)))
+  implicit val arbitraryMonthDay: Arbitrary[MonthDay] = Arbitrary(
+    arbitrary[LocalDateTime].map(ldt => MonthDay.of(ldt.getMonth, ldt.getDayOfMonth))
+  )
 
   implicit val arbitraryOffsetTime: Arbitrary[OffsetTime] = Arbitrary(arbitrary[OffsetDateTime].map(_.toOffsetTime))
 
-  implicit val arbitraryYear: Arbitrary[Year] = Arbitrary(arbitrary[LocalDateTime].map(
-    ldt => Year.of(ldt.getYear)))
+  implicit val arbitraryYear: Arbitrary[Year] = Arbitrary(arbitrary[LocalDateTime].map(ldt => Year.of(ldt.getYear)))
 
-  implicit val arbitraryYearMonth: Arbitrary[YearMonth] = Arbitrary(arbitrary[LocalDateTime].map(
-    ldt => YearMonth.of(ldt.getYear, ldt.getMonth)))
+  implicit val arbitraryYearMonth: Arbitrary[YearMonth] = Arbitrary(
+    arbitrary[LocalDateTime].map(ldt => YearMonth.of(ldt.getYear, ldt.getMonth))
+  )
 
   implicit val arbitraryZoneOffset: Arbitrary[ZoneOffset] =
     Arbitrary(Gen.choose(-18 * 60 * 60, 18 * 60 * 60).map(ZoneOffset.ofTotalSeconds))
@@ -132,15 +133,16 @@ class JavaTimeCodecSuite extends CirceSuite {
   val parseExceptionMessage = s"Text '$invalidText'"
 
   "Decoder[ZoneId]" should "fail for invalid ZoneId" in {
-    forAll((s: String) =>
-      whenever(!ZoneId.getAvailableZoneIds.contains(s)) {
-        val decodingResult = Decoder[ZoneId].decodeJson(Json.fromString(s))
+    forAll(
+      (s: String) =>
+        whenever(!ZoneId.getAvailableZoneIds.contains(s)) {
+          val decodingResult = Decoder[ZoneId].decodeJson(Json.fromString(s))
 
-        assert(decodingResult.isLeft)
-        // The middle part of the message depends on the type of zone.
-        assert(decodingResult.left.get.message.contains("ZoneId (Invalid"))
-        assert(decodingResult.left.get.message.contains(s", invalid format: $s)"))
-      }
+          assert(decodingResult.isLeft)
+          // The middle part of the message depends on the type of zone.
+          assert(decodingResult.left.get.message.contains("ZoneId (Invalid"))
+          assert(decodingResult.left.get.message.contains(s", invalid format: $s)"))
+        }
     )
   }
 


### PR DESCRIPTION
Fixes #1060. I've switched both to the standard `uuuu-MM` for `YearMonth` for consistency. Now the diff looks reasonable:

```scala
travis@sidmouth circe(fix/time-instance-discrepancies)$ diff modules/java8/src/main/scala/io/circe/java8/time/JavaTimeDecoders.scala modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeDecoders.scala 
1c1
< package io.circe.java8.time
---
> package io.circe
3d2
< import io.circe.{ Decoder, DecodingFailure, HCursor, Json }
31c30
< private[time] abstract class JavaTimeDecoder[A](name: String) extends Decoder[A] {
---
> private[circe] abstract class JavaTimeDecoder[A](name: String) extends Decoder[A] {
56c55
< private[time] abstract class StandardJavaTimeDecoder[A](name: String) extends JavaTimeDecoder[A](name) {
---
> private[circe] abstract class StandardJavaTimeDecoder[A](name: String) extends JavaTimeDecoder[A](name) {
61c60
< trait JavaTimeDecoders {
---
> private[circe] trait JavaTimeDecoders {
travis@sidmouth circe(fix/time-instance-discrepancies)$ diff modules/java8/src/main/scala/io/circe/java8/time/JavaTimeEncoders.scala modules/core/shared/src/main/scala-with-jdk8/io/circe/JavaTimeEncoders.scala 
1c1
< package io.circe.java8.time
---
> package io.circe
3d2
< import io.circe.{ Encoder, Json }
31c30
< private[time] abstract class JavaTimeEncoder[A <: TemporalAccessor] extends Encoder[A] {
---
> private[circe] abstract class JavaTimeEncoder[A <: TemporalAccessor] extends Encoder[A] {
37c36
< trait JavaTimeEncoders {
---
> private[circe] trait JavaTimeEncoders {
```
Unfortunately these changes break binary compatibility, so they'll have to wait for 0.12.0.