### PR TITLE
Fix StackOverflow of recursive Options tests

### DIFF
--- a/modules/generic/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
+++ b/modules/generic/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
@@ -143,16 +143,14 @@ package jsoncodecmacrossuiteaux {
     implicit val eqSelfRecursiveWithOption: Eq[SelfRecursiveWithOption] = Eq.fromUniversalEquals
 
     private def atDepth(depth: Int): Gen[SelfRecursiveWithOption] = if (depth < 3)
-      Arbitrary
-        .arbitrary[Option[SelfRecursiveWithOption]]
-        .map(
-          SelfRecursiveWithOption(_)
-        )
+      Gen.oneOf(
+        Gen.const(SelfRecursiveWithOption(None)),
+        atDepth(depth + 1).map(Some(_)).map(SelfRecursiveWithOption(_))
+      )
     else Gen.const(SelfRecursiveWithOption(None))
 
     implicit val arbitrarySelfRecursiveWithOption: Arbitrary[SelfRecursiveWithOption] =
-      Arbitrary(Gen.sized(atDepth(_)))
-
+      Arbitrary(atDepth(0))
   }
 }
 

--- a/modules/generic/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/modules/generic/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -66,11 +66,10 @@ object SemiautoDerivedSuite {
       Eq.fromUniversalEquals
 
     private def atDepth(depth: Int): Gen[RecursiveWithOptionExample] = if (depth < 3)
-      Arbitrary
-        .arbitrary[Option[RecursiveWithOptionExample]]
-        .map(
-          RecursiveWithOptionExample(_)
-        )
+      Gen.oneOf(
+        Gen.const(RecursiveWithOptionExample(None)),
+        atDepth(depth + 1).map(Some(_)).map(RecursiveWithOptionExample(_))
+      )
     else Gen.const(RecursiveWithOptionExample(None))
 
     implicit val arbitraryRecursiveWithOptionExample: Arbitrary[RecursiveWithOptionExample] =


### PR DESCRIPTION
Travis,

I believe I better understand this code.  The depth argument is incremented, now.  I also added `Gen.delay` to protect from infinite recursion, as well.

Follow-up to #1199.

