### PR TITLE
EnumerationEncoder/Decoder should respect Configuration

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/EnumerationDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/EnumerationDecoder.scala
@@ -17,7 +17,7 @@ final object EnumerationDecoder {
     wit: Witness.Aux[K],
     gv: LabelledGeneric.Aux[V, HNil],
     dr: EnumerationDecoder[R],
-    config: Configuration
+    config: Configuration = Configuration.default
   ): EnumerationDecoder[FieldType[K, V] :+: R] = new EnumerationDecoder[FieldType[K, V] :+: R] {
     def apply(c: HCursor): Decoder.Result[FieldType[K, V] :+: R] =
       c.as[String] match {

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/EnumerationDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/EnumerationDecoder.scala
@@ -1,6 +1,7 @@
 package io.circe.generic.extras.decoding
 
 import io.circe.{ Decoder, DecodingFailure, HCursor }
+import io.circe.generic.extras.Configuration
 import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness }
 import shapeless.labelled.{ field, FieldType }
 
@@ -15,11 +16,13 @@ final object EnumerationDecoder {
     implicit
     wit: Witness.Aux[K],
     gv: LabelledGeneric.Aux[V, HNil],
-    dr: EnumerationDecoder[R]
+    dr: EnumerationDecoder[R],
+    config: Configuration
   ): EnumerationDecoder[FieldType[K, V] :+: R] = new EnumerationDecoder[FieldType[K, V] :+: R] {
     def apply(c: HCursor): Decoder.Result[FieldType[K, V] :+: R] =
       c.as[String] match {
-        case Right(s) if s == wit.value.name => Right(Inl(field[K](gv.from(HNil))))
+        case Right(s) if s == config.transformConstructorNames(wit.value.name) =>
+          Right(Inl(field[K](gv.from(HNil))))
         case Right(_) =>
           dr.apply(c) match {
             case Right(v)  => Right(Inr(v))

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
@@ -1,6 +1,7 @@
 package io.circe.generic.extras.encoding
 
 import io.circe.{ Encoder, Json }
+import io.circe.generic.extras.Configuration
 import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness }
 import shapeless.labelled.FieldType
 
@@ -15,10 +16,11 @@ final object EnumerationEncoder {
     implicit
     wit: Witness.Aux[K],
     gv: LabelledGeneric.Aux[V, HNil],
-    dr: EnumerationEncoder[R]
+    dr: EnumerationEncoder[R],
+    config: Configuration
   ): EnumerationEncoder[FieldType[K, V] :+: R] = new EnumerationEncoder[FieldType[K, V] :+: R] {
     def apply(a: FieldType[K, V] :+: R): Json = a match {
-      case Inl(l) => Json.fromString(wit.value.name)
+      case Inl(l) => Json.fromString(config.transformConstructorNames(wit.value.name))
       case Inr(r) => dr(r)
     }
   }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/EnumerationEncoder.scala
@@ -17,7 +17,7 @@ final object EnumerationEncoder {
     wit: Witness.Aux[K],
     gv: LabelledGeneric.Aux[V, HNil],
     dr: EnumerationEncoder[R],
-    config: Configuration
+    config: Configuration = Configuration.default
   ): EnumerationEncoder[FieldType[K, V] :+: R] = new EnumerationEncoder[FieldType[K, V] :+: R] {
     def apply(a: FieldType[K, V] :+: R): Json = a match {
       case Inl(l) => Json.fromString(config.transformConstructorNames(wit.value.name))

--- a/modules/generic-extras/src/test/scala/io/circe/generic/extras/EnumerationSemiautoDerivedSuite.scala
+++ b/modules/generic-extras/src/test/scala/io/circe/generic/extras/EnumerationSemiautoDerivedSuite.scala
@@ -15,10 +15,26 @@ class EnumerationSemiautoDerivedSuite extends CirceSuite {
   checkLaws("Codec[CardinalDirection]", CodecTests[CardinalDirection].codec)
 
   "deriveEnumerationDecoder" should "not compile on an ADT with case classes" in {
+    implicit val config: Configuration = Configuration.default
     illTyped("deriveEnumerationDecoder[ExtendedCardinalDirection]")
   }
 
+  it should "respect Configuration" in {
+    implicit val config: Configuration = Configuration.default.withSnakeCaseConstructorNames
+    val decodeMary = deriveEnumerationDecoder[Mary]
+    val expected = json""""little_lamb""""
+    assert(decodeMary.decodeJson(expected) === Right(LittleLamb))
+  }
+
   "deriveEnumerationEncoder" should "not compile on an ADT with case classes" in {
+    implicit val config: Configuration = Configuration.default
     illTyped("deriveEnumerationEncoder[ExtendedCardinalDirection]")
+  }
+
+  it should "respect Configuration" in {
+    implicit val config: Configuration = Configuration.default.withSnakeCaseConstructorNames
+    val encodeMary = deriveEnumerationEncoder[Mary]
+    val expected = json""""little_lamb""""
+    assert(encodeMary(LittleLamb) === expected)
   }
 }

--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -72,6 +72,13 @@ package examples {
   case class Baz(xs: List[String]) extends Foo
   case class Bam(w: Wub, d: Double) extends Foo
 
+  sealed trait Mary
+  case object HadA extends Mary
+  case object LittleLamb extends Mary
+  object Mary {
+    implicit val eqMary: Eq[Mary] = Eq.fromUniversalEquals[Mary]
+  }
+
   object Bar {
     implicit val eqBar: Eq[Bar] = Eq.fromUniversalEquals
     implicit val arbitraryBar: Arbitrary[Bar] = Arbitrary(


### PR DESCRIPTION
Currently, `EnumerationEncoder`/`Decoder` will use case object names as-is even when a `Configuration` with snakecase constructor names is in scope.

This PR makes `EnumerationEncoder`/`Decoder` rely on `Configuration.transformConstructorNames` when a configuration is available.

I made the configuration parameter default to `Configuration.defaults`—this isn't consistent with `deriveDecoder` and `deriveEncoder`, but can reduce disruption should this PR be accepted.
