### PR TITLE
Fix Travis failed to install JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: scala
 
 scala:
@@ -6,7 +7,7 @@ scala:
   - 2.12.8
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 cache:
   directories:


### PR DESCRIPTION
Recent PRs like #1131, #1132, #1133, #1135 and #1136 due to JDK installation failure on Travis.

```
install-jdk.sh 2019-05-02
Expected feature release number in range of 9 to 13, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```

This PR fixes it.

[As of  2019-04-15, `xenial` is now default and recommended on Travis](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment), so let's move on instead of staying trusty. 
This PR explicitly specifies the build environment, so it wont be automatically updated to latest environments and break builds.