### PR TITLE
Add instances for literal types

### DIFF
--- a/modules/core/shared/src/main/scala-2.12-/io/circe/LiteralDecoders.scala
+++ b/modules/core/shared/src/main/scala-2.12-/io/circe/LiteralDecoders.scala
@@ -1,0 +1,3 @@
+package io.circe
+
+private[circe] trait LiteralDecoders

--- a/modules/core/shared/src/main/scala-2.12-/io/circe/LiteralEncoders.scala
+++ b/modules/core/shared/src/main/scala-2.12-/io/circe/LiteralEncoders.scala
@@ -1,0 +1,3 @@
+package io.circe
+
+private[circe] trait LiteralEncoders

--- a/modules/core/shared/src/main/scala-2.13+/io/circe/LiteralDecoders.scala
+++ b/modules/core/shared/src/main/scala-2.13+/io/circe/LiteralDecoders.scala
@@ -1,0 +1,90 @@
+package io.circe
+
+private[circe] trait LiteralDecoders {
+  private[this] abstract class LiteralDecoder[A, L <: A](decodeA: Decoder[A], L: ValueOf[L]) extends Decoder[L] {
+    protected[this] def check(a: A): Boolean
+    protected[this] def message: String
+
+    final def apply(c: HCursor): Decoder.Result[L] = decodeA(c) match {
+      case r @ Right(value) if check(value) => r.asInstanceOf[Decoder.Result[L]]
+      case _                                => Left(DecodingFailure(message, c.history))
+    }
+  }
+
+  /**
+   * Decode a `String` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def decodeLiteralString[L <: String](implicit L: ValueOf[L]): Decoder[L] =
+    new LiteralDecoder[String, L](Decoder.decodeString, L) {
+      protected[this] final def check(a: String): Boolean = a == L.value
+      protected[this] final def message: String = s"""String("${L.value}")"""
+    }
+
+  /**
+   * Decode a `Double` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def decodeLiteralDouble[L <: Double](implicit L: ValueOf[L]): Decoder[L] =
+    new LiteralDecoder[Double, L](Decoder.decodeDouble, L) {
+      protected[this] final def check(a: Double): Boolean = java.lang.Double.compare(a, L.value) == 0
+      protected[this] final def message: String = s"""Double(${L.value})"""
+    }
+
+  /**
+   * Decode a `Float` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def decodeLiteralFloat[L <: Float](implicit L: ValueOf[L]): Decoder[L] =
+    new LiteralDecoder[Float, L](Decoder.decodeFloat, L) {
+      protected[this] final def check(a: Float): Boolean = java.lang.Float.compare(a, L.value) == 0
+      protected[this] final def message: String = s"""Float(${L.value})"""
+    }
+
+  /**
+   * Decode a `Long` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def decodeLiteralLong[L <: Long](implicit L: ValueOf[L]): Decoder[L] =
+    new LiteralDecoder[Long, L](Decoder.decodeLong, L) {
+      protected[this] final def check(a: Long): Boolean = a == L.value
+      protected[this] final def message: String = s"""Long(${L.value})"""
+    }
+
+  /**
+   * Decode a `Int` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def decodeLiteralInt[L <: Int](implicit L: ValueOf[L]): Decoder[L] =
+    new LiteralDecoder[Int, L](Decoder.decodeInt, L) {
+      protected[this] final def check(a: Int): Boolean = a == L.value
+      protected[this] final def message: String = s"""Int(${L.value})"""
+    }
+
+  /**
+   * Decode a `Char` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def decodeLiteralChar[L <: Char](implicit L: ValueOf[L]): Decoder[L] =
+    new LiteralDecoder[Char, L](Decoder.decodeChar, L) {
+      protected[this] final def check(a: Char): Boolean = a == L.value
+      protected[this] final def message: String = s"""Char(${L.value})"""
+    }
+
+  /**
+   * Decode a `Boolean` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def decodeLiteralBoolean[L <: Boolean](implicit L: ValueOf[L]): Decoder[L] =
+    new LiteralDecoder[Boolean, L](Decoder.decodeBoolean, L) {
+      protected[this] final def check(a: Boolean): Boolean = a == L.value
+      protected[this] final def message: String = s"""Boolean(${L.value})"""
+    }
+}

--- a/modules/core/shared/src/main/scala-2.13+/io/circe/LiteralEncoders.scala
+++ b/modules/core/shared/src/main/scala-2.13+/io/circe/LiteralEncoders.scala
@@ -1,0 +1,63 @@
+package io.circe
+
+private[circe] trait LiteralEncoders {
+  private[this] final class LiteralEncoder[L](private[this] final val encoded: Json) extends Encoder[L] {
+    final def apply(a: L): Json = encoded
+  }
+
+  /**
+   * Encode a `String` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def encodeLiteralString[L <: String](implicit L: ValueOf[L]): Encoder[L] =
+    new LiteralEncoder[L](Encoder.encodeString(L.value))
+
+  /**
+   * Encode a `Double` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def encodeLiteralDouble[L <: Double](implicit L: ValueOf[L]): Encoder[L] =
+    new LiteralEncoder[L](Encoder.encodeDouble(L.value))
+
+  /**
+   * Encode a `Float` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def encodeLiteralFloat[L <: Float](implicit L: ValueOf[L]): Encoder[L] =
+    new LiteralEncoder[L](Encoder.encodeFloat(L.value))
+
+  /**
+   * Encode a `Long` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def encodeLiteralLong[L <: Long](implicit L: ValueOf[L]): Encoder[L] =
+    new LiteralEncoder[L](Encoder.encodeLong(L.value))
+
+  /**
+   * Encode a `Int` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def encodeLiteralInt[L <: Int](implicit L: ValueOf[L]): Encoder[L] =
+    new LiteralEncoder[L](Encoder.encodeInt(L.value))
+
+  /**
+   * Encode a `Char` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def encodeLiteralChar[L <: Char](implicit L: ValueOf[L]): Encoder[L] =
+    new LiteralEncoder[L](Encoder.encodeChar(L.value))
+
+  /**
+   * Encode a `Boolean` whose value is known at compile time.
+   *
+   * @group Literal
+   */
+  implicit final def encodeLiteralBoolean[L <: Boolean](implicit L: ValueOf[L]): Encoder[L] =
+    new LiteralEncoder[L](Encoder.encodeBoolean(L.value))
+}

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -400,12 +400,20 @@ trait Decoder[A] extends Serializable { self =>
  * @groupname Time Java date and time instances
  * @groupprio Time 8
  *
+ * @groupname Literal Literal type instances
+ * @groupprio Literal 9
+ *
  * @groupname Prioritization Instance prioritization
  * @groupprio Prioritization 10
  *
  * @author Travis Brown
  */
-final object Decoder extends CollectionDecoders with TupleDecoders with ProductDecoders with LowPriorityDecoders {
+final object Decoder
+    extends CollectionDecoders
+    with TupleDecoders
+    with ProductDecoders
+    with LiteralDecoders
+    with LowPriorityDecoders {
 
   /**
    * @group Aliases

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -97,12 +97,15 @@ trait Encoder[A] extends Serializable { self =>
  * @groupname Time Java date and time instances
  * @groupprio Time 8
  *
+ * @groupname Literal Literal type instances
+ * @groupprio Literal 9
+ *
  * @groupname Prioritization Instance prioritization
  * @groupprio Prioritization 10
  *
  * @author Travis Brown
  */
-final object Encoder extends TupleEncoders with ProductEncoders with MidPriorityEncoders {
+final object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders with MidPriorityEncoders {
 
   /**
    * Return an instance for a given type `A`.

--- a/modules/tests/shared/src/test/scala-2.13/io/circe/LiteralSuite.scala
+++ b/modules/tests/shared/src/test/scala-2.13/io/circe/LiteralSuite.scala
@@ -1,0 +1,20 @@
+package io.circe
+
+import cats.kernel.Eq
+import io.circe.testing.CodecTests
+import io.circe.tests.CirceSuite
+import org.scalacheck.{ Arbitrary, Gen }
+
+class LiteralCodecSuite extends CirceSuite {
+  implicit def arbitraryLiteral[L](implicit L: ValueOf[L]): Arbitrary[L] = Arbitrary(Gen.const(L.value))
+  implicit def eqLiteral[A, L <: A](implicit A: Eq[A], L: ValueOf[L]): Eq[L] = Eq.by[L, A](identity)
+
+  checkLaws("""Codec["foo"]"""", CodecTests["foo"].codec)
+  checkLaws("""Codec[1.2345]""", CodecTests[1.2345].codec)
+  checkLaws("""Codec[1.234F]""", CodecTests[1.2345f].codec)
+  checkLaws("""Codec[12345L]""", CodecTests[12345L].codec)
+  checkLaws("""Codec[123456]""", CodecTests[123456].codec)
+  checkLaws("""Codec['a']""", CodecTests['a'].codec)
+  checkLaws("""Codec[true]""", CodecTests[true].codec)
+  checkLaws("""Codec[false]""", CodecTests[false].codec)
+}


### PR DESCRIPTION
I was just reminded that I've been meaning to add these by [this conversation](https://github.com/typelevel/scala/issues/186).

We currently provide these instances in circe-literal, not circe-core, because before 2.13 there was no way to use them without either Shapeless or custom macros or TLS. In 2.13 literal types are available to everyone and it's possible to define instances without macros, so I'm moving them into circe-core.

This means that you can now write the following in a vanilla 2.13 REPL with only circe-core, circe-parser, and circe-generic:

```scala
scala> io.circe.parser.decode[true]("true")
res0: Either[io.circe.Error,true] = Right(true)

scala> io.circe.parser.decode["foo"](""""foo"""")
res1: Either[io.circe.Error,"foo"] = Right(foo)

scala> io.circe.parser.decode[1.23]("1.23")
res2: Either[io.circe.Error,1.23] = Right(1.23)

scala> io.circe.parser.decode[1.23]("1.234")
res3: Either[io.circe.Error,1.23] = Left(DecodingFailure(Double(1.23), List()))

scala> case class Foo(i: 123, b: true)
defined class Foo

scala> import io.circe.generic.auto._
import io.circe.generic.auto._

scala> io.circe.parser.decode[Foo]("""{"i": 123, "b": true}""")
res4: Either[io.circe.Error,Foo] = Right(Foo(123,true))
```

Note that I've followed circe-literal in using the "standard" decoders for the widened types, not any custom decoder that may be in scope—i.e., if you write `decode["foo"](json)`, the JSON value will be decoded via `Decoder.decodeString` even if you have a different `Decoder[String]` in scope. This feels right to me, and defining custom decoders for primitive types isn't something I'd encourage anyway, but I'm happy to hear out any arguments against this behavior.

Also note that the new literal encoders cache the (constant) encoded value when they are instantiated. This could be done lazily, but this version is a little simpler and the `Json` values are small.

Lastly, I'm thinking we should still provide the macro-powered versions of these instances in circe-literal on 2.13. This probably doesn't make a big difference, but it simplifies the circe-literal code layout a bit, and it ensure that if you import `io.circe.literal._` in cross-built code, you'll get consistency across 2.13 and earlier versions.