### PR TITLE
Fix #1228

### DIFF
--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/codec/ReprAsObjectCodec.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/codec/ReprAsObjectCodec.scala
@@ -14,15 +14,10 @@ import shapeless.labelled.{ FieldType, field }
 abstract class ReprAsObjectCodec[A] extends Codec.AsObject[A]
 
 object ReprAsObjectCodec {
-  def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(
+  private[this] def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(
     implicit F: Apply[F]
   ): F[FieldType[K, V] :: T] =
     F.map2(hv, tr)((v, t) => field[K].apply[V](v) :: t)
-
-  def injectLeftValue[K, V, R <: Coproduct](v: V): FieldType[K, V] :+: R = Inl(field[K].apply[V](v))
-
-  val hnilResult: Decoder.Result[HNil] = Right(HNil)
-  val hnilResultAccumulating: Decoder.AccumulatingResult[HNil] = Validated.valid(HNil)
 
   implicit val codecForHNil: ReprAsObjectCodec[HNil] = new ReprAsObjectCodec[HNil] {
     def apply(c: HCursor): Decoder.Result[HNil] = Right(HNil)

--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/decoding/ReprDecoder.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/decoding/ReprDecoder.scala
@@ -13,7 +13,17 @@ import shapeless.labelled.{ FieldType, field }
  */
 abstract class ReprDecoder[A] extends Decoder[A]
 
-object ReprDecoder extends LowPriorityReprDecoderInstances {
+object ReprDecoder {
+  def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(
+    implicit F: Apply[F]
+  ): F[FieldType[K, V] :: T] =
+    F.map2(hv, tr)((v, t) => field[K].apply[V](v) :: t)
+
+  def injectLeftValue[K, V, R <: Coproduct](v: V): FieldType[K, V] :+: R = Inl(field[K].apply[V](v))
+
+  val hnilResult: Decoder.Result[HNil] = Right(HNil)
+  val hnilResultAccumulating: Decoder.AccumulatingResult[HNil] = Validated.valid(HNil)
+
   implicit val decodeHNil: ReprDecoder[HNil] = new ReprDecoder[HNil] {
     def apply(c: HCursor): Decoder.Result[HNil] = Right(HNil)
   }
@@ -44,61 +54,6 @@ object ReprDecoder extends LowPriorityReprDecoderInstances {
     implicit
     key: Witness.Aux[K],
     decodeL: Decoder[L],
-    decodeR: => ReprDecoder[R]
-  ): ReprDecoder[FieldType[K, L] :+: R] = new ReprDecoder[FieldType[K, L] :+: R] {
-    private[this] lazy val cachedDecodeR: Decoder[R] = decodeR
-
-    def apply(c: HCursor): Decoder.Result[FieldType[K, L] :+: R] =
-      c.downField(key.value.name).focus match {
-        case Some(value) => value.as(decodeL).map(l => Inl(field(l)))
-        case None        => cachedDecodeR(c).map(Inr(_))
-      }
-
-    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[FieldType[K, L] :+: R] = {
-      val f = c.downField(key.value.name)
-
-      f.focus match {
-        case Some(value) => decodeL.tryDecodeAccumulating(f).map(l => Inl(field(l)))
-        case None        => cachedDecodeR.decodeAccumulating(c).map(Inr(_))
-      }
-    }
-  }
-
-}
-
-trait LowPriorityReprDecoderInstances {
-  def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(
-    implicit F: Apply[F]
-  ): F[FieldType[K, V] :: T] =
-    F.map2(hv, tr)((v, t) => field[K].apply[V](v) :: t)
-
-  def injectLeftValue[K, V, R <: Coproduct](v: V): FieldType[K, V] :+: R = Inl(field[K].apply[V](v))
-
-  val hnilResult: Decoder.Result[HNil] = Right(HNil)
-  val hnilResultAccumulating: Decoder.AccumulatingResult[HNil] = Validated.valid(HNil)
-
-  implicit def decodeHConsDerived[K <: Symbol, H, T <: HList](
-    implicit
-    key: Witness.Aux[K],
-    decodeH: DerivedDecoder[H],
-    decodeT: ReprDecoder[T]
-  ): ReprDecoder[FieldType[K, H] :: T] = new ReprDecoder[FieldType[K, H] :: T] {
-    def apply(c: HCursor): Decoder.Result[FieldType[K, H] :: T] = for {
-      h <- c.get(key.value.name)(decodeH)
-      t <- decodeT(c)
-    } yield field[K](h) :: t
-
-    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[FieldType[K, H] :: T] =
-      consResults[Decoder.AccumulatingResult, K, H, T](
-        decodeH.tryDecodeAccumulating(c.downField(key.value.name)),
-        decodeT.decodeAccumulating(c)
-      )
-  }
-
-  implicit def decodeCoproductDerived[K <: Symbol, L, R <: Coproduct](
-    implicit
-    key: Witness.Aux[K],
-    decodeL: DerivedDecoder[L],
     decodeR: => ReprDecoder[R]
   ): ReprDecoder[FieldType[K, L] :+: R] = new ReprDecoder[FieldType[K, L] :+: R] {
     private[this] lazy val cachedDecodeR: Decoder[R] = decodeR

--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/decoding/ReprDecoder.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/decoding/ReprDecoder.scala
@@ -14,15 +14,10 @@ import shapeless.labelled.{ FieldType, field }
 abstract class ReprDecoder[A] extends Decoder[A]
 
 object ReprDecoder {
-  def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(
+  private[this] def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(
     implicit F: Apply[F]
   ): F[FieldType[K, V] :: T] =
     F.map2(hv, tr)((v, t) => field[K].apply[V](v) :: t)
-
-  def injectLeftValue[K, V, R <: Coproduct](v: V): FieldType[K, V] :+: R = Inl(field[K].apply[V](v))
-
-  val hnilResult: Decoder.Result[HNil] = Right(HNil)
-  val hnilResultAccumulating: Decoder.AccumulatingResult[HNil] = Validated.valid(HNil)
 
   implicit val decodeHNil: ReprDecoder[HNil] = new ReprDecoder[HNil] {
     def apply(c: HCursor): Decoder.Result[HNil] = Right(HNil)

--- a/modules/generic-simple/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
+++ b/modules/generic-simple/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
@@ -39,42 +39,6 @@ object AutoDerivedSuite extends AllSyntax {
       )
   }
 
-  sealed trait RecursiveAdtExample
-  case class BaseAdtExample(a: String) extends RecursiveAdtExample
-  case class NestedAdtExample(r: RecursiveAdtExample) extends RecursiveAdtExample
-
-  object RecursiveAdtExample {
-    implicit val eqRecursiveAdtExample: Eq[RecursiveAdtExample] = Eq.fromUniversalEquals
-
-    private def atDepth(depth: Int): Gen[RecursiveAdtExample] = if (depth < 3)
-      Gen.oneOf(
-        Arbitrary.arbitrary[String].map(BaseAdtExample(_)),
-        atDepth(depth + 1).map(NestedAdtExample(_))
-      )
-    else Arbitrary.arbitrary[String].map(BaseAdtExample(_))
-
-    implicit val arbitraryRecursiveAdtExample: Arbitrary[RecursiveAdtExample] =
-      Arbitrary(atDepth(0))
-  }
-
-  case class RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])
-
-  object RecursiveWithOptionExample {
-    implicit val eqRecursiveWithOptionExample: Eq[RecursiveWithOptionExample] =
-      Eq.fromUniversalEquals
-
-    private def atDepth(depth: Int): Gen[RecursiveWithOptionExample] = if (depth < 3)
-      Gen
-        .option(atDepth(depth + 1))
-        .map(
-          RecursiveWithOptionExample(_)
-        )
-    else Gen.const(RecursiveWithOptionExample(None))
-
-    implicit val arbitraryRecursiveWithOptionExample: Arbitrary[RecursiveWithOptionExample] =
-      Arbitrary(atDepth(0))
-  }
-
   import shapeless.tag
   import shapeless.tag.@@
 
@@ -125,8 +89,6 @@ class AutoDerivedSuite extends CirceSuite {
   checkLaws("Codec[Baz]", CodecTests[Baz].codec)
   checkLaws("Codec[Foo]", CodecTests[Foo].codec)
   checkLaws("Codec[OuterCaseClassExample]", CodecTests[OuterCaseClassExample].codec)
-  checkLaws("Codec[RecursiveAdtExample]", CodecTests[RecursiveAdtExample].codec)
-  checkLaws("Codec[RecursiveWithOptionExample]", CodecTests[RecursiveWithOptionExample].codec)
 
   "Decoder[Int => Qux[String]]" should "decode partial JSON representations" in forAll { (i: Int, s: String, j: Int) =>
     val result = Json

--- a/modules/generic-simple/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
+++ b/modules/generic-simple/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
@@ -93,9 +93,9 @@ package jsoncodecmacrossuiteaux {
   // Hierarchy
 
   @JsonCodec sealed trait Hierarchy
-  final case class Hierarchy1(i: Int, s: String) extends Hierarchy
-  final case class Hierarchy2(xs: List[String]) extends Hierarchy
-  final case class Hierarchy3(s: Single, d: Double) extends Hierarchy
+  @JsonCodec final case class Hierarchy1(i: Int, s: String) extends Hierarchy
+  @JsonCodec final case class Hierarchy2(xs: List[String]) extends Hierarchy
+  @JsonCodec final case class Hierarchy3(s: Single, d: Double) extends Hierarchy
 
   object Hierarchy {
     implicit val eqHierarchy: Eq[Hierarchy] = Eq.fromUniversalEquals
@@ -118,8 +118,8 @@ package jsoncodecmacrossuiteaux {
   // RecursiveHierarchy
 
   @JsonCodec sealed trait RecursiveHierarchy
-  final case class BaseRecursiveHierarchy(a: String) extends RecursiveHierarchy
-  final case class NestedRecursiveHierarchy(r: RecursiveHierarchy) extends RecursiveHierarchy
+  @JsonCodec final case class BaseRecursiveHierarchy(a: String) extends RecursiveHierarchy
+  @JsonCodec final case class NestedRecursiveHierarchy(r: RecursiveHierarchy) extends RecursiveHierarchy
 
   object RecursiveHierarchy {
     implicit val eqRecursiveHierarchy: Eq[RecursiveHierarchy] = Eq.fromUniversalEquals

--- a/modules/generic-simple/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/modules/generic-simple/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -25,6 +25,10 @@ object SemiautoDerivedSuite {
   implicit val encodeWub: Encoder.AsObject[Wub] = deriveEncoder
   val codecForWub: Codec.AsObject[Wub] = deriveCodec
 
+  implicit val codecForBar: Codec.AsObject[Bar] = deriveCodec
+  implicit val codecForBaz: Codec.AsObject[Baz] = deriveCodec
+  implicit val codecForBam: Codec.AsObject[Bam] = deriveCodec
+
   implicit val decodeFoo: Decoder[Foo] = deriveDecoder
   implicit val encodeFoo: Encoder.AsObject[Foo] = deriveEncoder
   val codecForFoo: Codec.AsObject[Foo] = deriveCodec
@@ -53,6 +57,9 @@ object SemiautoDerivedSuite {
 
     implicit val arbitraryRecursiveAdtExample: Arbitrary[RecursiveAdtExample] =
       Arbitrary(atDepth(0))
+
+    implicit val codecForBaseAdtExample: Codec.AsObject[BaseAdtExample] = deriveCodec
+    implicit val codecForNestedAdtExample: Codec.AsObject[NestedAdtExample] = deriveCodec
 
     implicit val decodeRecursiveAdtExample: Decoder[RecursiveAdtExample] = deriveDecoder
     implicit val encodeRecursiveAdtExample: Encoder.AsObject[RecursiveAdtExample] = deriveEncoder


### PR DESCRIPTION
I've decided for now to remove support for a couple of complex use cases from circe-generic-simple, since they're more difficult to deal with without macros.

When using `simple.semiauto`, you now must derive instances for all case classes or objects in an ADT in order to be able to derive an instance for the ADT root. (I've wanted to do this for circe-generic for a long time, but I think that ship has sailed.)

It's also no longer possible to use `simple.auto` to derive instances for recursive case classes. If someone wants to fix this, I'll happily review, but I don't think it's necessary (you can use `simple.semiauto`, or of course `generic.auto`) and it makes things a lot simpler.