### PR TITLE
Fix fix for #1101

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -91,7 +91,18 @@ sealed abstract class JsonNumber extends Serializable {
 
 private sealed abstract class BiggerDecimalJsonNumber(input: String) extends JsonNumber {
   final def toBigInt: Option[BigInt] = toBiggerDecimal.toBigInteger.map(BigInt(_))
-  final def toBigDecimal: Option[BigDecimal] = toBiggerDecimal.toBigDecimal.map(_ => BigDecimal(input))
+  final def toBigDecimal: Option[BigDecimal] =
+    toBiggerDecimal.toBigDecimal.map(
+      value =>
+        if (value == JavaBigDecimal.ZERO) BigDecimal(JavaBigDecimal.ZERO)
+        else {
+          try BigDecimal(input)
+          catch {
+            case _: NumberFormatException => value
+          }
+        }
+    )
+
   final def toLong: Option[Long] = toBiggerDecimal.toLong
   override final def toString: String = input
   private[circe] final def appendToStringBuilder(builder: StringBuilder): Unit = builder.append(input)

--- a/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/JsonNumberString.scala
+++ b/modules/numbers-testing/src/main/scala/io/circe/numbers/testing/JsonNumberString.scala
@@ -8,28 +8,35 @@ import org.scalacheck.{ Arbitrary, Gen }
 final case class JsonNumberString(value: String)
 
 object JsonNumberString {
-  implicit val arbitraryJsonNumberString: Arbitrary[JsonNumberString] = Arbitrary(
+  private val genSign: Gen[String] = Gen.oneOf("", "-")
+  private val genIntegral: Gen[String] = Gen.oneOf(
+    Gen.const("0"),
     for {
-      sign <- Gen.oneOf("", "-")
-      integral <- Gen.oneOf(
-        Gen.const("0"),
-        for {
-          nonZero <- Gen.choose(1, 9).map(_.toString)
-          rest <- Gen.numStr
-        } yield s"$nonZero$rest"
-      )
-      fractional <- Gen.oneOf(
-        Gen.const(""),
-        Gen.nonEmptyListOf(Gen.numChar).map(_.mkString).map("." + _)
-      )
-      exponent <- Gen.oneOf(
-        Gen.const(""),
-        for {
-          e <- Gen.oneOf("e", "E")
-          s <- Gen.oneOf("", "+", "-")
-          n <- Gen.nonEmptyListOf(Gen.numChar).map(_.mkString)
-        } yield s"$e$s$n"
-      )
-    } yield JsonNumberString(s"$sign$integral$fractional$exponent")
+      nonZero <- Gen.choose(1, 9).map(_.toString)
+      rest <- Gen.numStr
+    } yield s"$nonZero$rest"
+  )
+  private val genFractional: Gen[String] =
+    Gen.nonEmptyListOf(Gen.numChar).map(_.mkString).map("." + _)
+  private val genExponent: Gen[String] =
+    for {
+      e <- Gen.oneOf("e", "E")
+      s <- Gen.oneOf("", "+", "-")
+      n <- Gen.nonEmptyListOf(Gen.numChar).map(_.mkString)
+    } yield s"$e$s$n"
+
+  implicit val arbitraryJsonNumberString: Arbitrary[JsonNumberString] = Arbitrary(
+    Gen.frequency(
+      1 -> (for {
+        sign <- genSign
+        exponent <- genExponent
+      } yield JsonNumberString(s"${sign}0$exponent")),
+      10 -> (for {
+        sign <- genSign
+        integral <- genIntegral
+        fractional <- Gen.oneOf(Gen.const(""), genFractional)
+        exponent <- Gen.oneOf(Gen.const(""), genExponent)
+      } yield JsonNumberString(s"$sign$integral$fractional$exponent"))
+    )
   )
 }


### PR DESCRIPTION
#1217 failed to work properly in some corner cases like `0.1e2147483649`. The change here fixes these cases and makes our arbitrary JSON numbers more likely to exercise some of these corner cases.