### PR TITLE
Move pattern functor to separate module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,6 +188,7 @@ lazy val circeCrossModules = Seq[(Project, Project)](
   (numbersTesting, numbersTestingJS),
   (numbers, numbersJS),
   (core, coreJS),
+  (rs, rsJS),
   (generic, genericJS),
   (genericExtras, genericExtrasJS),
   (shapes, shapesJS),
@@ -311,6 +312,11 @@ lazy val coreBase = circeCrossModule("core", mima = previousCirceVersion)
 lazy val core = coreBase.jvm
 lazy val coreJS = coreBase.js
 
+lazy val rsBase = circeCrossModule("rs", mima = previousCirceVersion, CrossType.Pure).dependsOn(coreBase)
+
+lazy val rs = rsBase.jvm
+lazy val rsJS = rsBase.js
+
 lazy val genericBase = circeCrossModule("generic", mima = previousCirceVersion)
   .settings(macroSettings)
   .settings(
@@ -419,7 +425,7 @@ lazy val testingBase = circeCrossModule("testing", mima = previousCirceVersion)
   .settings(
     coverageExcludedPackages := "io\\.circe\\.testing\\..*"
   )
-  .dependsOn(coreBase, numbersTestingBase)
+  .dependsOn(coreBase, numbersTestingBase, rsBase)
 
 lazy val testing = testingBase.jvm
 lazy val testingJS = testingBase.js

--- a/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
+++ b/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
@@ -6,7 +6,6 @@ import cats.instances.vector._
 import cats.kernel.Eq
 import cats.kernel.instances.string._
 import io.circe.{ JsonNumber, Json, JsonObject }
-import io.circe.Json._
 
 /**
  * A pattern-functor reflecting the JSON datatype structure in a
@@ -91,7 +90,7 @@ object JsonF {
   }
 
   private val unfolder: Json.Folder[JsonF[Json]] =
-    new Folder[JsonF[Json]] {
+    new Json.Folder[JsonF[Json]] {
       def onNull = JNullF
       def onBoolean(value: Boolean) = JBooleanF(value)
       def onNumber(value: JsonNumber) = JNumberF(value)

--- a/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
+++ b/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
@@ -13,16 +13,15 @@ import io.circe.{ JsonNumber, Json, JsonObject }
  */
 sealed trait JsonF[+A]
 
-// format: off
-final case object JNullF                                  extends JsonF[Nothing]
-final case class JBooleanF(b: Boolean)                    extends JsonF[Nothing]
-final case class JNumberF(n: JsonNumber)                  extends JsonF[Nothing]
-final case class JStringF(s: String)                      extends JsonF[Nothing]
-final case class JArrayF[A](value: Vector[A])             extends JsonF[A]
-final case class JObjectF[A](fields: Vector[(String, A)]) extends JsonF[A]
-// format: on
-
 object JsonF {
+  // format: off
+  final case object JNullF                                  extends JsonF[Nothing]
+  final case class JBooleanF(b: Boolean)                    extends JsonF[Nothing]
+  final case class JNumberF(n: JsonNumber)                  extends JsonF[Nothing]
+  final case class JStringF(s: String)                      extends JsonF[Nothing]
+  final case class JArrayF[A](value: Vector[A])             extends JsonF[A]
+  final case class JObjectF[A](fields: Vector[(String, A)]) extends JsonF[A]
+  // format: on
 
   /**
    * An co-algebraic function that unfolds one layer of json into

--- a/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
+++ b/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
@@ -1,12 +1,10 @@
 package io.circe.rs
 
 import cats.{ Applicative, Eval, Foldable, Traverse }
-import cats.instances.string._
 import cats.instances.tuple._
 import cats.instances.vector._
 import cats.kernel.Eq
-import cats.syntax.functor._
-import cats.syntax.traverse._
+import cats.kernel.instances.string._
 import io.circe.{ JsonNumber, Json, JsonObject }
 import io.circe.Json._
 
@@ -54,9 +52,9 @@ object JsonF {
       case x @ JBooleanF(_) => G.pure(x)
       case x @ JStringF(_)  => G.pure(x)
       case x @ JNumberF(_)  => G.pure(x)
-      case JArrayF(vecA)    => vecA.traverse(f).map(vecB => JArrayF(vecB))
+      case JArrayF(vecA)    => G.map(Traverse[Vector].traverse(vecA)(f))(vecB => JArrayF(vecB))
       case JObjectF(fieldsA) =>
-        Traverse[Vector].compose[Field].traverse(fieldsA)(f).map(fieldsB => JObjectF(fieldsB))
+        G.map(Traverse[Vector].compose[Field].traverse(fieldsA)(f))(fieldsB => JObjectF(fieldsB))
     }
 
     override def foldLeft[A, B](fa: JsonF[A], b: B)(f: (B, A) => B): B =

--- a/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
+++ b/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
@@ -1,4 +1,4 @@
-package io.circe
+package io.circe.rs
 
 import cats.{ Applicative, Eval, Foldable, Traverse }
 import cats.instances.string._
@@ -7,6 +7,7 @@ import cats.instances.vector._
 import cats.kernel.Eq
 import cats.syntax.functor._
 import cats.syntax.traverse._
+import io.circe.{ JsonNumber, Json, JsonObject }
 import io.circe.Json._
 
 /**

--- a/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
+++ b/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
@@ -5,7 +5,7 @@ import cats.instances.tuple._
 import cats.instances.vector._
 import cats.kernel.Eq
 import cats.kernel.instances.string._
-import io.circe.{ JsonNumber, Json, JsonObject }
+import io.circe.{ Json, JsonNumber, JsonObject }
 
 /**
  * A pattern-functor reflecting the JSON datatype structure in a

--- a/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
+++ b/modules/rs/src/main/scala/io/circe/rs/JsonF.scala
@@ -42,7 +42,7 @@ object JsonF {
     case JObjectF(fields) => Json.obj(fields: _*)
   }
 
-  private type Field[A] = (String, A)
+  private[this] type Field[A] = (String, A)
 
   implicit val jsonFTraverseInstance: Traverse[JsonF] = new Traverse[JsonF] {
     override def traverse[G[_], A, B](fa: JsonF[A])(f: A => G[B])(implicit G: Applicative[G]): G[JsonF[B]] = fa match {
@@ -88,7 +88,7 @@ object JsonF {
     case _                                      => false
   }
 
-  private val unfolder: Json.Folder[JsonF[Json]] =
+  private[this] val unfolder: Json.Folder[JsonF[Json]] =
     new Json.Folder[JsonF[Json]] {
       def onNull = JNullF
       def onBoolean(value: Boolean) = JBooleanF(value)

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -9,23 +9,17 @@ import io.circe.{
   Decoder,
   DecodingFailure,
   Encoder,
-  JArrayF,
-  JBooleanF,
-  JNullF,
-  JNumberF,
-  JObjectF,
   Json,
   JsonBiggerDecimal,
-  JsonF,
   JsonNumber,
   JsonObject,
-  JStringF,
   KeyDecoder,
   KeyEncoder,
   ObjectEncoder
 }
 import io.circe.numbers.BiggerDecimal
 import io.circe.numbers.testing.{ IntegralString, JsonNumberString }
+import io.circe.rs.{ JArrayF, JBooleanF, JNullF, JNumberF, JObjectF, JsonF, JStringF }
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
 
 trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstances with ShrinkInstances {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -19,7 +19,8 @@ import io.circe.{
 }
 import io.circe.numbers.BiggerDecimal
 import io.circe.numbers.testing.{ IntegralString, JsonNumberString }
-import io.circe.rs.{ JArrayF, JBooleanF, JNullF, JNumberF, JObjectF, JsonF, JStringF }
+import io.circe.rs.JsonF
+import io.circe.rs.JsonF.{ JArrayF, JBooleanF, JNullF, JNumberF, JObjectF, JStringF }
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
 
 trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstances with ShrinkInstances {

--- a/modules/tests/shared/src/test/scala/io/circe/rs/JsonFSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/rs/JsonFSuite.scala
@@ -1,7 +1,8 @@
-package io.circe
+package io.circe.rs
 
 import cats.laws.discipline.TraverseTests
-import io.circe.JsonF.{ foldJson, unfoldJson }
+import io.circe.Json
+import io.circe.rs.JsonF.{ foldJson, unfoldJson }
 import io.circe.tests.CirceSuite
 
 class JsonFSuite extends CirceSuite {


### PR DESCRIPTION
@Baccata What do you think? This just moves `JsonF` to a new circe-rs module (for _recursion schemes_, but I'm happy to change the package name). I want to get an 0.12.0 release out as soon as ScalaTest 3.0.7 is here, and we can decide whether this belongs in core after that.