### PR TITLE
Store by-name instances in generic-simple

### DIFF
--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/codec/DerivedAsObjectCodec.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/codec/DerivedAsObjectCodec.scala
@@ -9,15 +9,17 @@ final object DerivedAsObjectCodec {
   implicit def deriveCodec[A, R](
     implicit
     gen: LabelledGeneric.Aux[A, R],
-    codec: => ReprAsObjectCodec[R]
+    codecForR: => ReprAsObjectCodec[R]
   ): DerivedAsObjectCodec[A] = new DerivedAsObjectCodec[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = codec.apply(c) match {
+    private[this] lazy val cachedCodecForR: Codec.AsObject[R] = codecForR
+
+    final def apply(c: HCursor): Decoder.Result[A] = cachedCodecForR.apply(c) match {
       case Right(r)    => Right(gen.from(r))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
     }
     override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
-      codec.decodeAccumulating(c).map(gen.from)
+      cachedCodecForR.decodeAccumulating(c).map(gen.from)
 
-    final def encodeObject(a: A): JsonObject = codec.encodeObject(gen.to(a))
+    final def encodeObject(a: A): JsonObject = cachedCodecForR.encodeObject(gen.to(a))
   }
 }

--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/decoding/DerivedDecoder.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/decoding/DerivedDecoder.scala
@@ -9,13 +9,15 @@ final object DerivedDecoder extends IncompleteDerivedDecoders {
   implicit def deriveDecoder[A, R](
     implicit
     gen: LabelledGeneric.Aux[A, R],
-    decode: => ReprDecoder[R]
+    decodeR: => ReprDecoder[R]
   ): DerivedDecoder[A] = new DerivedDecoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = decode(c) match {
+    private[this] lazy val cachedDecodeR: Decoder[R] = decodeR
+
+    final def apply(c: HCursor): Decoder.Result[A] = cachedDecodeR(c) match {
       case Right(r)    => Right(gen.from(r))
       case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
     }
     override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
-      decode.decodeAccumulating(c).map(gen.from)
+      cachedDecodeR.decodeAccumulating(c).map(gen.from)
   }
 }

--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/encoding/DerivedAsObjectEncoder.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/encoding/DerivedAsObjectEncoder.scala
@@ -9,8 +9,9 @@ final object DerivedAsObjectEncoder {
   implicit def deriveEncoder[A, R](
     implicit
     gen: LabelledGeneric.Aux[A, R],
-    encode: => ReprAsObjectEncoder[R]
+    encodeR: => ReprAsObjectEncoder[R]
   ): DerivedAsObjectEncoder[A] = new DerivedAsObjectEncoder[A] {
-    final def encodeObject(a: A): JsonObject = encode.encodeObject(gen.to(a))
+    private[this] lazy val cachedEncodeR: Encoder.AsObject[R] = encodeR
+    final def encodeObject(a: A): JsonObject = cachedEncodeR.encodeObject(gen.to(a))
   }
 }

--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/encoding/ReprAsObjectEncoder.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/encoding/ReprAsObjectEncoder.scala
@@ -38,9 +38,11 @@ final object ReprAsObjectEncoder extends LowPriorityReprAsObjectEncoderInstances
     encodeL: Encoder[L],
     encodeR: => ReprAsObjectEncoder[R]
   ): ReprAsObjectEncoder[FieldType[K, L] :+: R] = new ReprAsObjectEncoder[FieldType[K, L] :+: R] {
+    private[this] lazy val cachedEncodeR: Encoder.AsObject[R] = encodeR
+
     def encodeObject(a: FieldType[K, L] :+: R): JsonObject = a match {
       case Inl(l) => JsonObject.singleton(key.value.name, encodeL(l))
-      case Inr(r) => encodeR.encodeObject(r)
+      case Inr(r) => cachedEncodeR.encodeObject(r)
     }
   }
 }
@@ -63,9 +65,11 @@ private[circe] trait LowPriorityReprAsObjectEncoderInstances {
     encodeL: DerivedAsObjectEncoder[L],
     encodeR: => ReprAsObjectEncoder[R]
   ): ReprAsObjectEncoder[FieldType[K, L] :+: R] = new ReprAsObjectEncoder[FieldType[K, L] :+: R] {
+    private[this] lazy val cachedEncodeR: Encoder.AsObject[R] = encodeR
+
     def encodeObject(a: FieldType[K, L] :+: R): JsonObject = a match {
       case Inl(l) => JsonObject.singleton(key.value.name, encodeL(l))
-      case Inr(r) => encodeR.encodeObject(r)
+      case Inr(r) => cachedEncodeR.encodeObject(r)
     }
   }
 }

--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/util/macros/ExportMacros.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/util/macros/ExportMacros.scala
@@ -13,7 +13,7 @@ trait Lazy[+A] extends Serializable {
 object Lazy {
   implicit def apply[A](implicit A: => A): Lazy[A] =
     new Lazy[A] {
-      val value = A
+      lazy val value = A
     }
   def lazily[A](implicit L: Lazy[A]): A = L.value
 }


### PR DESCRIPTION
See @johnynek's comment [here](https://github.com/circe/circe/pull/1180#pullrequestreview-253505389). With `Lazy` we got this for free, but by-name parameters need the extra step.