### PR TITLE
Rename enumDecoder / enumEncoder for consistency

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -1374,17 +1374,28 @@ final object Decoder extends CollectionDecoders with TupleDecoders with ProductD
   /**
    * {{{
    *   object WeekDay extends Enumeration { ... }
-   *   implicit val weekDayDecoder = Decoder.enumDecoder(WeekDay)
+   *   implicit val weekDayDecoder = Decoder.decodeEnumeration(WeekDay)
    * }}}
    *
    * @group Utilities
    */
-  final def enumDecoder[E <: Enumeration](enum: E): Decoder[E#Value] =
+  final def decodeEnumeration[E <: Enumeration](enum: E): Decoder[E#Value] =
     Decoder.decodeString.flatMap { str =>
       Decoder.instanceTry { _ =>
         Try(enum.withName(str))
       }
     }
+
+  /**
+   * {{{
+   *   object WeekDay extends Enumeration { ... }
+   *   implicit val weekDayDecoder = Decoder.enumDecoder(WeekDay)
+   * }}}
+   *
+   * @group Utilities
+   */
+  @deprecated("Use decodeEnumeration", "0.12.0")
+  final def enumDecoder[E <: Enumeration](enum: E): Decoder[E#Value] = decodeEnumeration[E](enum)
 
   /**
    * Helper methods for working with [[cats.data.StateT]] values that transform

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -479,13 +479,23 @@ final object Encoder extends TupleEncoders with ProductEncoders with MidPriority
   /**
    * {{{
    *   object WeekDay extends Enumeration { ... }
+   *   implicit val weekDayEncoder = Encoder.encodeEnumeration(WeekDay)
+   * }}}
+   * @group Utilities
+   */
+  final def encodeEnumeration[E <: Enumeration](enum: E): Encoder[E#Value] = new Encoder[E#Value] {
+    override def apply(e: E#Value): Json = Encoder.encodeString(e.toString)
+  }
+
+  /**
+   * {{{
+   *   object WeekDay extends Enumeration { ... }
    *   implicit val weekDayEncoder = Encoder.enumEncoder(WeekDay)
    * }}}
    * @group Utilities
    */
-  final def enumEncoder[E <: Enumeration](enum: E): Encoder[E#Value] = new Encoder[E#Value] {
-    override def apply(e: E#Value): Json = Encoder.encodeString(e.toString)
-  }
+  @deprecated("Use encodeEnumeration", "0.12.0")
+  final def enumEncoder[E <: Enumeration](enum: E): Encoder[E#Value] = encodeEnumeration[E](enum)
 
   /**
    * Note that this implementation assumes that the collection does not contain duplicate keys.

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -316,7 +316,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
       val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
     }
 
-    val decoder = Decoder.enumDecoder(WeekDay)
+    val decoder = Decoder.decodeEnumeration(WeekDay)
     val Right(friday) = parse("\"Fri\"")
     assert(decoder.apply(friday.hcursor) == Right(WeekDay.Fri))
   }
@@ -327,7 +327,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
       val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
     }
 
-    val decoder = Decoder.enumDecoder(WeekDay)
+    val decoder = Decoder.decodeEnumeration(WeekDay)
     val Right(friday) = parse("\"Friday\"")
 
     assert(decoder.apply(friday.hcursor).isEmpty)

--- a/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
@@ -25,9 +25,9 @@ class EncoderSuite extends CirceSuite {
       val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
     }
 
-    implicit val encoder = Encoder.enumEncoder(WeekDay)
+    implicit val encoder = Encoder.encodeEnumeration(WeekDay)
     val json = WeekDay.Fri.asJson
-    val decoder = Decoder.enumDecoder(WeekDay)
+    val decoder = Decoder.decodeEnumeration(WeekDay)
     assert(decoder.apply(json.hcursor) == Right(WeekDay.Fri))
   }
 


### PR DESCRIPTION
I'm not sure how this happened but it bothers me that these are inconsistent with every other encoder or decoder instance.