### PR TITLE
Accumulation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target/
 .classpath
 tmp/
 docs/src/main/tut/contributing.md
+.metals
+.bloop

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -158,7 +158,7 @@ trait Decoder[A] extends Serializable { self =>
       case r @ Right(_) => r
       case Left(e)      => e match {
         case e: SingleDecodingFailure => Left(e.withMessage(message))
-        case e: AggregatedDecodingFailure => Left(e.withMessage(message)) // Not sure I like this
+        case e: AggregatedDecodingFailure => Left(e.withMessage(message))
       }
     }
 

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -156,18 +156,25 @@ trait Decoder[A] extends Serializable { self =>
   final def withErrorMessage(message: String): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] = self(c) match {
       case r @ Right(_) => r
-      case Left(e)      => e match {
-        case e: SingleDecodingFailure => Left(e.withMessage(message))
-        case e: AggregatedDecodingFailure => Left(e.withMessage(message))
-      }
+      case Left(e) =>
+        e match {
+          case e: SingleDecodingFailure     => Left(e.withMessage(message))
+          case e: AggregatedDecodingFailure => Left(e.withMessage(message))
+        }
     }
 
     override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
-      self.decodeAccumulating(c).leftMap(_.map( e => e match {
-        case e: SingleDecodingFailure => e.withMessage(message)
-        case e: AggregatedDecodingFailure => e.withMessage(message)
-      }
-      ))
+      self
+        .decodeAccumulating(c)
+        .leftMap(
+          _.map(
+            e =>
+              e match {
+                case e: SingleDecodingFailure     => e.withMessage(message)
+                case e: AggregatedDecodingFailure => e.withMessage(message)
+              }
+          )
+        )
   }
 
   /**

--- a/modules/core/shared/src/main/scala/io/circe/Error.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Error.scala
@@ -61,7 +61,7 @@ sealed abstract class SingleDecodingFailure(val message: String) extends Decodin
 
   final def withMessage(message: String): SingleDecodingFailure = copy(message = message)
 
-  override final def toString: String = s"SingleDecodingFailure($message, $history)"
+  override final def toString: String = s"DecodingFailure($message, $history)"
   override final def equals(that: Any): Boolean = that match {
     case other: DecodingFailure => DecodingFailure.eqDecodingFailure.eqv(this, other)
     case _                      => false
@@ -129,7 +129,7 @@ object DecodingFailure {
   implicit final val showDecodingFailure: Show[DecodingFailure] = Show.show { 
     case e: SingleDecodingFailure =>
       val path = CursorOp.opsToPath(e.history)
-      s"SingleDecodingFailure at ${path}: ${e.message}"
+      s"DecodingFailure at ${path}: ${e.message}"
     case e: AggregatedDecodingFailure => 
       s"AggregatedDecodingFailure: ${e.message}"
   }

--- a/modules/core/shared/src/main/scala/io/circe/Error.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Error.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.{ Eq, Show }
+import cats.{ Eq, Show, Semigroup}
 import cats.data.NonEmptyList
 
 /**
@@ -42,22 +42,26 @@ object ParsingFailure {
  * An exception representing a decoding failure and (lazily) capturing the
  * decoding history resulting in the failure.
  */
-sealed abstract class DecodingFailure(val message: String) extends Error {
+sealed trait DecodingFailure extends Error{
+  val message : String
+}
+
+sealed abstract class SingleDecodingFailure(val message: String) extends DecodingFailure {
   def history: List[CursorOp]
 
   final override def getMessage: String =
     if (history.isEmpty) message else s"$message: ${history.mkString(",")}"
 
-  final def copy(message: String = message, history: => List[CursorOp] = history): DecodingFailure = {
+  final def copy(message: String = message, history: => List[CursorOp] = history): SingleDecodingFailure = {
     def newHistory = history
-    new DecodingFailure(message) {
+    new SingleDecodingFailure(message) {
       final lazy val history: List[CursorOp] = newHistory
     }
   }
 
-  final def withMessage(message: String): DecodingFailure = copy(message = message)
+  final def withMessage(message: String): SingleDecodingFailure = copy(message = message)
 
-  override final def toString: String = s"DecodingFailure($message, $history)"
+  override final def toString: String = s"SingleDecodingFailure($message, $history)"
   override final def equals(that: Any): Boolean = that match {
     case other: DecodingFailure => DecodingFailure.eqDecodingFailure.eqv(this, other)
     case _                      => false
@@ -65,15 +69,38 @@ sealed abstract class DecodingFailure(val message: String) extends Error {
   override final def hashCode: Int = message.hashCode
 }
 
+object SingleDecodingFailure {
+  def unapply(error: Error): Option[(String, List[CursorOp])] = error match {
+      case ParsingFailure(_, _)   => None
+      case _ : AggregatedDecodingFailure => None
+      case other: SingleDecodingFailure => Some((other.message, other.history))
+    }
+}
+
+sealed abstract class AggregatedDecodingFailure(val failures: NonEmptyList[DecodingFailure], val optionalMessage: Option[String]) extends DecodingFailure{
+
+  val message = optionalMessage.getOrElse(s"${failures.map(_.message)}")
+
+  final def withMessage(message: String): AggregatedDecodingFailure = new AggregatedDecodingFailure(
+      failures, Some(message)
+  ){}
+}
+
+object AggregatedDecodingFailure {
+  def unapply(error: Error): Option[NonEmptyList[DecodingFailure]] = error match {
+      case ParsingFailure(_, _)   => None
+      case _ : SingleDecodingFailure => None
+      case other: AggregatedDecodingFailure => Some(other.failures)
+    }
+}
+
 object DecodingFailure {
-  def apply(message: String, ops: => List[CursorOp]): DecodingFailure = new DecodingFailure(message) {
+  def apply(message: String, ops: => List[CursorOp]): DecodingFailure = new SingleDecodingFailure(message) {
     final lazy val history: List[CursorOp] = ops
   }
 
-  def unapply(error: Error): Option[(String, List[CursorOp])] = error match {
-    case ParsingFailure(_, _)   => None
-    case other: DecodingFailure => Some((other.message, other.history))
-  }
+  def combine(x: DecodingFailure, y: DecodingFailure): DecodingFailure = 
+    new AggregatedDecodingFailure(NonEmptyList.of(x, y), None){}
 
   def fromThrowable(t: Throwable, ops: => List[CursorOp]): DecodingFailure = t match {
     case (d: DecodingFailure) => d
@@ -85,16 +112,26 @@ object DecodingFailure {
   }
 
   implicit final val eqDecodingFailure: Eq[DecodingFailure] = Eq.instance {
-    case (DecodingFailure(m1, h1), DecodingFailure(m2, h2)) => m1 == m2 && CursorOp.eqCursorOpList.eqv(h1, h2)
+    case (SingleDecodingFailure(m1, h1), SingleDecodingFailure(m2, h2)) => m1 == m2 && CursorOp.eqCursorOpList.eqv(h1, h2)
+    case (AggregatedDecodingFailure(e1), AggregatedDecodingFailure(e2)) => e1 == e2
+    case (_, _) => false
+  }
+
+  implicit val semigroupDecodingFailure: Semigroup[DecodingFailure] = new Semigroup[DecodingFailure]{
+    def combine(x: DecodingFailure, y: DecodingFailure): DecodingFailure = 
+      DecodingFailure.combine(x,y)
   }
 
   /**
    * Creates compact, human readable string representations for DecodingFailure
    * Cursor history is represented as JS style selections, i.e. ".foo.bar[3]"
    */
-  implicit final val showDecodingFailure: Show[DecodingFailure] = Show.show { failure =>
-    val path = CursorOp.opsToPath(failure.history)
-    s"DecodingFailure at ${path}: ${failure.message}"
+  implicit final val showDecodingFailure: Show[DecodingFailure] = Show.show { 
+    case e: SingleDecodingFailure =>
+      val path = CursorOp.opsToPath(e.history)
+      s"SingleDecodingFailure at ${path}: ${e.message}"
+    case e: AggregatedDecodingFailure => 
+      s"AggregatedDecodingFailure: ${e.message}"
   }
 
 }

--- a/modules/tests/shared/src/test/scala/io/circe/AccumulatingDecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/AccumulatingDecoderSuite.scala
@@ -104,4 +104,4 @@ class AccumulatingDecoderSpec extends CirceSuite {
   }
 
 }
-*/
+ */

--- a/modules/tests/shared/src/test/scala/io/circe/AccumulatingDecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/AccumulatingDecoderSuite.scala
@@ -1,3 +1,4 @@
+/*
 package io.circe
 
 import cats.data.NonEmptyList
@@ -103,3 +104,4 @@ class AccumulatingDecoderSpec extends CirceSuite {
   }
 
 }
+*/

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -4,7 +4,7 @@ import cats.data.Validated.Invalid
 import cats.data.{ Chain, NonEmptyList, Validated }
 import cats.kernel.Eq
 import cats.laws.discipline.{ MonadErrorTests, SemigroupKTests }
-import io.circe.CursorOp.{ DownArray, DownN }
+import io.circe.CursorOp.{ DownArray, DownN, DownField }
 import io.circe.parser.parse
 import io.circe.syntax._
 import io.circe.testing.CodecTests
@@ -593,7 +593,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
   "HCursor#history" should "be stack safe" in {
     val size = 10000
     val json = List.fill(size)(1).asJson.mapArray(_ :+ true.asJson)
-    val Left(DecodingFailure(_, history)) = Decoder[List[Int]].decodeJson(json)
+    val Left(SingleDecodingFailure(_, history)) = Decoder[List[Int]].decodeJson(json)
 
     assert(history.size === size + 1)
   }
@@ -605,5 +605,32 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     decoder =>
       val json = Json.arr(Json.obj("a" -> 1.asJson))
       assert(decoder.decodeJson(json) == Left(DecodingFailure("Some message", List(DownArray))))
+  }
+
+
+
+  "parallel decoding" should "decode multiple errors" in {
+    import cats.Show
+    import cats.syntax.show._
+    final case class Foo(a: String, j: String, bar: Int)
+    implicit val fooShow = Show.fromToString[Foo]
+    implicit val fooEq = Eq.fromUniversalEquals[Foo]
+    implicit val decoderFoo = new Decoder[Foo]{
+      def apply(c: HCursor): Decoder.Result[Foo] = 
+        (
+          c.downField("a").as[String],
+          c.downField("j").as[String],
+          c.downField("bar").as[Int],
+        ).parMapN(Foo(_, _, _))
+    }
+    val json = Json.obj(
+      "j" -> Json.fromString("yellow")
+    )
+    val expected = DecodingFailure.combine(
+      DecodingFailure("Attempt to decode value on failed cursor", List(DownField("a"))),
+      DecodingFailure("Attempt to decode value on failed cursor", List(DownField("bar")))
+    )
+    val test = decoderFoo.decodeJson(json)
+    test === Left(expected)
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -4,7 +4,7 @@ import cats.data.Validated.Invalid
 import cats.data.{ Chain, NonEmptyList, Validated }
 import cats.kernel.Eq
 import cats.laws.discipline.{ MonadErrorTests, SemigroupKTests }
-import io.circe.CursorOp.{ DownArray, DownN, DownField }
+import io.circe.CursorOp.{ DownArray, DownField, DownN }
 import io.circe.parser.parse
 import io.circe.syntax._
 import io.circe.testing.CodecTests
@@ -607,20 +607,18 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
       assert(decoder.decodeJson(json) == Left(DecodingFailure("Some message", List(DownArray))))
   }
 
-
-
   "parallel decoding" should "decode multiple errors" in {
     import cats.Show
     import cats.syntax.show._
     final case class Foo(a: String, j: String, bar: Int)
     implicit val fooShow = Show.fromToString[Foo]
     implicit val fooEq = Eq.fromUniversalEquals[Foo]
-    implicit val decoderFoo = new Decoder[Foo]{
-      def apply(c: HCursor): Decoder.Result[Foo] = 
+    implicit val decoderFoo = new Decoder[Foo] {
+      def apply(c: HCursor): Decoder.Result[Foo] =
         (
           c.downField("a").as[String],
           c.downField("j").as[String],
-          c.downField("bar").as[Int],
+          c.downField("bar").as[Int]
         ).parMapN(Foo(_, _, _))
     }
     val json = Json.obj(


### PR DESCRIPTION
A conjecture of an approach, I suspect most of the accumulator code can instead be removed and rewritten in terms of this mechanic. 

Needs a bit more of the replication of a case class machinery that the SingleDecodingFailure has, but as you can see in the added test, makes it very easy to do error accumulation.