### PR TITLE
Fixes errorHandling for withDefault Configuration

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
@@ -38,7 +38,8 @@ class ConfigurableDeriver(val c: whitebox.Context)
 
   protected[this] def decodeField(name: String, decode: TermName): Tree = q"""
     orDefault(
-      $decode.tryDecode(c.downField(transformMemberNames($name))),
+      c.downField(transformMemberNames($name)),
+      $decode,
       $name,
       defaults
     )
@@ -46,7 +47,8 @@ class ConfigurableDeriver(val c: whitebox.Context)
 
   protected[this] def decodeFieldAccumulating(name: String, decode: TermName): Tree = q"""
     orDefaultAccumulating(
-      $decode.tryDecodeAccumulating(c.downField(transformMemberNames($name))),
+      c.downField(transformMemberNames($name)),
+      $decode,
       $name,
       defaults
     )


### PR DESCRIPTION
Changes withDefault semantics to only return defaults when field is
missing and not for parse errors on existing fields.

closes https://github.com/circe/circe/issues/1024