### PR TITLE
More circe-rs stuff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -247,7 +247,7 @@ lazy val circe = project
       """.stripMargin
   )
   .aggregate(aggregatedProjects: _*)
-  .dependsOn(core, genericExtras, literal, parser)
+  .dependsOn(core, genericExtras, literal, parser, rs)
 
 lazy val numbersTestingBase = circeCrossModule("numbers-testing", mima = previousCirceVersion, CrossType.Pure).settings(
   scalacOptions ~= {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -141,7 +141,7 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
         Arbitrary.arbitrary[JsonNumber].map(JNumberF),
         Gen.const(JNullF),
         Arbitrary.arbitrary[String].map(JStringF),
-        Arbitrary.arbitrary[Vector[(String, A)]].map(JObjectF.apply),
+        Arbitrary.arbitrary[Vector[(String, A)]].map(_.groupBy(_._1).mapValues(_.head._2).toVector).map(JObjectF.apply),
         Arbitrary.arbitrary[Vector[A]].map(JArrayF.apply)
       )
     )

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ShrinkInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ShrinkInstances.scala
@@ -1,6 +1,7 @@
 package io.circe.testing
 
 import io.circe.{ Json, JsonBigDecimal, JsonNumber, JsonObject }
+import io.circe.rs.JsonF
 import org.scalacheck.Shrink
 
 private[testing] trait ShrinkInstances {
@@ -58,4 +59,15 @@ private[testing] trait ShrinkInstances {
         }
     )
   )
+
+  implicit def shrinkJsonF[A](implicit A: Shrink[A]): Shrink[JsonF[A]] = Shrink {
+    case JsonF.JNullF       => Stream.empty
+    case JsonF.JBooleanF(_) => Stream.empty
+    case JsonF.JNumberF(n)  => shrinkJsonNumber.shrink(n).map(JsonF.JNumberF(_))
+    case JsonF.JStringF(s)  => Shrink.shrinkString.shrink(s).map(JsonF.JStringF(_))
+    case JsonF.JArrayF(values) =>
+      Shrink.shrinkContainer[Vector, A].shrink(values).map(JsonF.JArrayF(_))
+    case JsonF.JObjectF(fields) =>
+      Shrink.shrinkContainer[Vector, (String, A)].shrink(fields).map(JsonF.JObjectF(_))
+  }
 }


### PR DESCRIPTION
Some builds have been failing because of the fold-unfold test, and I took a quick look but couldn't reproduce locally and didn't want to wade through the huge `JsonF` values, so I added a `Shrink` instance (and went ahead and threw in a couple of other small changes as well).