### PR TITLE
Rename pretty to print

### DIFF
--- a/modules/benchmark/src/main/scala/io/circe/benchmark/PrintingBenchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/PrintingBenchmark.scala
@@ -17,26 +17,26 @@ import org.openjdk.jmh.annotations._
 @OutputTimeUnit(TimeUnit.SECONDS)
 class PrintingBenchmark extends ExampleData {
   @Benchmark
-  def printFoosToString: String = Printer.noSpaces.pretty(foosJson)
+  def printFoosToString: String = Printer.noSpaces.print(foosJson)
 
   @Benchmark
-  def printFoosToByteBuffer: ByteBuffer = Printer.noSpaces.prettyByteBuffer(foosJson)
+  def printFoosToByteBuffer: ByteBuffer = Printer.noSpaces.printToByteBuffer(foosJson)
 
   @Benchmark
-  def printHelloWorldToString: String = Printer.noSpaces.pretty(helloWorldJson)
+  def printHelloWorldToString: String = Printer.noSpaces.print(helloWorldJson)
 
   @Benchmark
-  def printHelloWorldToByteBuffer: ByteBuffer = Printer.noSpaces.prettyByteBuffer(helloWorldJson)
+  def printHelloWorldToByteBuffer: ByteBuffer = Printer.noSpaces.printToByteBuffer(helloWorldJson)
 
   @Benchmark
-  def printBooleansToString: String = Printer.noSpaces.pretty(booleansJson)
+  def printBooleansToString: String = Printer.noSpaces.print(booleansJson)
 
   @Benchmark
-  def printBooleansToByteBuffer: ByteBuffer = Printer.noSpaces.prettyByteBuffer(booleansJson)
+  def printBooleansToByteBuffer: ByteBuffer = Printer.noSpaces.printToByteBuffer(booleansJson)
 
   @Benchmark
-  def printIntsToString: String = Printer.noSpaces.pretty(intsJson)
+  def printIntsToString: String = Printer.noSpaces.print(intsJson)
 
   @Benchmark
-  def printIntsToByteBuffer: ByteBuffer = Printer.noSpaces.prettyByteBuffer(intsJson)
+  def printIntsToByteBuffer: ByteBuffer = Printer.noSpaces.printToByteBuffer(intsJson)
 }

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -109,40 +109,46 @@ sealed abstract class Json extends Product with Serializable {
   /**
    * Pretty-print this JSON value to a string using the given pretty-printer.
    */
-  final def pretty(p: Printer): String = p.pretty(this)
+  final def printWith(p: Printer): String = p.print(this)
+
+  /**
+   * Pretty-print this JSON value to a string using the given pretty-printer.
+   */
+  @deprecated("Use printWith", "0.12.0")
+  final def pretty(p: Printer): String = printWith(p)
 
   /**
    * Pretty-print this JSON value to a string with no spaces.
    */
-  final def noSpaces: String = Printer.noSpaces.pretty(this)
+  final def noSpaces: String = Printer.noSpaces.print(this)
 
   /**
    * Pretty-print this JSON value to a string indentation of two spaces.
    */
-  final def spaces2: String = Printer.spaces2.pretty(this)
+  final def spaces2: String = Printer.spaces2.print(this)
 
   /**
    * Pretty-print this JSON value to a string indentation of four spaces.
    */
-  final def spaces4: String = Printer.spaces4.pretty(this)
+  final def spaces4: String = Printer.spaces4.print(this)
 
   /**
    * Pretty-print this JSON value to a string with no spaces, with object keys
    * sorted alphabetically.
    */
-  final def noSpacesSortKeys: String = Printer.noSpacesSortKeys.pretty(this)
+  final def noSpacesSortKeys: String = Printer.noSpacesSortKeys.print(this)
 
   /**
    * Pretty-print this JSON value to a string indentation of two spaces, with
    * object keys sorted alphabetically.
    */
-  final def spaces2SortKeys: String = Printer.spaces2SortKeys.pretty(this)
+  final def spaces2SortKeys: String = Printer.spaces2SortKeys.print(this)
 
   /**
    * Pretty-print this JSON value to a string indentation of four spaces, with
    * object keys sorted alphabetically.
    */
-  final def spaces4SortKeys: String = Printer.spaces4SortKeys.pretty(this)
+  final def spaces4SortKeys: String = Printer.spaces4SortKeys.print(this)
 
   /**
    * Perform a deep merge of this JSON value with another JSON value.

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -182,7 +182,7 @@ final case class Printer(
   /**
    * Returns a string representation of a pretty-printed JSON value.
    */
-  final def pretty(json: Json): String = {
+  final def print(json: Json): String = {
     val writer = if (reuseWriters && stringWriter.ne(null)) {
       val w = stringWriter.get()
       w.setLength(0)
@@ -196,6 +196,12 @@ final case class Printer(
     writer.toString
   }
 
+  /**
+   * Returns a string representation of a pretty-printed JSON value.
+   */
+  @deprecated("Use print", "0.12.0")
+  final def pretty(json: Json): String = pretty(json)
+
   @transient
   private[this] final val sizePredictor: ThreadLocal[Printer.SizePredictor] =
     new ThreadLocal[Printer.SizePredictor] {
@@ -203,7 +209,7 @@ final case class Printer(
         new Printer.AdaptiveSizePredictor()
     }
 
-  final def prettyByteBuffer(json: Json, cs: Charset): ByteBuffer = {
+  final def printToByteBuffer(json: Json, cs: Charset): ByteBuffer = {
     val predictor =
       if (predictSize && sizePredictor.ne(null)) sizePredictor.get()
       else Printer.NoSizePredictor
@@ -216,8 +222,13 @@ final case class Printer(
     writer.toByteBuffer
   }
 
-  final def prettyByteBuffer(json: Json): ByteBuffer =
-    prettyByteBuffer(json, StandardCharsets.UTF_8)
+  final def printToByteBuffer(json: Json): ByteBuffer =
+    printToByteBuffer(json, StandardCharsets.UTF_8)
+  @deprecated("Use printToByteBuffer", "0.12.0")
+  final def prettyByteBuffer(json: Json, cs: Charset): ByteBuffer = printToByteBuffer(json)
+
+  @deprecated("Use printToByteBuffer", "0.12.0")
+  final def prettyByteBuffer(json: Json): ByteBuffer = printToByteBuffer(json)
 
   /**
    * The same pretty-printer configuration that outputs fields in sorted order.

--- a/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
@@ -14,7 +14,7 @@ trait PrinterLaws[A] {
   def encode: Encoder[A]
 
   def printerRoundTrip(printer: Printer, parser: Parser, a: A): IsEq[Option[A]] =
-    parser.decode(printer.pretty(encode(a)))(decode).toOption <-> Some(a)
+    parser.decode(printer.print(encode(a)))(decode).toOption <-> Some(a)
 }
 
 object PrinterLaws {

--- a/modules/tests/jvm/src/test/scala/io/circe/PrinterWriterReuseSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/PrinterWriterReuseSuite.scala
@@ -13,12 +13,12 @@ class PrinterWriterReuseSuite extends CirceSuite with ScalaFutures {
     sizeRange = 100
   )
 
-  "Printer#reuseWriters" should "not change the behavior of pretty" in forAll { (values: List[Json]) =>
+  "Printer#reuseWriters" should "not change the behavior of print" in forAll { (values: List[Json]) =>
     val default = Printer.spaces4
     val reusing = default.copy(reuseWriters = true)
-    val expected = values.map(default.pretty)
+    val expected = values.map(default.print)
 
-    whenReady(Future.traverse(values)(value => Future(reusing.pretty(value)))) { result =>
+    whenReady(Future.traverse(values)(value => Future(reusing.print(value)))) { result =>
       assert(result === expected)
     }
   }

--- a/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala
@@ -22,7 +22,7 @@ trait Spaces2PrinterExample { this: Spaces2PrinterSuite =>
   source.close()
 
   "Printer.spaces2" should "generate the expected output for the example doc" in {
-    val printed = Printer.spaces2.pretty(doc) + "\n"
+    val printed = Printer.spaces2.print(doc) + "\n"
 
     assert(printed === expected)
   }

--- a/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -14,14 +14,14 @@ class PrinterSuite(val printer: Printer, val parser: Parser) extends CirceSuite 
   checkLaws("Printing Int", PrinterTests[Int].printer(printer, parser))
   checkLaws("Printing Map", PrinterTests[Map[String, List[Int]]].printer(printer, parser))
 
-  "prettyByteBuffer" should "match pretty" in forAll { (json: Json, predictSize: Boolean) =>
-    val buffer = printer.copy(predictSize = predictSize).prettyByteBuffer(json)
+  "printToByteBuffer" should "match print" in forAll { (json: Json, predictSize: Boolean) =>
+    val buffer = printer.copy(predictSize = predictSize).printToByteBuffer(json)
 
     val bytes = new Array[Byte](buffer.limit)
     buffer.get(bytes)
 
     val asString = new String(bytes, UTF_8)
-    val expected = printer.pretty(json)
+    val expected = printer.print(json)
 
     assert(asString === expected)
   }

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -231,11 +231,11 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
   }
 
   "printer shortcuts" should "print the object" in forAll { (json: Json) =>
-    assert(json.noSpaces === Printer.noSpaces.pretty(json))
-    assert(json.spaces2 === Printer.spaces2.pretty(json))
-    assert(json.spaces4 === Printer.spaces4.pretty(json))
-    assert(json.noSpacesSortKeys === Printer.noSpacesSortKeys.pretty(json))
-    assert(json.spaces2SortKeys === Printer.spaces2SortKeys.pretty(json))
-    assert(json.spaces4SortKeys === Printer.spaces4SortKeys.pretty(json))
+    assert(json.noSpaces === Printer.noSpaces.print(json))
+    assert(json.spaces2 === Printer.spaces2.print(json))
+    assert(json.spaces4 === Printer.spaces4.print(json))
+    assert(json.noSpacesSortKeys === Printer.noSpacesSortKeys.print(json))
+    assert(json.spaces2SortKeys === Printer.spaces2SortKeys.print(json))
+    assert(json.spaces4SortKeys === Printer.spaces4SortKeys.print(json))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -8,7 +8,7 @@ class NoSpacesPrinterSuite extends PrinterSuite(Printer.noSpaces, parser.`packag
 class UnicodeEscapePrinterSuite extends PrinterSuite(Printer.noSpaces.copy(escapeNonAscii = true), parser.`package`) {
   import io.circe.syntax._
   "Printing object" should "unicode-escape all non-ASCII chars" in {
-    val actual = Json.obj("0 ℃" := "32 ℉").pretty(printer)
+    val actual = Json.obj("0 ℃" := "32 ℉").print(printer)
     val expected = "{\"0 \\u2103\":\"32 \\u2109\"}"
     assert(actual === expected)
   }

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -8,7 +8,7 @@ class NoSpacesPrinterSuite extends PrinterSuite(Printer.noSpaces, parser.`packag
 class UnicodeEscapePrinterSuite extends PrinterSuite(Printer.noSpaces.copy(escapeNonAscii = true), parser.`package`) {
   import io.circe.syntax._
   "Printing object" should "unicode-escape all non-ASCII chars" in {
-    val actual = Json.obj("0 ℃" := "32 ℉").print(printer)
+    val actual = Json.obj("0 ℃" := "32 ℉").printWith(printer)
     val expected = "{\"0 \\u2103\":\"32 \\u2109\"}"
     assert(actual === expected)
   }

--- a/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
@@ -11,7 +11,7 @@ trait SortedKeysSuite { this: PrinterSuite =>
       "three" -> Json.fromInt(3)
     )
 
-    parser.parse(printer.pretty(input)).toOption.flatMap(_.asObject) match {
+    parser.parse(printer.print(input)).toOption.flatMap(_.asObject) match {
       case None => fail("Cannot parse result back to an object")
       case Some(output) =>
         assert(output.keys.toList === List("one", "three", "two"))
@@ -20,7 +20,7 @@ trait SortedKeysSuite { this: PrinterSuite =>
 
   "Printer with sortKeys" should "sort the object keys" in {
     Checkers.check(Prop.forAll { value: Map[String, List[Int]] =>
-      val printed = printer.pretty(implicitly[Encoder[Map[String, List[Int]]]].apply(value))
+      val printed = printer.print(implicitly[Encoder[Map[String, List[Int]]]].apply(value))
       val parsed = parser.parse(printed).toOption.flatMap(_.asObject).get
       val keys = parsed.keys.toVector
       keys.sorted === keys


### PR DESCRIPTION
This is one more piece of Argonaut legacy that I've wanted to fix for a while, and I decided we might as well get it into 0.12.0.

The name `pretty` here (and the terminology of _pretty-printing_) isn't really accurate, since you could in theory have an obfuscating printer, and even `noSpaces` for example doesn't really seem to count as a pretty printer. `print` seems much clearer.