### PR TITLE
Follow-up to #1117

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/Configuration.scala
@@ -14,14 +14,14 @@ import java.util.regex.Pattern
  *                      the contents of the ADT are stored as an object.
  * @param transformConstructorNames Transforms the value of any constructor names in the JSON allowing, for example,
  *                                  formatting or case changes.
- * @param strictDeserialization Whether to fail when superfluous fields are found.
+ * @param strictDecoding Whether to fail when superfluous fields are found.
  */
 final case class Configuration(
   transformMemberNames: String => String,
   transformConstructorNames: String => String,
   useDefaults: Boolean,
   discriminator: Option[String],
-  strictDeserialization: Boolean = false
+  strictDecoding: Boolean = false
 ) {
   def withSnakeCaseMemberNames: Configuration = copy(
     transformMemberNames = Configuration.snakeCaseTransformation
@@ -42,7 +42,7 @@ final case class Configuration(
   def withDefaults: Configuration = copy(useDefaults = true)
   def withDiscriminator(discriminator: String): Configuration = copy(discriminator = Some(discriminator))
 
-  def withStrictDeserialization: Configuration = copy(strictDeserialization = true)
+  def withStrictDecoding: Configuration = copy(strictDecoding = true)
 }
 
 final object Configuration {


### PR DESCRIPTION
This makes the `strictDeserialization`-to-`strictDecoding` name change I mentioned in #1117, and also rearranges the implementation a little. The only substantive change is that if `maybeUnexpectedErrors` ends up being `None`, the new implementation does not fail. It should only ever be `None` in the case where the focus isn't a JSON object, and in that case we wouldn't have gotten even this far.

r? @pfcoperez 