### PR TITLE
Update sbt-coursier to 1.1.0-M13-2

### DIFF
--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-2")


### PR DESCRIPTION
sbt-coursier 1.1.0-M13-2 fixes a bug that prevents scala-steward from working on this repo. See https://github.com/fthomas/scala-steward/issues/383 for details.