### PR TITLE
Codec

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Codec.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Codec.scala
@@ -1,0 +1,17 @@
+import io.circe._
+
+/**
+ * A type class that provides back and forth conversion between values of type `A`
+ * and the [[Json]] format. Must obey the laws defined in [[io.circe.tests.CodecLaws]].
+ */
+trait Codec[A] extends Encoder[A] with Decoder[A]
+
+object Codec {
+  def apply[A](implicit instance: Codec[A]): Codec[A] = instance
+
+  implicit def fromEncoderDecoder[A](implicit e: Encoder[A], d: Decoder[A]): Codec[A] =
+    new Codec[A] {
+      def apply(c: HCursor): Decoder.Result[A] = d(c)
+      def apply(a: A): Json = e(a)
+    }
+}

--- a/modules/core/shared/src/main/scala/io/circe/Codec.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Codec.scala
@@ -1,17 +1,52 @@
-import io.circe._
+package io.circe
 
 /**
  * A type class that provides back and forth conversion between values of type `A`
- * and the [[Json]] format. Must obey the laws defined in [[io.circe.tests.CodecLaws]].
+ * and the [[Json]] format.
+ *
+ * Note that this type class is only intended to make instance definition more
+ * convenient; it generally should not be used as a constraint.
+ *
+ * Instances should obey the laws defined in [[io.circe.testing.CodecLaws]].
  */
-trait Codec[A] extends Encoder[A] with Decoder[A]
+trait Codec[A] extends Decoder[A] with Encoder[A]
 
-object Codec {
+final object Codec {
   def apply[A](implicit instance: Codec[A]): Codec[A] = instance
 
-  implicit def fromEncoderDecoder[A](implicit e: Encoder[A], d: Decoder[A]): Codec[A] =
+  def from[A](decodeA: Decoder[A], encodeA: Encoder[A]): Codec[A] =
     new Codec[A] {
-      def apply(c: HCursor): Decoder.Result[A] = d(c)
-      def apply(a: A): Json = e(a)
+      def apply(c: HCursor): Decoder.Result[A] = decodeA(c)
+      def apply(a: A): Json = encodeA(a)
     }
+
+  trait AsRoot[A] extends Codec[A] with Encoder.AsRoot[A]
+
+  final object AsRoot {
+    def apply[A](implicit instance: AsRoot[A]): AsRoot[A] = instance
+  }
+
+  trait AsArray[A] extends AsRoot[A] with Encoder.AsArray[A]
+
+  final object AsArray {
+    def apply[A](implicit instance: AsArray[A]): AsArray[A] = instance
+
+    def from[A](decodeA: Decoder[A], encodeA: Encoder.AsArray[A]): AsArray[A] =
+      new AsArray[A] {
+        def apply(c: HCursor): Decoder.Result[A] = decodeA(c)
+        def encodeArray(a: A): Vector[Json] = encodeA.encodeArray(a)
+      }
+  }
+
+  trait AsObject[A] extends AsRoot[A] with Encoder.AsObject[A]
+
+  final object AsObject {
+    def apply[A](implicit instance: AsObject[A]): AsObject[A] = instance
+
+    def from[A](decodeA: Decoder[A], encodeA: Encoder.AsObject[A]): AsObject[A] =
+      new AsObject[A] {
+        def apply(c: HCursor): Decoder.Result[A] = decodeA(c)
+        def encodeObject(a: A): JsonObject = encodeA.encodeObject(a)
+      }
+  }
 }

--- a/modules/core/shared/src/main/scala/io/circe/Codec.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Codec.scala
@@ -11,7 +11,7 @@ package io.circe
  */
 trait Codec[A] extends Decoder[A] with Encoder[A]
 
-final object Codec {
+final object Codec extends ProductCodecs {
   def apply[A](implicit instance: Codec[A]): Codec[A] = instance
 
   def from[A](decodeA: Decoder[A], encodeA: Encoder[A]): Codec[A] =

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -50,6 +50,9 @@ import scala.collection.immutable.{ Map => ImmutableMap, Set, SortedMap, SortedS
 import scala.collection.mutable.Builder
 import scala.util.{ Failure, Success, Try }
 
+/**
+ * A type class that provides a way to produce a value of type `A` from a [[Json]] value.
+ */
 trait Decoder[A] extends Serializable { self =>
 
   /**

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
@@ -1,24 +1,36 @@
 package io.circe.generic.extras
 
+import io.circe.generic.extras.codec.{ ConfiguredAsObjectCodec, ReprAsObjectCodec }
 import io.circe.generic.extras.decoding.{ ConfiguredDecoder, ReprDecoder }
 import io.circe.generic.extras.encoding.{ ConfiguredAsObjectEncoder, ReprAsObjectEncoder }
 import io.circe.generic.util.macros.DerivationMacros
 import scala.reflect.macros.whitebox
 
 class ConfigurableDeriver(val c: whitebox.Context)
-    extends DerivationMacros[ReprDecoder, ReprAsObjectEncoder, ConfiguredDecoder, ConfiguredAsObjectEncoder] {
+    extends DerivationMacros[
+      ReprDecoder,
+      ReprAsObjectEncoder,
+      ReprAsObjectCodec,
+      ConfiguredDecoder,
+      ConfiguredAsObjectEncoder,
+      ConfiguredAsObjectCodec
+    ] {
   import c.universe._
 
   def deriveDecoder[R: c.WeakTypeTag]: c.Expr[ReprDecoder[R]] = c.Expr[ReprDecoder[R]](constructDecoder[R])
   def deriveEncoder[R: c.WeakTypeTag]: c.Expr[ReprAsObjectEncoder[R]] =
     c.Expr[ReprAsObjectEncoder[R]](constructEncoder[R])
+  def deriveCodec[R: c.WeakTypeTag]: c.Expr[ReprAsObjectCodec[R]] = c.Expr[ReprAsObjectCodec[R]](constructCodec[R])
 
   protected[this] val RD: TypeTag[ReprDecoder[_]] = c.typeTag
   protected[this] val RE: TypeTag[ReprAsObjectEncoder[_]] = c.typeTag
+  protected[this] val RC: TypeTag[ReprAsObjectCodec[_]] = c.typeTag
   protected[this] val DD: TypeTag[ConfiguredDecoder[_]] = c.typeTag
   protected[this] val DE: TypeTag[ConfiguredAsObjectEncoder[_]] = c.typeTag
+  protected[this] val DC: TypeTag[ConfiguredAsObjectCodec[_]] = c.typeTag
 
   protected[this] val hnilReprDecoder: Tree = q"_root_.io.circe.generic.extras.decoding.ReprDecoder.hnilReprDecoder"
+  protected[this] val hnilReprCodec: Tree = q"_root_.io.circe.generic.extras.codec.ReprAsObjectCodec.hnilReprCodec"
 
   protected[this] val decodeMethodName: TermName = TermName("configuredDecode")
   protected[this] val decodeAccumulatingMethodName: TermName = TermName("configuredDecodeAccumulating")

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/codec/ConfiguredAsObjectCodec.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/codec/ConfiguredAsObjectCodec.scala
@@ -1,0 +1,67 @@
+package io.circe.generic.extras.codec
+
+import io.circe.{ Decoder, Encoder, HCursor, JsonObject }
+import io.circe.generic.codec.DerivedAsObjectCodec
+import io.circe.generic.extras.{ Configuration, JsonKey }
+import io.circe.generic.extras.decoding.ConfiguredDecoder
+import io.circe.generic.extras.encoding.ConfiguredAsObjectEncoder
+import io.circe.generic.extras.util.RecordToMap
+import shapeless.{ Annotations, Coproduct, Default, HList, LabelledGeneric, Lazy }
+import shapeless.ops.hlist.ToTraversable
+import shapeless.ops.record.Keys
+
+abstract class ConfiguredAsObjectCodec[A] extends DerivedAsObjectCodec[A]
+
+final object ConfiguredAsObjectCodec {
+  implicit def codecForCaseClass[A, R <: HList, D <: HList, F <: HList, K <: HList](
+    implicit
+    gen: LabelledGeneric.Aux[A, R],
+    codec: Lazy[ReprAsObjectCodec[R]],
+    defaults: Default.AsRecord.Aux[A, D],
+    defaultMapper: RecordToMap[D],
+    config: Configuration,
+    fields: Keys.Aux[R, F],
+    fieldsToList: ToTraversable.Aux[F, List, Symbol],
+    keys: Annotations.Aux[JsonKey, A, K],
+    keysToList: ToTraversable.Aux[K, List, Option[JsonKey]]
+  ): ConfiguredAsObjectCodec[A] = new ConfiguredAsObjectCodec[A] {
+    private[this] val decodeA: Decoder[A] =
+      ConfiguredDecoder.decodeCaseClass[A, R, D, F, K](
+        gen,
+        codec,
+        defaults,
+        defaultMapper,
+        config,
+        fields,
+        fieldsToList,
+        keys,
+        keysToList
+      )
+
+    private[this] val encodeA: Encoder.AsObject[A] =
+      ConfiguredAsObjectEncoder.encodeCaseClass[A, R, F, K](gen, codec, config, fields, fieldsToList, keys, keysToList)
+
+    final def apply(c: HCursor): Decoder.Result[A] = decodeA.apply(c)
+    final override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] = decodeA.decodeAccumulating(c)
+
+    final def encodeObject(a: A): JsonObject = encodeA.encodeObject(a)
+  }
+
+  implicit def codecForAdt[A, R <: Coproduct](
+    implicit
+    gen: LabelledGeneric.Aux[A, R],
+    codec: Lazy[ReprAsObjectCodec[R]],
+    config: Configuration
+  ): ConfiguredAsObjectCodec[A] = new ConfiguredAsObjectCodec[A] {
+    private[this] val decodeA: Decoder[A] =
+      ConfiguredDecoder.decodeAdt[A, R](gen, codec, config)
+
+    private[this] val encodeA: Encoder.AsObject[A] =
+      ConfiguredAsObjectEncoder.encodeAdt[A, R](gen, codec, config)
+
+    final def apply(c: HCursor): Decoder.Result[A] = decodeA.apply(c)
+    final override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] = decodeA.decodeAccumulating(c)
+
+    final def encodeObject(a: A): JsonObject = encodeA.encodeObject(a)
+  }
+}

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/codec/ReprAsObjectCodec.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/codec/ReprAsObjectCodec.scala
@@ -1,0 +1,43 @@
+package io.circe.generic.extras.codec
+
+import cats.data.Validated
+import io.circe.{ Decoder, HCursor, JsonObject }
+import io.circe.generic.extras.ConfigurableDeriver
+import io.circe.generic.extras.decoding.ReprDecoder
+import io.circe.generic.extras.encoding.ReprAsObjectEncoder
+import scala.collection.immutable.Map
+import scala.language.experimental.macros
+import shapeless.HNil
+
+/**
+ * A codec for a generic representation of a case class or ADT.
+ *
+ * Note that users typically will not work with instances of this class.
+ */
+abstract class ReprAsObjectCodec[A] extends ReprDecoder[A] with ReprAsObjectEncoder[A]
+
+final object ReprAsObjectCodec {
+  implicit def deriveReprAsObjectCodec[R]: ReprAsObjectCodec[R] = macro ConfigurableDeriver.deriveCodec[R]
+
+  val hnilReprDecoder: ReprAsObjectCodec[HNil] = new ReprAsObjectCodec[HNil] {
+    def configuredDecode(c: HCursor)(
+      transformMemberNames: String => String,
+      transformConstructorNames: String => String,
+      defaults: Map[String, Any],
+      discriminator: Option[String]
+    ): Decoder.Result[HNil] = Right(HNil)
+
+    def configuredDecodeAccumulating(c: HCursor)(
+      transformMemberNames: String => String,
+      transformConstructorNames: String => String,
+      defaults: Map[String, Any],
+      discriminator: Option[String]
+    ): Decoder.AccumulatingResult[HNil] = Validated.valid(HNil)
+
+    def configuredEncodeObject(a: HNil)(
+      transformMemberNames: String => String,
+      transformDiscriminator: String => String,
+      discriminator: Option[String]
+    ): JsonObject = JsonObject.empty
+  }
+}

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprAsObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprAsObjectEncoder.scala
@@ -9,7 +9,7 @@ import scala.language.experimental.macros
  *
  * Note that users typically will not work with instances of this class.
  */
-abstract class ReprAsObjectEncoder[A] extends Encoder.AsObject[A] {
+trait ReprAsObjectEncoder[A] extends Encoder.AsObject[A] {
   def configuredEncodeObject(a: A)(
     transformMemberNames: String => String,
     transformDiscriminator: String => String,

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/package.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/package.scala
@@ -1,0 +1,13 @@
+package io.circe.generic.extras
+
+package object encoding {
+  @deprecated("Use ConfiguredAsObjectEncoder", "0.12.0")
+  type ConfiguredObjectEncoder[A] = ConfiguredAsObjectEncoder[A]
+  @deprecated("Use ConfiguredAsObjectEncoder", "0.12.0")
+  val ConfiguredObjectEncoder = ConfiguredAsObjectEncoder
+
+  @deprecated("Use ReprAsObjectEncoder", "0.12.0")
+  type ReprObjectEncoder[A] = ReprAsObjectEncoder[A]
+  @deprecated("Use ReprAsObjectEncoder", "0.12.0")
+  val ReprObjectEncoder = ReprAsObjectEncoder
+}

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/semiauto.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/semiauto.scala
@@ -1,6 +1,7 @@
 package io.circe.generic.extras
 
-import io.circe.{ Decoder, Encoder }
+import io.circe.{ Codec, Decoder, Encoder }
+import io.circe.generic.extras.codec.ConfiguredAsObjectCodec
 import io.circe.generic.extras.decoding.{ ConfiguredDecoder, EnumerationDecoder, ReprDecoder, UnwrappedDecoder }
 import io.circe.generic.extras.encoding.{ ConfiguredAsObjectEncoder, EnumerationEncoder, UnwrappedEncoder }
 import io.circe.generic.extras.util.RecordToMap
@@ -31,6 +32,7 @@ import shapeless.ops.record.RemoveAll
 final object semiauto {
   final def deriveDecoder[A](implicit decode: Lazy[ConfiguredDecoder[A]]): Decoder[A] = decode.value
   final def deriveEncoder[A](implicit encode: Lazy[ConfiguredAsObjectEncoder[A]]): Encoder.AsObject[A] = encode.value
+  final def deriveCodec[A](implicit codec: Lazy[ConfiguredAsObjectCodec[A]]): Codec.AsObject[A] = codec.value
 
   final def deriveFor[A]: DerivationHelper[A] = new DerivationHelper[A]
 

--- a/modules/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
+++ b/modules/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
@@ -1,7 +1,7 @@
 package io.circe.generic.extras
 
 import cats.kernel.Eq
-import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
+import io.circe.{ Codec, Decoder, DecodingFailure, Encoder, Json }
 import io.circe.generic.extras.semiauto._
 import io.circe.literal._
 import io.circe.testing.CodecTests
@@ -51,12 +51,25 @@ object ConfiguredSemiautoDerivedSuite {
 
   implicit val decodeConfigExampleBase: Decoder[ConfigExampleBase] = deriveDecoder
   implicit val encodeConfigExampleBase: Encoder.AsObject[ConfigExampleBase] = deriveEncoder
+  val codecForConfigExampleBase: Codec.AsObject[ConfigExampleBase] = deriveCodec
 }
 
 class ConfiguredSemiautoDerivedSuite extends CirceSuite {
   import ConfiguredSemiautoDerivedSuite._, localExamples._
 
   checkLaws("Codec[ConfigExampleBase]", CodecTests[ConfigExampleBase].codec)
+  checkLaws(
+    "Codec[ConfigExampleBase] via Codec",
+    CodecTests[ConfigExampleBase](codecForConfigExampleBase, codecForConfigExampleBase).codec
+  )
+  checkLaws(
+    "Codec[ConfigExampleBase] via Decoder and Codec",
+    CodecTests[ConfigExampleBase](implicitly, codecForConfigExampleBase).codec
+  )
+  checkLaws(
+    "Codec[ConfigExampleBase] via Encoder and Codec",
+    CodecTests[ConfigExampleBase](codecForConfigExampleBase, implicitly).codec
+  )
 
   "Semi-automatic derivation" should "support configuration" in forAll { (f: String, b: Double) =>
     val foo: ConfigExampleBase = ConfigExampleFoo(f, 0, b)

--- a/modules/generic/shared/src/main/scala/io/circe/generic/Deriver.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/Deriver.scala
@@ -1,24 +1,36 @@
 package io.circe.generic
 
+import io.circe.generic.codec.{ DerivedAsObjectCodec, ReprAsObjectCodec }
 import io.circe.generic.decoding.{ DerivedDecoder, ReprDecoder }
 import io.circe.generic.encoding.{ DerivedAsObjectEncoder, ReprAsObjectEncoder }
 import io.circe.generic.util.macros.DerivationMacros
 import scala.reflect.macros.whitebox
 
 class Deriver(val c: whitebox.Context)
-    extends DerivationMacros[ReprDecoder, ReprAsObjectEncoder, DerivedDecoder, DerivedAsObjectEncoder] {
+    extends DerivationMacros[
+      ReprDecoder,
+      ReprAsObjectEncoder,
+      ReprAsObjectCodec,
+      DerivedDecoder,
+      DerivedAsObjectEncoder,
+      DerivedAsObjectCodec
+    ] {
   import c.universe._
 
   def deriveDecoder[R: c.WeakTypeTag]: c.Expr[ReprDecoder[R]] = c.Expr[ReprDecoder[R]](constructDecoder[R])
   def deriveEncoder[R: c.WeakTypeTag]: c.Expr[ReprAsObjectEncoder[R]] =
     c.Expr[ReprAsObjectEncoder[R]](constructEncoder[R])
+  def deriveCodec[R: c.WeakTypeTag]: c.Expr[ReprAsObjectCodec[R]] = c.Expr[ReprAsObjectCodec[R]](constructCodec[R])
 
   protected[this] val RD: TypeTag[ReprDecoder[_]] = c.typeTag
   protected[this] val RE: TypeTag[ReprAsObjectEncoder[_]] = c.typeTag
+  protected[this] val RC: TypeTag[ReprAsObjectCodec[_]] = c.typeTag
   protected[this] val DD: TypeTag[DerivedDecoder[_]] = c.typeTag
   protected[this] val DE: TypeTag[DerivedAsObjectEncoder[_]] = c.typeTag
+  protected[this] val DC: TypeTag[DerivedAsObjectCodec[_]] = c.typeTag
 
   protected[this] val hnilReprDecoder: Tree = q"_root_.io.circe.generic.decoding.ReprDecoder.hnilReprDecoder"
+  protected[this] val hnilReprCodec: Tree = q"_root_.io.circe.generic.codec.ReprAsObjectCodec.hnilReprCodec"
 
   protected[this] val decodeMethodName: TermName = TermName("apply")
   protected[this] val decodeAccumulatingMethodName: TermName = TermName("decodeAccumulating")

--- a/modules/generic/shared/src/main/scala/io/circe/generic/codec/DerivedAsObjectCodec.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/codec/DerivedAsObjectCodec.scala
@@ -11,15 +11,13 @@ final object DerivedAsObjectCodec {
     gen: LabelledGeneric.Aux[A, R],
     codec: Lazy[ReprAsObjectCodec[R]]
   ): DerivedAsObjectCodec[A] = new DerivedAsObjectCodec[A] {
-    private[this] val reprCodec: ReprAsObjectCodec[R] = codec.value
-
-    final def apply(c: HCursor): Decoder.Result[A] = reprCodec.apply(c) match {
+    final def apply(c: HCursor): Decoder.Result[A] = codec.value.apply(c) match {
       case Right(r)    => Right(gen.from(r))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
     }
     override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
-      reprCodec.decodeAccumulating(c).map(gen.from)
+      codec.value.decodeAccumulating(c).map(gen.from)
 
-    final def encodeObject(a: A): JsonObject = reprCodec.encodeObject(gen.to(a))
+    final def encodeObject(a: A): JsonObject = codec.value.encodeObject(gen.to(a))
   }
 }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/codec/DerivedAsObjectCodec.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/codec/DerivedAsObjectCodec.scala
@@ -1,0 +1,25 @@
+package io.circe.generic.codec
+
+import io.circe.{ Codec, Decoder, HCursor, JsonObject }
+import shapeless.{ LabelledGeneric, Lazy }
+
+abstract class DerivedAsObjectCodec[A] extends Codec.AsObject[A]
+
+final object DerivedAsObjectCodec {
+  implicit def deriveCodec[A, R](
+    implicit
+    gen: LabelledGeneric.Aux[A, R],
+    codec: Lazy[ReprAsObjectCodec[R]]
+  ): DerivedAsObjectCodec[A] = new DerivedAsObjectCodec[A] {
+    private[this] val reprCodec: ReprAsObjectCodec[R] = codec.value
+
+    final def apply(c: HCursor): Decoder.Result[A] = reprCodec.apply(c) match {
+      case Right(r)    => Right(gen.from(r))
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
+    }
+    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
+      reprCodec.decodeAccumulating(c).map(gen.from)
+
+    final def encodeObject(a: A): JsonObject = reprCodec.encodeObject(gen.to(a))
+  }
+}

--- a/modules/generic/shared/src/main/scala/io/circe/generic/codec/ReprAsObjectCodec.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/codec/ReprAsObjectCodec.scala
@@ -1,0 +1,22 @@
+package io.circe.generic.codec
+
+import io.circe.{ Codec, Decoder, HCursor, JsonObject }
+import io.circe.generic.Deriver
+import scala.language.experimental.macros
+import shapeless.HNil
+
+/**
+ * A codec for a generic representation of a case class or ADT.
+ *
+ * Note that users typically will not work with instances of this class.
+ */
+abstract class ReprAsObjectCodec[A] extends Codec.AsObject[A]
+
+final object ReprAsObjectCodec {
+  implicit def deriveReprAsObjectCodec[R]: ReprAsObjectCodec[R] = macro Deriver.deriveCodec[R]
+
+  val hnilReprCodec: ReprAsObjectCodec[HNil] = new ReprAsObjectCodec[HNil] {
+    def apply(c: HCursor): Decoder.Result[HNil] = Right(HNil)
+    def encodeObject(a: HNil): JsonObject = JsonObject.empty
+  }
+}

--- a/modules/generic/shared/src/main/scala/io/circe/generic/encoding/package.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/encoding/package.scala
@@ -1,0 +1,13 @@
+package io.circe.generic
+
+package object encoding {
+  @deprecated("Use DerivedAsObjectEncoder", "0.12.0")
+  type DerivedObjectEncoder[A] = DerivedAsObjectEncoder[A]
+  @deprecated("Use DerivedAsObjectEncoder", "0.12.0")
+  val DerivedObjectEncoder = DerivedAsObjectEncoder
+
+  @deprecated("Use ReprAsObjectEncoder", "0.12.0")
+  type ReprObjectEncoder[A] = ReprAsObjectEncoder[A]
+  @deprecated("Use ReprAsObjectEncoder", "0.12.0")
+  val ReprObjectEncoder = ReprAsObjectEncoder
+}

--- a/modules/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -1,6 +1,7 @@
 package io.circe.generic
 
-import io.circe.{ Decoder, Encoder }
+import io.circe.{ Codec, Decoder, Encoder }
+import io.circe.generic.codec.DerivedAsObjectCodec
 import io.circe.generic.decoding.{ DerivedDecoder, ReprDecoder }
 import io.circe.generic.encoding.DerivedAsObjectEncoder
 import io.circe.generic.util.PatchWithOptions
@@ -30,6 +31,7 @@ import shapeless.ops.record.RemoveAll
 final object semiauto {
   final def deriveDecoder[A](implicit decode: Lazy[DerivedDecoder[A]]): Decoder[A] = decode.value
   final def deriveEncoder[A](implicit encode: Lazy[DerivedAsObjectEncoder[A]]): Encoder.AsObject[A] = encode.value
+  final def deriveCodec[A](implicit codec: Lazy[DerivedAsObjectCodec[A]]): Codec.AsObject[A] = codec.value
 
   final def deriveFor[A]: DerivationHelper[A] = new DerivationHelper[A]
 

--- a/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/JsonCodecMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/JsonCodecMacros.scala
@@ -73,15 +73,15 @@ abstract class JsonCodecMacros {
       )
     } else {
       val tparamNames = tparams.map(_.name)
-      def mkImplicitParams(typeSymbol: TypeSymbol) =
+      def mkImplicitParams(prefix: String, typeSymbol: TypeSymbol) =
         tparamNames.zipWithIndex.map {
           case (tparamName, i) =>
-            val paramName = TermName(s"instance$i")
+            val paramName = TermName(s"$prefix$i")
             val paramType = tq"$typeSymbol[$tparamName]"
             q"$paramName: $paramType"
         }
-      val decodeParams = mkImplicitParams(DecoderClass)
-      val encodeParams = mkImplicitParams(EncoderClass)
+      val decodeParams = mkImplicitParams("decode", DecoderClass)
+      val encodeParams = mkImplicitParams("encode", EncoderClass)
       val Type = tq"$tpname[..$tparamNames]"
       (
         q"""implicit def $decodeName[..$tparams](implicit ..$decodeParams): $DecoderClass[$Type] =

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -380,8 +380,22 @@ object Boilerplate {
         -      Encoder.forProduct$arity($memberNames)((Cc$arity.unapply _).andThen(_.get))
         -    implicit val decodeCc$arity: Decoder[Cc$arity] =
         -      Decoder.forProduct$arity($memberNames)(Cc$arity.apply)
+        -    val codecForCc$arity: Codec[Cc$arity] =
+        -      Codec.forProduct$arity($memberNames)(Cc$arity.apply)((Cc$arity.unapply _).andThen(_.get))
         -  }
         -  checkLaws("Codec[Cc$arity]", CodecTests[Cc$arity].unserializableCodec)
+        -  checkLaws(
+        -    "Codec[Cc$arity] via Codec",
+        -    CodecTests[Cc$arity](Cc$arity.codecForCc$arity, Cc$arity.codecForCc$arity).unserializableCodec
+        -  )
+        -  checkLaws(
+        -    "Codec[Cc$arity] via Decoder and Codec",
+        -    CodecTests[Cc$arity](Cc$arity.decodeCc$arity, Cc$arity.codecForCc$arity).unserializableCodec
+        -  )
+        -  checkLaws(
+        -    "Codec[Cc$arity] via Encoder and Codec",
+        -    CodecTests[Cc$arity](Cc$arity.codecForCc$arity, Cc$arity.encodeCc$arity).unserializableCodec
+        -  )
         |}
       """
     }


### PR DESCRIPTION
I've resisted adding this thing for years, but I've finally been convinced that having `Codec` around for more convenient definitions (and faster semi-automatic derivation) is a good idea. This PR builds on #1150 (which is motivated by this change but should stand on its own) and includes @OlivierBlanvillain's change from #301. It doesn't build on @lorandszakacs's #811 at the moment, but I'll probably pull some tests from there.

Note that the intention is that `Codec` should only be used to make defining instances more convenient, and not as a constraint. The core module provides no `Codec` instances for any standard library types, and there is no machinery for summoning `Codec` instances given an encoder-decoder pair. Fully-automatic generic derivation does not (and probably will not) provide `Codec` instances, although semi-automatic derivation is supported in both the vanilla circe-generic form and with configuration in circe-generic-extras.

The motivation is to speed up semi-automatic generic derivation (it should be not too far off twice as fast as deriving separate encoders and decoders, ~~but I've not actually done any benchmarking yet~~) and to avoid forcing users to write out member names twice when using `forProductN`.

Update: I put together a file with 200 case classes and either `deriveCodec` or a `deriveDecoder` / `deriveEncoder` pair in the companion class, and after half a dozen runs of each on Scala 2.12.8, the new `deriveCodec` approach consistently compiles in 20-21 seconds, while the old approach takes 35-36 seconds. So about 42% faster for that example case, which is actually a little better than I expected.

The implementation currently supports writing this:

```scala
import io.circe.Codec
import io.circe.generic.semiauto.deriveCodec

case class Foo(a: String, b: List[Boolean], c: Double)

object Foo {
  implicit val fooCodec: Codec[Foo] = deriveCodec
}
```
…or this:

```scala
import io.circe.Codec

case class Foo(a: String, b: List[Boolean], c: Double)

object Foo {
  implicit val fooCodec: Codec[Foo] =
    Codec.forProduct3("a", "b", "c")(Foo(_, _, _))(foo => (foo.a, foo.b, foo.c))
}
```
…instead of this:
```scala
import io.circe.{ Decoder, ObjectEncoder }
import io.circe.generic.semiauto._

case class Foo(a: String, b: List[Boolean], c: Double)

object Foo {
  implicit val decodeFoo: Decoder[Foo] = deriveDecoder
  implicit val encodeFoo: ObjectEncoder[Foo] = deriveEncoder
}
```
…or this:
```scala
import io.circe.{ Decoder, Encoder, ObjectEncoder }

case class Foo(a: String, b: List[Boolean], c: Double)

object Foo {
  implicit val decodeFoo: Decoder[Foo] =
    Decoder.forProduct3("a", "b", "c")(Foo(_, _, _))

  implicit val encodeFoo: ObjectEncoder[Foo] =
    Encoder.forProduct3("a", "b", "c")(foo => (foo.a, foo.b, foo.c))
}
```

It still needs tests and better docs and probably some clean-up.