### PR TITLE
Json.findAllByKey: avoid allocations.

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.{ Eq, Show }
 import io.circe.numbers.BiggerDecimal
 import java.io.Serializable
+import scala.collection.mutable.ListBuffer
 
 /**
  * A data type representing possible JSON values.
@@ -202,18 +203,21 @@ sealed abstract class Json extends Product with Serializable {
    * The Play docs, from which this method was inspired, reads:
    *   "Lookup for fieldName in the current object and all descendants."
    */
-  final def findAllByKey(key: String): List[Json] = keyValues(this).collect {
-    case (k, v) if (k == key) => v
+  final def findAllByKey(key: String): List[Json] = {
+    val hh: ListBuffer[Json] = ListBuffer.empty[Json]
+    def loop(json: Json): Unit = json match {
+      case JObject(obj) =>
+        obj.toIterable.foreach {
+          case (k, v) =>
+            if (k == key) hh += v
+            loop(v)
+        }
+      case JArray(elems) => elems.foreach(loop)
+      case _             => // do nothing
+    }
+    loop(this)
+    hh.toList
   }
-
-  private def keyValues(json: Json): List[(String, Json)] = json match {
-    case JObject(obj)  => obj.toList.flatMap { case (k, v) => keyValuesHelper(k, v) }
-    case JArray(elems) => elems.toList.flatMap(keyValues)
-    case _             => Nil
-  }
-
-  private def keyValuesHelper(key: String, value: Json): List[(String, Json)] =
-    (key, value) :: keyValues(value)
 }
 
 final object Json {


### PR DESCRIPTION
The existing code of `findAllByKey` was performing several memory allocations, not needed to create the final result.

- It creates a long list with `keyValues` from which it filters   only the pairs with a certain Key.
- Performs several transformations of `Vector` to list, which may  mean copying the whole Vector.
- For each field, it creates a new tuple-pair.

Instead of all that, we use a mutable ListBuffer, and a recursive loop that runs through the Json, picking only the fields and values that it cares about.