### PR TITLE
Fix StackOverflow of Codec[SelfRecursiveWithOption]

### DIFF
--- a/modules/generic/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
+++ b/modules/generic/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
@@ -151,7 +151,8 @@ package jsoncodecmacrossuiteaux {
     else Gen.const(SelfRecursiveWithOption(None))
 
     implicit val arbitrarySelfRecursiveWithOption: Arbitrary[SelfRecursiveWithOption] =
-      Arbitrary(atDepth(0))
+      Arbitrary(Gen.sized(atDepth(_)))
+
   }
 }
 


### PR DESCRIPTION
Found in the Scala Community Build, and likely caused by a seemingly innocuous change in ScalaCheck to `Arbitrary.arbOption`.

https://github.com/rickynils/scalacheck/issues/485