### PR TITLE
Rename generic-extras configured derive functions

### DIFF
--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfigurableDeriver.scala
@@ -17,10 +17,12 @@ class ConfigurableDeriver(val c: whitebox.Context)
     ] {
   import c.universe._
 
-  def deriveDecoder[R: c.WeakTypeTag]: c.Expr[ReprDecoder[R]] = c.Expr[ReprDecoder[R]](constructDecoder[R])
-  def deriveEncoder[R: c.WeakTypeTag]: c.Expr[ReprAsObjectEncoder[R]] =
+  def deriveConfiguredDecoder[R: c.WeakTypeTag]: c.Expr[ReprDecoder[R]] =
+    c.Expr[ReprDecoder[R]](constructDecoder[R])
+  def deriveConfiguredEncoder[R: c.WeakTypeTag]: c.Expr[ReprAsObjectEncoder[R]] =
     c.Expr[ReprAsObjectEncoder[R]](constructEncoder[R])
-  def deriveCodec[R: c.WeakTypeTag]: c.Expr[ReprAsObjectCodec[R]] = c.Expr[ReprAsObjectCodec[R]](constructCodec[R])
+  def deriveConfiguredCodec[R: c.WeakTypeTag]: c.Expr[ReprAsObjectCodec[R]] =
+    c.Expr[ReprAsObjectCodec[R]](constructCodec[R])
 
   protected[this] val RD: TypeTag[ReprDecoder[_]] = c.typeTag
   protected[this] val RE: TypeTag[ReprAsObjectEncoder[_]] = c.typeTag

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfiguredJsonCodec.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfiguredJsonCodec.scala
@@ -15,6 +15,7 @@ private[generic] class ConfiguredJsonCodecMacros(val c: blackbox.Context) extend
   import c.universe._
 
   protected[this] def semiautoObj: Symbol = symbolOf[semiauto.type].asClass.module
+  protected[this] def deriveFunctionPrefix: String = "deriveConfigured"
 
   def jsonCodecAnnotationMacro(annottees: Tree*): Tree = constructJsonCodec(annottees: _*)
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfiguredJsonCodec.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/ConfiguredJsonCodec.scala
@@ -15,7 +15,7 @@ private[generic] class ConfiguredJsonCodecMacros(val c: blackbox.Context) extend
   import c.universe._
 
   protected[this] def semiautoObj: Symbol = symbolOf[semiauto.type].asClass.module
-  protected[this] def deriveFunctionPrefix: String = "deriveConfigured"
+  protected[this] def deriveMethodPrefix: String = "deriveConfigured"
 
   def jsonCodecAnnotationMacro(annottees: Tree*): Tree = constructJsonCodec(annottees: _*)
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/codec/ReprAsObjectCodec.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/codec/ReprAsObjectCodec.scala
@@ -17,7 +17,7 @@ import shapeless.HNil
 abstract class ReprAsObjectCodec[A] extends ReprDecoder[A] with ReprAsObjectEncoder[A]
 
 object ReprAsObjectCodec {
-  implicit def deriveReprAsObjectCodec[R]: ReprAsObjectCodec[R] = macro ConfigurableDeriver.deriveCodec[R]
+  implicit def deriveReprAsObjectCodec[R]: ReprAsObjectCodec[R] = macro ConfigurableDeriver.deriveConfiguredCodec[R]
 
   val hnilReprDecoder: ReprAsObjectCodec[HNil] = new ReprAsObjectCodec[HNil] {
     def configuredDecode(c: HCursor)(

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/decoding/ReprDecoder.scala
@@ -107,7 +107,7 @@ abstract class ReprDecoder[A] extends Decoder[A] {
 }
 
 object ReprDecoder {
-  implicit def deriveReprDecoder[R]: ReprDecoder[R] = macro ConfigurableDeriver.deriveDecoder[R]
+  implicit def deriveReprDecoder[R]: ReprDecoder[R] = macro ConfigurableDeriver.deriveConfiguredDecoder[R]
 
   val hnilReprDecoder: ReprDecoder[HNil] = new ReprDecoder[HNil] {
     def configuredDecode(c: HCursor)(

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprAsObjectEncoder.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/encoding/ReprAsObjectEncoder.scala
@@ -34,5 +34,6 @@ trait ReprAsObjectEncoder[A] extends Encoder.AsObject[A] {
 }
 
 object ReprAsObjectEncoder {
-  implicit def deriveReprAsObjectEncoder[R]: ReprAsObjectEncoder[R] = macro ConfigurableDeriver.deriveEncoder[R]
+  implicit def deriveReprAsObjectEncoder[R]: ReprAsObjectEncoder[R] =
+    macro ConfigurableDeriver.deriveConfiguredEncoder[R]
 }

--- a/modules/generic-extras/src/main/scala/io/circe/generic/extras/semiauto.scala
+++ b/modules/generic-extras/src/main/scala/io/circe/generic/extras/semiauto.scala
@@ -24,17 +24,32 @@ import shapeless.ops.record.RemoveAll
  *   case class Foo(i: Int, p: (String, Double))
  *
  *   object Foo {
- *     implicit val decodeFoo: Decoder[Foo] = deriveDecoder[Foo]
- *     implicit val encodeFoo: Encoder.AsObject[Foo] = deriveEncoder[Foo]
+ *     implicit val decodeFoo: Decoder[Foo] = deriveConfiguredDecoder[Foo]
+ *     implicit val encodeFoo: Encoder.AsObject[Foo] = deriveConfiguredEncoder[Foo]
  *   }
  * }}}
  */
 object semiauto {
-  final def deriveDecoder[A](implicit decode: Lazy[ConfiguredDecoder[A]]): Decoder[A] = decode.value
-  final def deriveEncoder[A](implicit encode: Lazy[ConfiguredAsObjectEncoder[A]]): Encoder.AsObject[A] = encode.value
-  final def deriveCodec[A](implicit codec: Lazy[ConfiguredAsObjectCodec[A]]): Codec.AsObject[A] = codec.value
+  @deprecated("Use deriveConfiguredDecoder", "0.12.0")
+  final def deriveDecoder[A](implicit decode: Lazy[ConfiguredDecoder[A]]): Decoder[A] =
+    deriveConfiguredDecoder
+  @deprecated("Use deriveConfiguredEncoder", "0.12.0")
+  final def deriveEncoder[A](implicit encode: Lazy[ConfiguredAsObjectEncoder[A]]): Encoder.AsObject[A] =
+    deriveConfiguredEncoder
+  @deprecated("Use deriveConfiguredCodec", "0.12.0")
+  final def deriveCodec[A](implicit codec: Lazy[ConfiguredAsObjectCodec[A]]): Codec.AsObject[A] =
+    deriveConfiguredCodec
+  @deprecated("Use deriveConfiguredFor", "0.12.0")
+  final def deriveFor[A]: DerivationHelper[A] = deriveConfiguredFor
 
-  final def deriveFor[A]: DerivationHelper[A] = new DerivationHelper[A]
+  final def deriveConfiguredDecoder[A](implicit decode: Lazy[ConfiguredDecoder[A]]): Decoder[A] =
+    decode.value
+  final def deriveConfiguredEncoder[A](implicit encode: Lazy[ConfiguredAsObjectEncoder[A]]): Encoder.AsObject[A] =
+    encode.value
+  final def deriveConfiguredCodec[A](implicit codec: Lazy[ConfiguredAsObjectCodec[A]]): Codec.AsObject[A] =
+    codec.value
+
+  final def deriveConfiguredFor[A]: DerivationHelper[A] = new DerivationHelper[A]
 
   /**
    * Derive a decoder for a sealed trait hierarchy made up of case objects.

--- a/modules/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
+++ b/modules/generic-extras/src/test/scala/io/circe/generic/extras/ConfiguredSemiautoDerivedSuite.scala
@@ -38,16 +38,16 @@ object ConfiguredSemiautoDerivedSuite {
     Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("type").withSnakeCaseConstructorNames
 
   implicit val decodeIntlessQux: Decoder[Int => Qux[String]] =
-    deriveFor[Int => Qux[String]].incomplete
+    deriveConfiguredFor[Int => Qux[String]].incomplete
 
   implicit val decodeJlessQux: Decoder[FieldType[Witness.`'j`.T, Int] => Qux[String]] =
-    deriveFor[FieldType[Witness.`'j`.T, Int] => Qux[String]].incomplete
+    deriveConfiguredFor[FieldType[Witness.`'j`.T, Int] => Qux[String]].incomplete
 
-  implicit val decodeQuxPatch: Decoder[Qux[String] => Qux[String]] = deriveFor[Qux[String]].patch
+  implicit val decodeQuxPatch: Decoder[Qux[String] => Qux[String]] = deriveConfiguredFor[Qux[String]].patch
 
-  implicit val decodeConfigExampleBase: Decoder[ConfigExampleBase] = deriveDecoder
-  implicit val encodeConfigExampleBase: Encoder.AsObject[ConfigExampleBase] = deriveEncoder
-  val codecForConfigExampleBase: Codec.AsObject[ConfigExampleBase] = deriveCodec
+  implicit val decodeConfigExampleBase: Decoder[ConfigExampleBase] = deriveConfiguredDecoder
+  implicit val encodeConfigExampleBase: Encoder.AsObject[ConfigExampleBase] = deriveConfiguredEncoder
+  val codecForConfigExampleBase: Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
 }
 
 class ConfiguredSemiautoDerivedSuite extends CirceSuite {
@@ -94,8 +94,8 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite {
     val decodeConstructorCount = 2
     val encodeConstructorCount = 1
 
-    val encoder: Encoder[ConfigExampleBase] = deriveEncoder
-    val decoder: Decoder[ConfigExampleBase] = deriveDecoder
+    val encoder: Encoder[ConfigExampleBase] = deriveConfiguredEncoder
+    val decoder: Decoder[ConfigExampleBase] = deriveConfiguredDecoder
     for {
       _ <- 1 until 100
     } {
@@ -115,7 +115,7 @@ class ConfiguredSemiautoDerivedSuite extends CirceSuite {
         .withSnakeCaseConstructorNames
         .withStrictDecoding
 
-    implicit val decodeConfigExampleBase: Decoder[ConfigExampleBase] = deriveDecoder
+    implicit val decodeConfigExampleBase: Decoder[ConfigExampleBase] = deriveConfiguredDecoder
 
     val json =
       json"""

--- a/modules/generic/shared/src/main/scala/io/circe/generic/JsonCodec.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/JsonCodec.scala
@@ -15,6 +15,7 @@ private[generic] final class GenericJsonCodecMacros(val c: blackbox.Context) ext
   import c.universe._
 
   protected[this] def semiautoObj: Symbol = symbolOf[semiauto.type].asClass.module
+  protected[this] def deriveFunctionPrefix: String = "derive"
 
   def jsonCodecAnnotationMacro(annottees: Tree*): Tree = constructJsonCodec(annottees: _*)
 }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/JsonCodec.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/JsonCodec.scala
@@ -15,7 +15,7 @@ private[generic] final class GenericJsonCodecMacros(val c: blackbox.Context) ext
   import c.universe._
 
   protected[this] def semiautoObj: Symbol = symbolOf[semiauto.type].asClass.module
-  protected[this] def deriveFunctionPrefix: String = "derive"
+  protected[this] def deriveMethodPrefix: String = "derive"
 
   def jsonCodecAnnotationMacro(annottees: Tree*): Tree = constructJsonCodec(annottees: _*)
 }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/JsonCodecMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/JsonCodecMacros.scala
@@ -9,7 +9,7 @@ abstract class JsonCodecMacros {
   import c.universe._
 
   protected[this] def semiautoObj: Symbol
-  protected[this] def deriveFunctionPrefix: String
+  protected[this] def deriveMethodPrefix: String
 
   private[this] def isCaseClassOrSealed(clsDef: ClassDef) =
     clsDef.mods.hasFlag(Flag.CASE) || clsDef.mods.hasFlag(Flag.SEALED)
@@ -65,7 +65,7 @@ abstract class JsonCodecMacros {
     val decodeName = TermName("decode" + tpname.decodedName)
     val encodeName = TermName("encode" + tpname.decodedName)
     val codecName = TermName("codecFor" + tpname.decodedName)
-    def deriveName(suffix: String) = TermName(deriveFunctionPrefix + suffix)
+    def deriveName(suffix: String) = TermName(deriveMethodPrefix + suffix)
     val (decoder, encoder, codec) = if (tparams.isEmpty) {
       val Type = tpname
       (

--- a/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/JsonCodecMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/util/macros/JsonCodecMacros.scala
@@ -9,6 +9,7 @@ abstract class JsonCodecMacros {
   import c.universe._
 
   protected[this] def semiautoObj: Symbol
+  protected[this] def deriveFunctionPrefix: String
 
   private[this] def isCaseClassOrSealed(clsDef: ClassDef) =
     clsDef.mods.hasFlag(Flag.CASE) || clsDef.mods.hasFlag(Flag.SEALED)
@@ -64,12 +65,13 @@ abstract class JsonCodecMacros {
     val decodeName = TermName("decode" + tpname.decodedName)
     val encodeName = TermName("encode" + tpname.decodedName)
     val codecName = TermName("codecFor" + tpname.decodedName)
+    def deriveName(suffix: String) = TermName(deriveFunctionPrefix + suffix)
     val (decoder, encoder, codec) = if (tparams.isEmpty) {
       val Type = tpname
       (
-        q"""implicit val $decodeName: $DecoderClass[$Type] = $semiautoObj.deriveDecoder[$Type]""",
-        q"""implicit val $encodeName: $AsObjectEncoderClass[$Type] = $semiautoObj.deriveEncoder[$Type]""",
-        q"""implicit val $codecName: $AsObjectCodecClass[$Type] = $semiautoObj.deriveCodec[$Type]"""
+        q"""implicit val $decodeName: $DecoderClass[$Type] = $semiautoObj.${deriveName("Decoder")}[$Type]""",
+        q"""implicit val $encodeName: $AsObjectEncoderClass[$Type] = $semiautoObj.${deriveName("Encoder")}[$Type]""",
+        q"""implicit val $codecName: $AsObjectCodecClass[$Type] = $semiautoObj.${deriveName("Codec")}[$Type]"""
       )
     } else {
       val tparamNames = tparams.map(_.name)


### PR DESCRIPTION
This is a PR addressing the usability problems explained in #1220.

I tried to rename all occurrences of `deriveEncoder`, `deriveDecoder`, `deriveCodec` and `deriveFor` to start with `deriveConfigured*`.

The original public functions in `io.circe.generic.extras.semiauto._` have been deprecated.

I didn't rename `deriveEnumeration*` and `deriveUnwrapped*` functions as they don't use the configuration afaik.

The methods in `ConfigurableDeriver` have been renamed without deprecation as it doesn't seem like a public API to me. Please tell me if I should add the deprecation there as well or if not renaming them is a better solution (the class is already named  `ConfigurableDeriver`, so the method names are a bit redundant).

I had to parameterize the function name prefix for the macro annotation in `JsonCodecMacros`. I'm not very experienced with macros but I tried a wrong prefix and it gave me expected compile-errors, so I think it works as it should.

Hope this is what you expected 🙂