### PR TITLE
Deprecate / remove AccumulatingDecoder

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
@@ -1,107 +1,18 @@
 package io.circe
 
-import cats.{ ApplicativeError, Semigroup, SemigroupK }
-import cats.data.{ NonEmptyList, Validated, ValidatedNel }
-import java.io.Serializable
+import cats.{ ApplicativeError, Semigroup }
+import cats.data.NonEmptyList
 
-sealed trait AccumulatingDecoder[A] extends Serializable { self =>
-
-  /**
-   * Decode the given [[HCursor]].
-   */
-  def apply(c: HCursor): AccumulatingDecoder.Result[A]
-
-  /**
-   * Map a function over this [[AccumulatingDecoder]].
-   */
-  final def map[B](f: A => B): AccumulatingDecoder[B] = new AccumulatingDecoder[B] {
-    final def apply(c: HCursor): AccumulatingDecoder.Result[B] = self(c).map(f)
-  }
-
-  /**
-   * Run two decoders and return their results as a pair.
-   */
-  final def and[B](other: AccumulatingDecoder[B]): AccumulatingDecoder[(A, B)] = new AccumulatingDecoder[(A, B)] {
-    final def apply(c: HCursor): AccumulatingDecoder.Result[(A, B)] = self(c).product(other(c))(
-      AccumulatingDecoder.failureNelInstance
-    )
-  }
-
-  /**
-   * Choose the first succeeding decoder.
-   */
-  final def or[AA >: A](d: => AccumulatingDecoder[AA]): AccumulatingDecoder[AA] = new AccumulatingDecoder[AA] {
-    final def apply(c: HCursor): AccumulatingDecoder.Result[AA] = self(c) match {
-      case v @ Validated.Valid(_) => v
-      case Validated.Invalid(_)   => d(c)
-    }
-  }
-
-  /**
-   * Create a new instance that handles any of this instance's errors with the
-   * given function.
-   */
-  final def handleErrorWith(f: NonEmptyList[DecodingFailure] => AccumulatingDecoder[A]): AccumulatingDecoder[A] =
-    new AccumulatingDecoder[A] {
-      final def apply(c: HCursor): AccumulatingDecoder.Result[A] =
-        AccumulatingDecoder.resultInstance.handleErrorWith(self(c))(failure => f(failure)(c))
-    }
-}
-
+@deprecated("Use Decoder", "0.12.0")
 final object AccumulatingDecoder {
-  final type Result[A] = ValidatedNel[DecodingFailure, A]
+  @deprecated("Use Decoder.AccumulatingResult", "0.12.0")
+  final type Result[A] = Decoder.AccumulatingResult[A]
 
+  @deprecated("Use NonEmptyList.catsDataSemigroupForNonEmptyList[DecodingFailure]", "0.12.0")
   final val failureNelInstance: Semigroup[NonEmptyList[DecodingFailure]] =
     NonEmptyList.catsDataSemigroupForNonEmptyList[DecodingFailure]
 
+  @deprecated("Use Decoder.accumulatingResultInstance", "0.12.0")
   final val resultInstance: ApplicativeError[Result, NonEmptyList[DecodingFailure]] =
-    Validated.catsDataApplicativeErrorForValidated[NonEmptyList[DecodingFailure]](failureNelInstance)
-
-  /**
-   * Return an instance for a given type.
-   */
-  final def apply[A](implicit d: AccumulatingDecoder[A]): AccumulatingDecoder[A] = d
-
-  /**
-   * Construct an instance from a function.
-   */
-  final def instance[A](f: HCursor => Result[A]): AccumulatingDecoder[A] = new AccumulatingDecoder[A] {
-    final def apply(c: HCursor): Result[A] = f(c)
-  }
-
-  implicit final def fromDecoder[A](implicit decode: Decoder[A]): AccumulatingDecoder[A] = new AccumulatingDecoder[A] {
-    final def apply(c: HCursor): Result[A] = decode.decodeAccumulating(c)
-  }
-
-  final def failed[A](e: NonEmptyList[DecodingFailure]): AccumulatingDecoder[A] = new AccumulatingDecoder[A] {
-    final def apply(c: HCursor): Result[A] = Validated.invalid(e)
-  }
-
-  implicit final val accumulatingDecoderInstances
-    : SemigroupK[AccumulatingDecoder] with ApplicativeError[AccumulatingDecoder, NonEmptyList[DecodingFailure]] =
-    new SemigroupK[AccumulatingDecoder] with ApplicativeError[AccumulatingDecoder, NonEmptyList[DecodingFailure]] {
-      final def combineK[A](x: AccumulatingDecoder[A], y: AccumulatingDecoder[A]): AccumulatingDecoder[A] = x.or(y)
-
-      final def pure[A](a: A): AccumulatingDecoder[A] = new AccumulatingDecoder[A] {
-        final def apply(c: HCursor): Result[A] = Validated.valid(a)
-      }
-
-      override final def map[A, B](fa: AccumulatingDecoder[A])(f: A => B): AccumulatingDecoder[B] = fa.map(f)
-
-      final def ap[A, B](f: AccumulatingDecoder[A => B])(fa: AccumulatingDecoder[A]): AccumulatingDecoder[B] =
-        new AccumulatingDecoder[B] {
-          final def apply(c: HCursor): Result[B] = resultInstance.ap(f(c))(fa(c))
-        }
-
-      override final def product[A, B](
-        fa: AccumulatingDecoder[A],
-        fb: AccumulatingDecoder[B]
-      ): AccumulatingDecoder[(A, B)] = fa.and(fb)
-
-      final def raiseError[A](e: NonEmptyList[DecodingFailure]): AccumulatingDecoder[A] = AccumulatingDecoder.failed(e)
-
-      final def handleErrorWith[A](fa: AccumulatingDecoder[A])(
-        f: NonEmptyList[DecodingFailure] => AccumulatingDecoder[A]
-      ): AccumulatingDecoder[A] = fa.handleErrorWith(f)
-    }
+    Decoder.accumulatingResultInstance
 }

--- a/modules/core/shared/src/main/scala/io/circe/MapDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/MapDecoder.scala
@@ -47,7 +47,7 @@ private[circe] abstract class MapDecoder[K, V, M[K, V] <: Map[K, V]](
       if (failed.eq(null)) Right(builder.result) else Left(failed)
   }
 
-  final override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[M[K, V]] = c.keys match {
+  final override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[M[K, V]] = c.keys match {
     case None => Validated.invalidNel[DecodingFailure, M[K, V]](MapDecoder.failure(c))
     case Some(keys) =>
       val it = keys.iterator

--- a/modules/core/shared/src/main/scala/io/circe/NonEmptySeqDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/NonEmptySeqDecoder.scala
@@ -22,10 +22,10 @@ private[circe] abstract class NonEmptySeqDecoder[A, C[_], S](decodeA: Decoder[A]
     }
   }
 
-  private[circe] final override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[S] = {
+  final override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[S] = {
     val arr = c.downArray
 
-    AccumulatingDecoder.resultInstance.map2(
+    Decoder.accumulatingResultInstance.map2(
       decodeA.tryDecodeAccumulating(arr),
       decodeCA.tryDecodeAccumulating(arr.delete)
     )(create)

--- a/modules/core/shared/src/main/scala/io/circe/Parser.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Parser.scala
@@ -19,7 +19,7 @@ trait Parser extends Serializable {
     decoder: Decoder[A]
   ): ValidatedNel[Error, A] = input match {
     case Right(json) =>
-      decoder.accumulating(json.hcursor).leftMap {
+      decoder.decodeAccumulating(json.hcursor).leftMap {
         case NonEmptyList(h, t) => NonEmptyList(h, t)
       }
     case Left(error) => Validated.invalidNel(error)

--- a/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
@@ -31,7 +31,7 @@ private[circe] abstract class SeqDecoder[A, C[_]](decodeA: Decoder[A]) extends D
     }
   }
 
-  override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[C[A]] = {
+  override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[C[A]] = {
     var current = c.downArray
 
     if (current.succeeded) {

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ConfiguredDecoder.scala
@@ -1,6 +1,6 @@
 package io.circe.generic.extras.decoding
 
-import io.circe.{ AccumulatingDecoder, Decoder, HCursor }
+import io.circe.{ Decoder, HCursor }
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.extras.{ Configuration, JsonKey }
 import io.circe.generic.extras.util.RecordToMap
@@ -70,7 +70,7 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
     }
 
-    override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
+    override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
       decodeR.value
         .configuredDecodeAccumulating(c)(
           memberNameTransformer,
@@ -112,7 +112,7 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
 
     final def apply(c: HCursor): Decoder.Result[A] = wrapped.apply(c)
 
-    override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] = wrapped.decodeAccumulating(c)
+    override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] = wrapped.decodeAccumulating(c)
   }
 
   private[this] class AdtConfiguredDecoder[A, R <: Coproduct](
@@ -130,7 +130,7 @@ final object ConfiguredDecoder extends IncompleteConfiguredDecoders {
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
     }
 
-    override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
+    override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
       decodeR.value
         .configuredDecodeAccumulating(c)(
           Predef.identity,

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/IncompleteConfiguredDecoders.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/IncompleteConfiguredDecoders.scala
@@ -1,6 +1,6 @@
 package io.circe.generic.extras.decoding
 
-import io.circe.{ AccumulatingDecoder, Decoder, HCursor }
+import io.circe.{ Decoder, HCursor }
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.util.RecordToMap
 import io.circe.generic.util.PatchWithOptions
@@ -32,7 +32,7 @@ private[circe] trait IncompleteConfiguredDecoders {
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[F]]
     }
 
-    override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[F] =
+    override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[F] =
       decode
         .configuredDecodeAccumulating(c)(
           config.transformMemberNames,
@@ -64,7 +64,7 @@ private[circe] trait IncompleteConfiguredDecoders {
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A => A]]
     }
 
-    override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A => A] =
+    override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A => A] =
       decode
         .configuredDecodeAccumulating(c)(
           config.transformMemberNames,

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
@@ -1,7 +1,7 @@
 package io.circe.generic.extras.decoding
 
 import cats.data.Validated
-import io.circe.{ AccumulatingDecoder, ACursor, Decoder, HCursor }
+import io.circe.{ ACursor, Decoder, HCursor }
 import io.circe.Json.JNull
 import io.circe.generic.extras.ConfigurableDeriver
 import scala.collection.immutable.Map
@@ -28,7 +28,7 @@ abstract class ReprDecoder[A] extends Decoder[A] {
     transformConstructorNames: String => String,
     defaults: Map[String, Any],
     discriminator: Option[String]
-  ): AccumulatingDecoder.Result[A]
+  ): Decoder.AccumulatingResult[A]
 
   final protected[this] def orDefault[B](
     c: ACursor,
@@ -52,7 +52,7 @@ abstract class ReprDecoder[A] extends Decoder[A] {
     decoder: Decoder[B],
     name: String,
     defaults: Map[String, Any]
-  ): AccumulatingDecoder.Result[B] = {
+  ): Decoder.AccumulatingResult[B] = {
     decoder.tryDecodeAccumulating(c) match {
       case r @ Validated.Valid(_) if r ne Decoder.keyMissingNoneAccumulating   => r
       case l @ Validated.Invalid(_) if c.succeeded && !c.focus.contains(JNull) => l
@@ -87,7 +87,7 @@ abstract class ReprDecoder[A] extends Decoder[A] {
     c: HCursor,
     name: String,
     discriminator: Option[String]
-  ): Option[AccumulatingDecoder.Result[V]] = discriminator match {
+  ): Option[Decoder.AccumulatingResult[V]] = discriminator match {
     case None =>
       val result = c.downField(name)
 
@@ -104,7 +104,7 @@ abstract class ReprDecoder[A] extends Decoder[A] {
   final def apply(c: HCursor): Decoder.Result[A] =
     configuredDecode(c)(Predef.identity, Predef.identity, Map.empty, None)
 
-  final override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
+  final override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
     configuredDecodeAccumulating(c)(Predef.identity, Predef.identity, Map.empty, None)
 }
 
@@ -124,6 +124,6 @@ final object ReprDecoder {
       transformConstructorNames: String => String,
       defaults: Map[String, Any],
       discriminator: Option[String]
-    ): AccumulatingDecoder.Result[HNil] = Validated.valid(HNil)
+    ): Decoder.AccumulatingResult[HNil] = Validated.valid(HNil)
   }
 }

--- a/modules/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
+++ b/modules/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredAutoDerivedSuite.scala
@@ -123,20 +123,20 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
     "Option[T] with default" should "be default value if missing key decoded" in {
       val json = json"""{}"""
       assert(Decoder[FooWithDefault].decodeJson(json) === Right(FooWithDefault(Some(0), "b")))
-      assert(Decoder[FooWithDefault].accumulating(json.hcursor) === Validated.valid(FooWithDefault(Some(0), "b")))
+      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor) === Validated.valid(FooWithDefault(Some(0), "b")))
     }
 
     "Value with default" should "be default value if value is null" in {
       val json = json"""{"b": null}"""
       assert(Decoder[FooWithDefault].decodeJson(json) === Right(FooWithDefault(Some(0), "b")))
-      assert(Decoder[FooWithDefault].accumulating(json.hcursor) === Validated.valid(FooWithDefault(Some(0), "b")))
+      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor) === Validated.valid(FooWithDefault(Some(0), "b")))
     }
 
     "Option[T] with default" should "fail to decode if type in json is not correct" in {
       val json = json"""{"a": "NotAnInt"}"""
       assert(Decoder[FooWithDefault].decodeJson(json) === Left(DecodingFailure("Int", List(DownField("a")))))
       assert(
-        Decoder[FooWithDefault].accumulating(json.hcursor)
+        Decoder[FooWithDefault].decodeAccumulating(json.hcursor)
           === Validated.invalidNel(DecodingFailure("Int", List(DownField("a"))))
       )
     }
@@ -145,7 +145,7 @@ class ConfiguredAutoDerivedSuite extends CirceSuite {
       val json = json"""{"b": 1}"""
       assert(Decoder[FooWithDefault].decodeJson(json) === Left(DecodingFailure("String", List(DownField("b")))))
       assert(
-        Decoder[FooWithDefault].accumulating(json.hcursor) === Validated.invalidNel(
+        Decoder[FooWithDefault].decodeAccumulating(json.hcursor) === Validated.invalidNel(
           DecodingFailure("String", List(DownField("b")))
         )
       )

--- a/modules/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -1,6 +1,6 @@
 package io.circe.generic.decoding
 
-import io.circe.{ AccumulatingDecoder, Decoder, HCursor }
+import io.circe.{ Decoder, HCursor }
 import shapeless.{ LabelledGeneric, Lazy }
 
 abstract class DerivedDecoder[A] extends Decoder[A]
@@ -15,7 +15,7 @@ final object DerivedDecoder extends IncompleteDerivedDecoders {
       case Right(r)    => Right(gen.from(r))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
     }
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
+    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
       decode.value.decodeAccumulating(c).map(gen.from)
   }
 }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
@@ -1,6 +1,6 @@
 package io.circe.generic.decoding
 
-import io.circe.{ AccumulatingDecoder, Decoder, HCursor }
+import io.circe.{ Decoder, HCursor }
 import io.circe.generic.util.PatchWithOptions
 import shapeless.{ HList, LabelledGeneric }
 import shapeless.ops.function.FnFromProduct
@@ -19,7 +19,7 @@ private[circe] trait IncompleteDerivedDecoders {
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[F]]
     }
 
-    override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[F] =
+    override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[F] =
       decode.decodeAccumulating(c).map(r => ffp(p => gen.from(removeAll.reinsert((p, r)))))
   }
 
@@ -34,7 +34,7 @@ private[circe] trait IncompleteDerivedDecoders {
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A => A]]
     }
 
-    override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A => A] =
+    override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A => A] =
       decode.decodeAccumulating(c).map(o => a => gen.from(patch(gen.to(a), o)))
   }
 }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/decoding/ReprDecoder.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/decoding/ReprDecoder.scala
@@ -2,7 +2,7 @@ package io.circe.generic.decoding
 
 import cats.Apply
 import cats.data.Validated
-import io.circe.{ AccumulatingDecoder, Decoder, HCursor }
+import io.circe.{ Decoder, HCursor }
 import io.circe.generic.Deriver
 import scala.language.experimental.macros
 import shapeless.{ :+:, ::, Coproduct, HList, HNil, Inl }
@@ -28,5 +28,5 @@ final object ReprDecoder {
   def injectLeftValue[K, V, R <: Coproduct](v: V): FieldType[K, V] :+: R = Inl(field[K].apply[V](v))
 
   val hnilResult: Decoder.Result[HNil] = Right(HNil)
-  val hnilResultAccumulating: AccumulatingDecoder.Result[HNil] = Validated.valid(HNil)
+  val hnilResultAccumulating: Decoder.AccumulatingResult[HNil] = Validated.valid(HNil)
 }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/DerivationMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/DerivationMacros.scala
@@ -196,14 +196,14 @@ abstract class DerivationMacros[RD[_], RE[_], DD[_], DE[_]] {
       """,
         q"""
         $ReprDecoderUtils.consResults[
-          _root_.io.circe.AccumulatingDecoder.Result,
+          _root_.io.circe.Decoder.AccumulatingResult,
           $nameTpe,
           $tpe,
           $accTail
         ](
           ${decodeFieldAccumulating(label, instanceName)},
           $accAccumulating
-        )(_root_.io.circe.AccumulatingDecoder.resultInstance)
+        )(_root_.io.circe.Decoder.accumulatingResultInstance)
       """
       )
   }
@@ -273,7 +273,7 @@ abstract class DerivationMacros[RD[_], RE[_], DD[_], DE[_]] {
 
             final override def $decodeAccumulatingMethodName(
               ...${fullDecodeAccumulatingMethodArgs(R.tpe)}
-            ): _root_.io.circe.AccumulatingDecoder.Result[$R] = $resultAccumulating
+            ): _root_.io.circe.Decoder.AccumulatingResult[$R] = $resultAccumulating
           }: $instanceType
         """
       }

--- a/modules/generic/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/modules/generic/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -108,7 +108,7 @@ class SemiautoDerivedSuite extends CirceSuite {
   }
 
   it should "return as many errors as invalid elements in a partial case class" in {
-    val decoded = deriveFor[Int => Qux[String]].incomplete.accumulating(Json.obj().hcursor)
+    val decoded = deriveFor[Int => Qux[String]].incomplete.decodeAccumulating(Json.obj().hcursor)
 
     assert(decoded.fold(_.tail.size + 1, _ => 0) === 2)
   }

--- a/modules/shapes/src/main/scala/io/circe/shapes/HListInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/HListInstances.scala
@@ -1,6 +1,6 @@
 package io.circe.shapes
 
-import io.circe.{ AccumulatingDecoder, ArrayEncoder, Decoder, Encoder, HCursor, Json, JsonObject, ObjectEncoder }
+import io.circe.{ ArrayEncoder, Decoder, Encoder, HCursor, Json, JsonObject, ObjectEncoder }
 import shapeless.{ ::, HList, HNil }
 
 trait HListInstances extends LowPriorityHListInstances {
@@ -30,10 +30,10 @@ private[shapes] trait LowPriorityHListInstances {
       Decoder.resultInstance.map2(first.as(decodeH), decodeT.tryDecode(first.delete))(_ :: _)
     }
 
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[H :: T] = {
+    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[H :: T] = {
       val first = c.downArray
 
-      AccumulatingDecoder.resultInstance.map2(
+      Decoder.accumulatingResultInstance.map2(
         decodeH.tryDecodeAccumulating(first),
         decodeT.tryDecodeAccumulating(first.delete)
       )(_ :: _)

--- a/modules/shapes/src/main/scala/io/circe/shapes/LabelledHListInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/LabelledHListInstances.scala
@@ -2,17 +2,7 @@ package io.circe.shapes
 
 import cats.data.Validated
 import cats.kernel.Eq
-import io.circe.{
-  AccumulatingDecoder,
-  Decoder,
-  DecodingFailure,
-  Encoder,
-  HCursor,
-  JsonObject,
-  KeyDecoder,
-  KeyEncoder,
-  ObjectEncoder
-}
+import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, JsonObject, KeyDecoder, KeyEncoder, ObjectEncoder }
 import shapeless.{ ::, HList, Widen, Witness }
 import shapeless.labelled.{ field, FieldType }
 
@@ -35,8 +25,8 @@ trait LabelledHListInstances extends LowPriorityLabelledHListInstances {
       decodeT(c)
     )((h, t) => field[K](h) :: t)
 
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[FieldType[K, V] :: T] =
-      AccumulatingDecoder.resultInstance.map2(
+    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[FieldType[K, V] :: T] =
+      Decoder.accumulatingResultInstance.map2(
         decodeV.tryDecodeAccumulating(c.downField(witK.value.name)),
         decodeT.decodeAccumulating(c)
       )((h, t) => field[K](h) :: t)
@@ -83,11 +73,11 @@ private[shapes] trait LowPriorityLabelledHListInstances extends HListInstances {
       decodeT(c)
     )((h, t) => field[K](h) :: t)
 
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[FieldType[K, V] :: T] =
-      AccumulatingDecoder.resultInstance.map2(
+    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[FieldType[K, V] :: T] =
+      Decoder.accumulatingResultInstance.map2(
         c.keys
           .flatMap(_.find(isK))
-          .fold[AccumulatingDecoder.Result[String]](
+          .fold[Decoder.AccumulatingResult[String]](
             Validated.invalidNel(DecodingFailure("Record", c.history))
           )(Validated.valid)
           .andThen(k => decodeV.tryDecodeAccumulating(c.downField(k))),

--- a/modules/shapes/src/main/scala/io/circe/shapes/SizedInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/SizedInstances.scala
@@ -1,7 +1,7 @@
 package io.circe.shapes
 
 import cats.data.Validated
-import io.circe.{ AccumulatingDecoder, Decoder, DecodingFailure, Encoder, HCursor }
+import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor }
 import scala.collection.GenTraversable
 import shapeless.{ AdditiveCollection, Nat, Sized }
 import shapeless.ops.nat.ToInt
@@ -28,14 +28,14 @@ trait SizedInstances {
         case l @ Left(_) => l.asInstanceOf[Decoder.Result[Sized[C[A], L]]]
       }
 
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[Sized[C[A], L]] =
+    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[Sized[C[A], L]] =
       decodeCA.decodeAccumulating(c) match {
         case Validated.Valid(as) =>
           checkSize(as) match {
             case Some(s) => Validated.valid(s)
             case None    => Validated.invalidNel(failure(c))
           }
-        case l @ Validated.Invalid(_) => l.asInstanceOf[AccumulatingDecoder.Result[Sized[C[A], L]]]
+        case l @ Validated.Invalid(_) => l.asInstanceOf[Decoder.AccumulatingResult[Sized[C[A], L]]]
       }
   }
 

--- a/modules/shapes/src/test/scala/io/circe/shapes/ShapelessSuite.scala
+++ b/modules/shapes/src/test/scala/io/circe/shapes/ShapelessSuite.scala
@@ -40,7 +40,7 @@ class ShapelessSuite extends CirceSuite {
   }
 
   it should "accumulate errors" in forAll { (foo: String, bar: Int, baz: List[Char]) =>
-    val result = hlistDecoder.accumulating(json"""[ $foo, $baz, $bar ]""".hcursor)
+    val result = hlistDecoder.decodeAccumulating(json"""[ $foo, $baz, $bar ]""".hcursor)
 
     assert(result.swap.exists(_.size == 2))
   }
@@ -55,7 +55,7 @@ class ShapelessSuite extends CirceSuite {
   }
 
   it should "accumulate errors" in forAll { (foo: String, bar: Int) =>
-    val result = recordDecoder.accumulating(json"""{ "foo": $bar, "bar": $foo }""".hcursor)
+    val result = recordDecoder.decodeAccumulating(json"""{ "foo": $bar, "bar": $foo }""".hcursor)
 
     assert(result.swap.exists(_.size == 2))
   }
@@ -72,7 +72,7 @@ class ShapelessSuite extends CirceSuite {
   it should "accumulate errors" in forAll { (a: Int, b: String, c: Int, d: String) =>
     val notIntB = b + "z"
     val notIntD = "a" + d
-    val result = sizedDecoder.accumulating(json"""[ $a, $notIntB, $c, $notIntD ]""".hcursor)
+    val result = sizedDecoder.decodeAccumulating(json"""[ $a, $notIntB, $c, $notIntD ]""".hcursor)
 
     assert(result.swap.exists(_.size == 2))
   }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -1,10 +1,7 @@
 package io.circe.testing
 
-import cats.data.ValidatedNel
 import cats.instances.list._
-import cats.laws.discipline.arbitrary._
 import io.circe.{
-  AccumulatingDecoder,
   ArrayEncoder,
   Decoder,
   DecodingFailure,
@@ -129,11 +126,6 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
     Arbitrary.arbitrary[A => Vector[Json]].map(ArrayEncoder.instance)
   )
 
-  implicit def arbitraryAccumulatingDecoder[A: Arbitrary]: Arbitrary[AccumulatingDecoder[A]] = Arbitrary(
-    Arbitrary
-      .arbitrary[Json => ValidatedNel[DecodingFailure, A]]
-      .map(f => AccumulatingDecoder.instance(c => f(c.value)))
-  )
   implicit def arbitraryJsonF[A: Arbitrary]: Arbitrary[JsonF[A]] = {
     Arbitrary(
       Gen.oneOf[JsonF[A]](

--- a/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
@@ -17,7 +17,7 @@ trait CodecLaws[A] {
     encode(a).as(decode) <-> Right(a)
 
   def codecAccumulatingConsistency(json: Json): IsEq[Decoder.Result[A]] =
-    decode(json.hcursor) <-> decode.accumulating(json.hcursor).leftMap(_.head).toEither
+    decode(json.hcursor) <-> decode.decodeAccumulating(json.hcursor).leftMap(_.head).toEither
 }
 
 object CodecLaws {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/EqInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/EqInstances.scala
@@ -4,7 +4,7 @@ import cats.instances.either._
 import cats.instances.option._
 import cats.instances.string._
 import cats.kernel.Eq
-import io.circe.{ AccumulatingDecoder, ArrayEncoder, Decoder, Encoder, Json, KeyDecoder, KeyEncoder, ObjectEncoder }
+import io.circe.{ ArrayEncoder, Decoder, Encoder, Json, KeyDecoder, KeyEncoder, ObjectEncoder }
 import org.scalacheck.Arbitrary
 
 trait EqInstances { this: ArbitraryInstances =>
@@ -45,11 +45,5 @@ trait EqInstances { this: ArbitraryInstances =>
 
   implicit def eqArrayEncoder[A: Arbitrary]: Eq[ArrayEncoder[A]] = Eq.instance { (e1, e2) =>
     arbitraryValues[A].take(codecEqualityCheckCount).forall(a => Eq[Json].eqv(e1(a), e2(a)))
-  }
-
-  implicit def eqAccumulatingDecoder[A: Eq]: Eq[AccumulatingDecoder[A]] = Eq.instance { (d1, d2) =>
-    arbitraryValues[Json]
-      .take(codecEqualityCheckCount)
-      .forall(json => Eq[AccumulatingDecoder.Result[A]].eqv(d1(json.hcursor), d2(json.hcursor)))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -38,7 +38,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     val decoder = transformation(Decoder[Int])
     forAll { (i: Int) =>
       assert(decoder.decodeJson(i.asJson) === Right(i))
-      assert(decoder.accumulating(i.asJson.hcursor) === Validated.valid(i))
+      assert(decoder.decodeAccumulating(i.asJson.hcursor) === Validated.valid(i))
     }
   }
 
@@ -47,7 +47,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     val failure = DecodingFailure("Some message", Nil)
     forAll { (i: Int) =>
       assert(decoder.decodeJson(i.asJson) === Left(failure))
-      assert(decoder.accumulating(i.asJson.hcursor) === Validated.invalidNel(failure))
+      assert(decoder.decodeAccumulating(i.asJson.hcursor) === Validated.invalidNel(failure))
     }
   }
 
@@ -63,7 +63,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
 
       case class Test(a: Option[String])
       assert(Decoder[Test].decodeJson(Json.obj()) === Right(Test(None)))
-      assert(Decoder[Test].accumulating(Json.obj().hcursor) === Validated.valid(Test(None)))
+      assert(Decoder[Test].decodeAccumulating(Json.obj().hcursor) === Validated.valid(Test(None)))
     }
 
   "prepare" should "move appropriately with downField" in forAll { (i: Int, k: String, m: Map[String, Int]) =>
@@ -199,7 +199,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
   "A nested optional decoder" should "accumulate failures" in {
     val pair = Json.arr(Json.fromInt(1), Json.fromInt(2))
 
-    val result = Decoder[Option[(String, String)]].accumulating(pair.hcursor)
+    val result = Decoder[Option[(String, String)]].decodeAccumulating(pair.hcursor)
     val expected = Validated.invalid(
       NonEmptyList.of(DecodingFailure("String", List(DownN(0))), DecodingFailure("String", List(DownN(1))))
     )
@@ -436,7 +436,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     val decoder: Decoder[Foo] = new Decoder[Foo] {
       override def apply(c: HCursor): Decoder.Result[Foo] = Right(new Foo {})
 
-      override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[Foo] = Invalid(
+      override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[Foo] = Invalid(
         NonEmptyList.one(DecodingFailure(message, c.history))
       )
     }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -119,7 +119,7 @@ object Boilerplate {
 
       val accumulatingResult =
         if (arity == 1) s"$accumulatingApplied.map(Tuple1(_))"
-        else s"AccumulatingDecoder.resultInstance.tuple$arity($accumulatingApplied)"
+        else s"Decoder.accumulatingResultInstance.tuple$arity($accumulatingApplied)"
 
       block"""
         |package io.circe
@@ -137,7 +137,7 @@ object Boilerplate {
         -        case _ => Left(DecodingFailure("${`(A..N)`}", c.history))
         -      }
         -
-        -      override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[${`(A..N)`}] = c.value match {
+        -      override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[${`(A..N)`}] = c.value match {
         -        case Json.JArray(values) if values.size == $arity => $accumulatingResult
         -        case _ => Validated.invalidNel(DecodingFailure("${`(A..N)`}", c.history))
         -      }
@@ -222,7 +222,7 @@ object Boilerplate {
 
       val accumulatingResult =
         if (arity == 1) s"$accumulatingResults.map(f)"
-        else s"AccumulatingDecoder.resultInstance.map$arity($accumulatingResults)(f)"
+        else s"Decoder.accumulatingResultInstance.map$arity($accumulatingResults)(f)"
 
       block"""
         |package io.circe
@@ -237,7 +237,7 @@ object Boilerplate {
         -    new Decoder[Target] {
         -      final def apply(c: HCursor): Decoder.Result[Target] = $result
         -
-        -      override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[Target] =
+        -      override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[Target] =
         -        $accumulatingResult
         -    }
         |}


### PR DESCRIPTION
When I introduced [error accumulation](https://meta.plasm.us/posts/2015/12/17/error-accumulating-decoders-in-circe/) I was worried about the ap-bind inconsistency issue and tried to minimize confusion by introducing a separate `AccumulatingDecoder` type that could be created from a `Decoder` but with error accumulation (if the decoder's definition supported that). This allowed me to have a single ap-bind-wise inconsistent method on `Decoder`, `accumulating`, which returned the `AccumulatingDecoder`. Other methods like `decodeAccumulating` were package-private.

Three years later I think this was unnecessary, and that the introduction of `AccumulatingDecoder` has caused more confusion that it was worth. I've seen many questions (on Stack Overflow, Gitter, issues here, etc.) about using `AccumulatingDecoder` as a type class / constraint, which was never really the intention, but is a totally reasonable interpretation you might come to when looking at the API. It's also just extra clutter.

This PR removes the `AccumulatingDecoder` trait, deprecates `AccumulatingDecoder.Result` (and some related stuff in the old `AccumulatingDecoder` companion object), and adds corresponding methods and aliases directly to `Decoder`.

It's a pretty big change, but for the vast majority of standard use cases upgrading will only involve making changes requested by the deprecation errors.