### PR TITLE
Strict de-serialization for configured semi-auto decoder derivation

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -14,12 +14,14 @@ import java.util.regex.Pattern
  *                      the contents of the ADT are stored as an object.
  * @param transformConstructorNames Transforms the value of any constructor names in the JSON allowing, for example,
  *                                  formatting or case changes.
+ * @param strictDeserialization Whether to fail when superfluous fields are found.
  */
 final case class Configuration(
   transformMemberNames: String => String,
   transformConstructorNames: String => String,
   useDefaults: Boolean,
-  discriminator: Option[String]
+  discriminator: Option[String],
+  strictDeserialization: Boolean = false
 ) {
   def withSnakeCaseMemberNames: Configuration = copy(
     transformMemberNames = Configuration.snakeCaseTransformation
@@ -39,6 +41,8 @@ final case class Configuration(
 
   def withDefaults: Configuration = copy(useDefaults = true)
   def withDiscriminator(discriminator: String): Configuration = copy(discriminator = Some(discriminator))
+
+  def withStrictDeserialization: Configuration = copy(strictDeserialization = true)
 }
 
 final object Configuration {


### PR DESCRIPTION
Partially addresses https://github.com/circe/circe/issues/374.

This PR adds `strictDeserialization` boolean flag to generic-extras' [`Configuration`](https://github.com/circe/circe/blob/master/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala#L18). 

When enabled, `decodeCaseClass` checks whether superfluous fields are present in the input JSON and, if that is the case, reports an error indicating the fields that are present in the decoded JSON but not expected in the target product.