### PR TITLE
Add canonicallyEqual method to Json

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -169,6 +169,15 @@ sealed abstract class Json extends Product with Serializable {
     }
 
   /**
+    *Equality method that does not consider field order or null
+    *values.
+    */
+  def canonicallyEqual(that: Any): Boolean = that match {
+    case that : Json => this.dropNullValues.equals(that.dropNullValues)
+    case _ => false
+  }
+
+  /**
    * Drop the entries with a null value if this is an object.
    *
    * Note that this does not apply recursively.

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -169,12 +169,12 @@ sealed abstract class Json extends Product with Serializable {
     }
 
   /**
-    *Equality method that does not consider field order or null
-    *values.
-    */
+   *Equality method that does not consider field order or null
+   *values.
+   */
   def canonicallyEqual(that: Any): Boolean = that match {
-    case that : Json => this.dropNullValues.equals(that.dropNullValues)
-    case _ => false
+    case that: Json => this.dropNullValues.equals(that.dropNullValues)
+    case _          => false
   }
 
   /**

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -84,6 +84,21 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
 
     assert(merged.asObject.map(_.toList) === Some(fields.reverse))
   }
+  "canonicallyEqual" should "not consider null values" in {
+    val expected = true
+    val this_json = Json.fromJsonObject(JsonObject.empty)
+    val that_json = Json.obj(("foo", Json.Null))
+    val actual = this_json.canonicallyEqual(that_json)
+    assert(actual == expected)
+  }
+
+  it should "not consider field ordering" in {
+    val expected = true
+    val this_json = Json.obj("a" -> Json.fromInt(1), "b" -> Json.fromInt(2))
+    val that_json = Json.obj("b" -> Json.fromInt(2), "a" -> Json.fromInt(1))
+    val actual = this_json.canonicallyEqual(that_json)
+    assert(actual == expected)
+  }
 
   val key = "x"
   val value1 = "fizz"

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -86,17 +86,17 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
   }
   "canonicallyEqual" should "not consider null values" in {
     val expected = true
-    val this_json = Json.fromJsonObject(JsonObject.empty)
-    val that_json = Json.obj(("foo", Json.Null))
-    val actual = this_json.canonicallyEqual(that_json)
+    val thisJson = Json.fromJsonObject(JsonObject.empty)
+    val thatJson = Json.obj(("foo", Json.Null))
+    val actual = thisJson.canonicallyEqual(thatJson)
     assert(actual == expected)
   }
 
   it should "not consider field ordering" in {
     val expected = true
-    val this_json = Json.obj("a" -> Json.fromInt(1), "b" -> Json.fromInt(2))
-    val that_json = Json.obj("b" -> Json.fromInt(2), "a" -> Json.fromInt(1))
-    val actual = this_json.canonicallyEqual(that_json)
+    val thisJson = Json.obj("a" -> Json.fromInt(1), "b" -> Json.fromInt(2))
+    val thatJson = Json.obj("b" -> Json.fromInt(2), "a" -> Json.fromInt(1))
+    val actual = thisJson.canonicallyEqual(thatJson)
     assert(actual == expected)
   }
 


### PR DESCRIPTION
Created method as per #797 with some tests.
Tests pass but get some errors on the scalaFmtCheck, ran `sbt scalasytle` but got no errors.
I could be missing something very simple but wanted to open the PR regardless to see if anyone could point me out what I am missing/doing wrong.

Any feedback would be very welcomed, thanks.