### PR TITLE
Replace CirceSupportParser companion object

### DIFF
--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -5,6 +5,8 @@ import java.io.Serializable
 import java.util.LinkedHashMap
 import org.typelevel.jawn.{ RawFacade, RawFContext, SupportParser }
 
+final object CirceSupportParser extends CirceSupportParser(None, true)
+
 class CirceSupportParser(maxValueSize: Option[Int], allowDuplicateKeys: Boolean)
     extends SupportParser[Json]
     with Serializable {


### PR DESCRIPTION
This was a accidental deletion. Shouldn't affect most users, but I'll probably publish an 0.12.0-M4 soon anyway.