### PR TITLE
Introduce Codec.codecForEnumeration, add tests, change error slightly

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -1062,8 +1062,8 @@ object Decoder
    */
   final def decodeEither[A, B](leftKey: String, rightKey: String)(
     implicit
-    da: Decoder[A],
-    db: Decoder[B]
+    decodeA: Decoder[A],
+    decodeB: Decoder[B]
   ): Decoder[Either[A, B]] = new Decoder[Either[A, B]] {
     private[this] def failure(c: HCursor): Decoder.Result[Either[A, B]] =
       Left(DecodingFailure("[A, B]Either[A, B]", c.history))
@@ -1077,7 +1077,7 @@ object Decoder
           rf match {
             case _: HCursor => failure(c)
             case rc =>
-              da(lc) match {
+              decodeA(lc) match {
                 case Right(v)    => Right(Left(v))
                 case l @ Left(_) => l.asInstanceOf[Result[Either[A, B]]]
               }
@@ -1085,7 +1085,7 @@ object Decoder
         case _ =>
           rf match {
             case rc: HCursor =>
-              db(rc) match {
+              decodeB(rc) match {
                 case Right(v)    => Right(Right(v))
                 case l @ Left(_) => l.asInstanceOf[Result[Either[A, B]]]
               }
@@ -1100,8 +1100,8 @@ object Decoder
    */
   final def decodeValidated[E, A](failureKey: String, successKey: String)(
     implicit
-    de: Decoder[E],
-    da: Decoder[A]
+    decodeE: Decoder[E],
+    decodeA: Decoder[A]
   ): Decoder[Validated[E, A]] =
     decodeEither[E, A](
       failureKey,

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -1393,12 +1393,14 @@ object Decoder
    *
    * @group Utilities
    */
-  final def decodeEnumeration[E <: Enumeration](enum: E): Decoder[E#Value] =
-    Decoder.decodeString.flatMap { str =>
-      Decoder.instanceTry { _ =>
-        Try(enum.withName(str))
+  final def decodeEnumeration[E <: Enumeration](enum: E): Decoder[E#Value] = new Decoder[E#Value] {
+    final def apply(c: HCursor): Decoder.Result[E#Value] = Decoder.decodeString(c).flatMap { str =>
+      Try(enum.withName(str)) match {
+        case Success(a) => Right(a)
+        case Failure(t) => Left(DecodingFailure(t.getMessage, c.history))
       }
     }
+  }
 
   /**
    * {{{

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -451,12 +451,12 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
    */
   final def encodeEither[A, B](leftKey: String, rightKey: String)(
     implicit
-    ea: Encoder[A],
-    eb: Encoder[B]
+    encodeA: Encoder[A],
+    encodeB: Encoder[B]
   ): AsObject[Either[A, B]] = new AsObject[Either[A, B]] {
     final def encodeObject(a: Either[A, B]): JsonObject = a match {
-      case Left(a)  => JsonObject.singleton(leftKey, ea(a))
-      case Right(b) => JsonObject.singleton(rightKey, eb(b))
+      case Left(a)  => JsonObject.singleton(leftKey, encodeA(a))
+      case Right(b) => JsonObject.singleton(rightKey, encodeB(b))
     }
   }
 
@@ -465,8 +465,8 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
    */
   final def encodeValidated[E, A](failureKey: String, successKey: String)(
     implicit
-    ee: Encoder[E],
-    ea: Encoder[A]
+    encodeE: Encoder[E],
+    encodeA: Encoder[A]
   ): AsObject[Validated[E, A]] = encodeEither[E, A](failureKey, successKey).contramapObject {
     case Validated.Invalid(e) => Left(e)
     case Validated.Valid(a)   => Right(a)

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -166,6 +166,34 @@ class CirceCodecSuite extends CirceSuite {
   checkLaws("Codec[Foo]", CodecTests[Foo](Foo.decodeFoo, Foo.encodeFoo).codec)
 }
 
+class EitherCodecSuite extends CirceSuite {
+  val decoder = Decoder.decodeEither[Int, String]("L", "R")
+  val encoder = Encoder.encodeEither[Int, String]("L", "R")
+  val codec = Codec.codecForEither[Int, String]("L", "R")
+
+  checkLaws("Codec[Either[Int, String]]", CodecTests[Either[Int, String]](decoder, encoder).codec)
+  checkLaws("Codec[Either[Int, String]] via Codec", CodecTests[Either[Int, String]](codec, codec).codec)
+  checkLaws("Codec[Either[Int, String]] via Decoder and Codec", CodecTests[Either[Int, String]](decoder, codec).codec)
+  checkLaws("Codec[Either[Int, String]] via Encoder and Codec", CodecTests[Either[Int, String]](codec, encoder).codec)
+}
+
+class ValidatedCodecSuite extends CirceSuite {
+  val decoder = Decoder.decodeValidated[Int, String]("E", "A")
+  val encoder = Encoder.encodeValidated[Int, String]("E", "A")
+  val codec = Codec.codecForValidated[Int, String]("E", "A")
+
+  checkLaws("Codec[Validated[Int, String]]", CodecTests[Validated[Int, String]](decoder, encoder).codec)
+  checkLaws("Codec[Validated[Int, String]] via Codec", CodecTests[Validated[Int, String]](codec, codec).codec)
+  checkLaws(
+    "Codec[Validated[Int, String]] via Decoder and Codec",
+    CodecTests[Validated[Int, String]](decoder, codec).codec
+  )
+  checkLaws(
+    "Codec[Validated[Int, String]] via Encoder and Codec",
+    CodecTests[Validated[Int, String]](codec, encoder).codec
+  )
+}
+
 class DisjunctionCodecSuite extends CirceSuite {
   import disjunctionCodecs._
 

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -173,6 +173,33 @@ class DisjunctionCodecSuite extends CirceSuite {
   checkLaws("Codec[Validated[String, Int]]", CodecTests[Validated[String, Int]].codec)
 }
 
+class EnumerationCodecSuite extends CirceSuite {
+  object WeekDay extends Enumeration {
+    type WeekDay = Value
+    val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
+
+    implicit val arbitraryWeekDay: Arbitrary[WeekDay.WeekDay] = Arbitrary(
+      Gen.oneOf(WeekDay.Mon, WeekDay.Tue, WeekDay.Wed, WeekDay.Thu, WeekDay.Fri, WeekDay.Sat, WeekDay.Sun)
+    )
+    implicit val eqWeekDay: Eq[WeekDay.WeekDay] = Eq.fromUniversalEquals
+  }
+
+  val decoder = Decoder.decodeEnumeration(WeekDay)
+  val encoder = Encoder.encodeEnumeration(WeekDay)
+  val codec = Codec.codecForEnumeration(WeekDay)
+
+  checkLaws("Codec[WeekDay.WeekDay]", CodecTests[WeekDay.WeekDay](decoder, encoder).unserializableCodec)
+  checkLaws("Codec[WeekDay.WeekDay] via Codec", CodecTests[WeekDay.WeekDay](codec, codec).unserializableCodec)
+  checkLaws(
+    "Codec[WeekDay.WeekDay] via Decoder and Codec",
+    CodecTests[WeekDay.WeekDay](decoder, codec).unserializableCodec
+  )
+  checkLaws(
+    "Codec[WeekDay.WeekDay] via Encoder and Codec",
+    CodecTests[WeekDay.WeekDay](codec, encoder).unserializableCodec
+  )
+}
+
 class DecodingFailureSuite extends CirceSuite {
   val n = Json.fromInt(10)
   val b = Json.True


### PR DESCRIPTION
I've added laws-checking for these instances, which turned up the fact that on decoding failures we were passing along the whole `NoSuchElementException` stack trace, which seems kind of bad, so I fixed it.