### PR TITLE
Update scala-java-time for 2.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val paradiseVersion = "2.1.1"
 val scalaTestVersion = "3.1.0-SNAP13"
 val scalaCheckVersion = "1.14.0"
 val disciplineVersion = "0.12.0-M3"
-val scalaJavaTimeVersion = "2.0.0-RC2"
+val scalaJavaTimeVersion = "2.0.0-RC3"
 
 /**
  * Some terrible hacks to work around Cats's decision to have builds for
@@ -312,10 +312,10 @@ lazy val genericBase = circeCrossModule("generic", mima = previousCirceVersion)
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.RuntimeDependencies
   )
   .jsSettings(
-    libraryDependencies += "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
-    libraryDependencies ++= (if (priorTo2_13(scalaVersion.value))
-                               Seq("io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
-                             else Nil)
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
+      "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
+    )
   )
   .dependsOn(coreBase, testsBase % Test, literalBase % Test)
 
@@ -337,10 +337,10 @@ lazy val genericExtrasBase = circeCrossModule("generic-extras", mima = previousC
     }
   )
   .jsSettings(
-    libraryDependencies += "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
-    libraryDependencies ++= (if (priorTo2_13(scalaVersion.value))
-                               Seq("io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
-                             else Nil)
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
+      "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
+    )
   )
   .jvmSettings(fork in Test := true)
   .dependsOn(genericBase, testsBase % Test, literalBase % Test)
@@ -355,10 +355,10 @@ lazy val shapesBase = circeCrossModule("shapes", mima = previousCirceVersion, Cr
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.RuntimeDependencies
   )
   .jsSettings(
-    libraryDependencies += "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
-    libraryDependencies ++= (if (priorTo2_13(scalaVersion.value))
-                               Seq("io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
-                             else Nil)
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
+      "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
+    )
   )
   .dependsOn(coreBase, testsBase % Test, literalBase % Test)
 
@@ -376,10 +376,10 @@ lazy val literalBase = circeCrossModule("literal", mima = previousCirceVersion, 
     )
   )
   .jsSettings(
-    libraryDependencies += "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
-    libraryDependencies ++= (if (priorTo2_13(scalaVersion.value))
-                               Seq("io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
-                             else Nil)
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
+      "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
+    )
   )
   .dependsOn(coreBase, parserBase % Test, testingBase % Test)
 
@@ -395,9 +395,7 @@ lazy val refinedBase = circeCrossModule("refined", mima = previousCirceVersion)
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.RuntimeDependencies
   )
   .jsSettings(
-    libraryDependencies ++= (if (priorTo2_13(scalaVersion.value))
-                               Seq("io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
-                             else Nil)
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
   )
   .dependsOn(coreBase, testsBase % Test)
 
@@ -420,9 +418,7 @@ lazy val scodecBase = circeCrossModule("scodec", mima = previousCirceVersion)
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.RuntimeDependencies
   )
   .jsSettings(
-    libraryDependencies ++= (if (priorTo2_13(scalaVersion.value))
-                               Seq("io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
-                             else Nil)
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
   )
   .dependsOn(coreBase, testsBase % Test)
 
@@ -480,9 +476,7 @@ lazy val testsBase = circeCrossModule("tests", mima = None)
     fork := true
   )
   .jsSettings(
-    libraryDependencies ++= (if (priorTo2_13(scalaVersion.value))
-                               Seq("io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
-                             else Nil)
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
   )
   .dependsOn(coreBase, parserBase, testingBase)
 


### PR DESCRIPTION
We'll be able to run tests for Scala.js on 2.13 now.