### PR TITLE
Remove ScalaTest dependency from circe-testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -368,7 +368,14 @@ lazy val shapesJS = shapesBase.js
 
 lazy val literalBase = circeCrossModule("literal", mima = previousCirceVersion, CrossType.Pure)
   .settings(macroSettings)
-  .settings(libraryDependencies += "com.chuusai" %%% "shapeless" % shapelessVersion % Test)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.chuusai" %%% "shapeless" % shapelessVersion % Test,
+      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test,
+      "org.scalatest" %%% "scalatest" % scalaTestVersion % Test,
+      "org.scalatestplus" %%% "scalatestplus-scalacheck" % "1.0.0-SNAP4" % Test
+    )
+  )
   .jsConfigure(_.settings(libraryDependencies += "org.typelevel" %% "jawn-parser" % jawnVersion % Test))
   .dependsOn(coreBase, parserBase % Test, testingBase % Test)
 
@@ -412,9 +419,7 @@ lazy val testingBase = circeCrossModule("testing", mima = previousCirceVersion)
       _.filterNot(Set("-Yno-predef"))
     },
     libraryDependencies ++= Seq(
-      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test,
-      "org.scalatest" %%% "scalatest" % scalaTestVersion,
-      "org.scalatestplus" %%% "scalatestplus-scalacheck" % "1.0.0-SNAP4",
+      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion,
       "org.typelevel" %%% "cats-laws" % catsVersion,
       "org.typelevel" %%% "discipline" % disciplineVersion
     )
@@ -434,7 +439,9 @@ lazy val testsBase = circeCrossModule("tests", mima = None)
       _.filterNot(Set("-Yno-predef"))
     },
     libraryDependencies ++= Seq(
-      "com.chuusai" %%% "shapeless" % shapelessVersion
+      "com.chuusai" %%% "shapeless" % shapelessVersion,
+      "org.scalatest" %%% "scalatest" % scalaTestVersion,
+      "org.scalatestplus" %%% "scalatestplus-scalacheck" % "1.0.0-SNAP4"
     ),
     sourceGenerators in Test += (sourceManaged in Test).map(Boilerplate.genTests).taskValue,
     unmanagedResourceDirectories in Compile +=

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/FoldingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/FoldingBenchmarkSpec.scala
@@ -1,8 +1,8 @@
 package io.circe.benchmark
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class FoldingBenchmarkSpec extends FlatSpec {
+class FoldingBenchmarkSpec extends AnyFlatSpec {
   val benchmark: FoldingBenchmark = new FoldingBenchmark
 
   "withFoldWith" should "give the correct result" in {

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/GenericDerivationBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/GenericDerivationBenchmarkSpec.scala
@@ -1,8 +1,8 @@
 package io.circe.benchmark
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class GenericDerivationBenchmarkSpec extends FlatSpec {
+class GenericDerivationBenchmarkSpec extends AnyFlatSpec {
   val benchmark: GenericDerivationBenchmark = new GenericDerivationBenchmark
 
   import benchmark._

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/JsonObjectBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/JsonObjectBenchmarkSpec.scala
@@ -1,9 +1,9 @@
 package io.circe.benchmark
 
 import io.circe.{ Json, JsonObject }
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class JsonObjectBenchmarkSpec extends FlatSpec {
+class JsonObjectBenchmarkSpec extends AnyFlatSpec {
   val benchmark: JsonObjectBenchmark = new JsonObjectBenchmark
 
   "buildWithFromIterable" should "build the correct JsonObject" in {

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/NumberParsingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/NumberParsingBenchmarkSpec.scala
@@ -1,9 +1,9 @@
 package io.circe.benchmark
 
 import io.circe.{ Json, JsonNumber }
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class NumberParsingBenchmarkSpec extends FlatSpec {
+class NumberParsingBenchmarkSpec extends AnyFlatSpec {
   val benchmark: NumberParsingBenchmark = new NumberParsingBenchmark
 
   val expectedBigDecimal = BigDecimal(benchmark.inputBigDecimal)

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
@@ -3,9 +3,9 @@ package io.circe.benchmark
 import io.circe.jawn.decode
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class PrintingBenchmarkSpec extends FlatSpec {
+class PrintingBenchmarkSpec extends AnyFlatSpec {
   val benchmark: PrintingBenchmark = new PrintingBenchmark
 
   import benchmark._

--- a/modules/jawn/src/test/scala/io/circe/jawn/JawnParserSuite.scala
+++ b/modules/jawn/src/test/scala/io/circe/jawn/JawnParserSuite.scala
@@ -1,8 +1,9 @@
 package io.circe.jawn
 
-import org.scalatest.{ FunSpec, Matchers }
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 
-class JawnParserSuite extends FunSpec with Matchers {
+class JawnParserSuite extends AnyFunSpec with Matchers {
   describe("JawnParser") {
     it("should respect maxValueSize for numbers") {
       val parser = JawnParser(10)


### PR DESCRIPTION
I don't know how this slipped in, but it's been around a while. I've also fixed a few lingering ScalaTest deprecation warnings.