### PR TITLE
Make some instances lazy for Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,7 @@ lazy val circeCrossModules = Seq[(Project, Project)](
   (hygiene, hygieneJS)
 )
 
-lazy val circeJsModules = Seq[Project](scalajs)
+lazy val circeJsModules = Seq[Project](scalajs, scalajsJavaTimeTest)
 lazy val circeJvmModules = Seq[Project](benchmark, jawn)
 lazy val circeDocsModules = Seq[Project](docs)
 
@@ -395,6 +395,15 @@ lazy val parser = parserBase.jvm
 lazy val parserJS = parserBase.js
 
 lazy val scalajs = circeModule("scalajs", mima = None).enablePlugins(ScalaJSPlugin).dependsOn(coreJS)
+lazy val scalajsJavaTimeTest = circeModule("scalajs-java-time-test", mima = None)
+  .enablePlugins(ScalaJSPlugin)
+  .settings(noPublishSettings: _*)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
+    )
+  )
+  .dependsOn(coreJS)
 
 lazy val scodecBase = circeCrossModule("scodec", mima = previousCirceVersion)
   .settings(

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -631,7 +631,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final lazy val decodeFloat: Decoder[Float] = new DecoderWithFailure[Float]("Float") {
+  implicit final val decodeFloat: Decoder[Float] = new DecoderWithFailure[Float]("Float") {
     final def apply(c: HCursor): Result[Float] = c.value match {
       case Json.JNumber(number) => Right(number.toFloat)
       case Json.JString(string) =>
@@ -687,7 +687,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final lazy val decodeByte: Decoder[Byte] = new DecoderWithFailure[Byte]("Byte") {
+  implicit final val decodeByte: Decoder[Byte] = new DecoderWithFailure[Byte]("Byte") {
     final def apply(c: HCursor): Result[Byte] = c.value match {
       case Json.JNumber(number) =>
         number.toByte match {
@@ -717,7 +717,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final lazy val decodeShort: Decoder[Short] = new DecoderWithFailure[Short]("Short") {
+  implicit final val decodeShort: Decoder[Short] = new DecoderWithFailure[Short]("Short") {
     final def apply(c: HCursor): Result[Short] = c.value match {
       case Json.JNumber(number) =>
         number.toShort match {
@@ -813,7 +813,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final lazy val decodeBigInt: Decoder[BigInt] = new DecoderWithFailure[BigInt]("BigInt") {
+  implicit final val decodeBigInt: Decoder[BigInt] = new DecoderWithFailure[BigInt]("BigInt") {
     final def apply(c: HCursor): Result[BigInt] = c.value match {
       case Json.JNumber(number) =>
         number.toBigInt match {
@@ -849,7 +849,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final lazy val decodeBigDecimal: Decoder[BigDecimal] = new DecoderWithFailure[BigDecimal]("BigDecimal") {
+  implicit final val decodeBigDecimal: Decoder[BigDecimal] = new DecoderWithFailure[BigDecimal]("BigDecimal") {
     final def apply(c: HCursor): Result[BigDecimal] = c.value match {
       case Json.JNumber(number) =>
         number.toBigDecimal match {
@@ -937,7 +937,7 @@ object Decoder
   /**
    * @group Decoding
    */
-  implicit final lazy val decodeNone: Decoder[None.type] = new Decoder[None.type] {
+  implicit final val decodeNone: Decoder[None.type] = new Decoder[None.type] {
     final def apply(c: HCursor): Result[None.type] = if (c.value.isNull) Right(None)
     else {
       Left(DecodingFailure("None", c.history))
@@ -1363,7 +1363,7 @@ object Decoder
   /**
    * @group Instances
    */
-  implicit final lazy val decoderInstances: SemigroupK[Decoder] with MonadError[Decoder, DecodingFailure] =
+  implicit final val decoderInstances: SemigroupK[Decoder] with MonadError[Decoder, DecodingFailure] =
     new SemigroupK[Decoder] with MonadError[Decoder, DecodingFailure] {
       final def combineK[A](x: Decoder[A], y: Decoder[A]): Decoder[A] = x.or(y)
       final def pure[A](a: A): Decoder[A] = const(a)

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -604,7 +604,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaBoolean: Decoder[java.lang.Boolean] = decodeBoolean.map(java.lang.Boolean.valueOf)
+  implicit final lazy val decodeJavaBoolean: Decoder[java.lang.Boolean] = decodeBoolean.map(java.lang.Boolean.valueOf)
 
   /**
    * @group Decoding
@@ -621,7 +621,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaCharacter: Decoder[java.lang.Character] = decodeChar.map(java.lang.Character.valueOf)
+  implicit final lazy val decodeJavaCharacter: Decoder[java.lang.Character] = decodeChar.map(java.lang.Character.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Float]].
@@ -630,7 +630,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeFloat: Decoder[Float] = new DecoderWithFailure[Float]("Float") {
+  implicit final lazy val decodeFloat: Decoder[Float] = new DecoderWithFailure[Float]("Float") {
     final def apply(c: HCursor): Result[Float] = c.value match {
       case Json.JNumber(number) => Right(number.toFloat)
       case Json.JString(string) =>
@@ -648,7 +648,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaFloat: Decoder[java.lang.Float] = decodeFloat.map(java.lang.Float.valueOf)
+  implicit final lazy val decodeJavaFloat: Decoder[java.lang.Float] = decodeFloat.map(java.lang.Float.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Double]].
@@ -677,7 +677,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaDouble: Decoder[java.lang.Double] = decodeDouble.map(java.lang.Double.valueOf)
+  implicit final lazy val decodeJavaDouble: Decoder[java.lang.Double] = decodeDouble.map(java.lang.Double.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Byte]].
@@ -686,7 +686,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeByte: Decoder[Byte] = new DecoderWithFailure[Byte]("Byte") {
+  implicit final lazy val decodeByte: Decoder[Byte] = new DecoderWithFailure[Byte]("Byte") {
     final def apply(c: HCursor): Result[Byte] = c.value match {
       case Json.JNumber(number) =>
         number.toByte match {
@@ -707,7 +707,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaByte: Decoder[java.lang.Byte] = decodeByte.map(java.lang.Byte.valueOf)
+  implicit final lazy val decodeJavaByte: Decoder[java.lang.Byte] = decodeByte.map(java.lang.Byte.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Short]].
@@ -716,7 +716,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeShort: Decoder[Short] = new DecoderWithFailure[Short]("Short") {
+  implicit final lazy val decodeShort: Decoder[Short] = new DecoderWithFailure[Short]("Short") {
     final def apply(c: HCursor): Result[Short] = c.value match {
       case Json.JNumber(number) =>
         number.toShort match {
@@ -737,7 +737,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaShort: Decoder[java.lang.Short] = decodeShort.map(java.lang.Short.valueOf)
+  implicit final lazy val decodeJavaShort: Decoder[java.lang.Short] = decodeShort.map(java.lang.Short.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Int]].
@@ -767,7 +767,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaInteger: Decoder[java.lang.Integer] = decodeInt.map(java.lang.Integer.valueOf)
+  implicit final lazy val decodeJavaInteger: Decoder[java.lang.Integer] = decodeInt.map(java.lang.Integer.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Long]].
@@ -800,7 +800,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaLong: Decoder[java.lang.Long] = decodeLong.map(java.lang.Long.valueOf)
+  implicit final lazy val decodeJavaLong: Decoder[java.lang.Long] = decodeLong.map(java.lang.Long.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.math.BigInt]].
@@ -812,7 +812,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeBigInt: Decoder[BigInt] = new DecoderWithFailure[BigInt]("BigInt") {
+  implicit final lazy val decodeBigInt: Decoder[BigInt] = new DecoderWithFailure[BigInt]("BigInt") {
     final def apply(c: HCursor): Result[BigInt] = c.value match {
       case Json.JNumber(number) =>
         number.toBigInt match {
@@ -833,7 +833,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaBigInteger: Decoder[java.math.BigInteger] = decodeBigInt.map(_.bigInteger)
+  implicit final lazy val decodeJavaBigInteger: Decoder[java.math.BigInteger] = decodeBigInt.map(_.bigInteger)
 
   /**
    * Decode a JSON value into a [[scala.math.BigDecimal]].
@@ -848,7 +848,7 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeBigDecimal: Decoder[BigDecimal] = new DecoderWithFailure[BigDecimal]("BigDecimal") {
+  implicit final lazy val decodeBigDecimal: Decoder[BigDecimal] = new DecoderWithFailure[BigDecimal]("BigDecimal") {
     final def apply(c: HCursor): Result[BigDecimal] = c.value match {
       case Json.JNumber(number) =>
         number.toBigDecimal match {
@@ -869,12 +869,12 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final val decodeJavaBigDecimal: Decoder[java.math.BigDecimal] = decodeBigDecimal.map(_.bigDecimal)
+  implicit final lazy val decodeJavaBigDecimal: Decoder[java.math.BigDecimal] = decodeBigDecimal.map(_.bigDecimal)
 
   /**
    * @group Decoding
    */
-  implicit final val decodeUUID: Decoder[UUID] = new Decoder[UUID] {
+  implicit final lazy val decodeUUID: Decoder[UUID] = new Decoder[UUID] {
     private[this] def fail(c: HCursor): Result[UUID] = Left(DecodingFailure("UUID", c.history))
 
     final def apply(c: HCursor): Result[UUID] = c.value match {
@@ -936,7 +936,7 @@ object Decoder
   /**
    * @group Decoding
    */
-  implicit final val decodeNone: Decoder[None.type] = new Decoder[None.type] {
+  implicit final lazy val decodeNone: Decoder[None.type] = new Decoder[None.type] {
     final def apply(c: HCursor): Result[None.type] = if (c.value.isNull) Right(None)
     else {
       Left(DecodingFailure("None", c.history))
@@ -1141,7 +1141,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeDuration: Decoder[Duration] =
+  implicit final lazy val decodeDuration: Decoder[Duration] =
     new JavaTimeDecoder[Duration]("Duration") {
       protected[this] final def parseUnsafe(input: String): Duration = Duration.parse(input)
 
@@ -1154,7 +1154,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeInstant: Decoder[Instant] =
+  implicit final lazy val decodeInstant: Decoder[Instant] =
     new StandardJavaTimeDecoder[Instant]("Instant") {
       protected[this] final def parseUnsafe(input: String): Instant = Instant.parse(input)
     }
@@ -1162,7 +1162,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodePeriod: Decoder[Period] =
+  implicit final lazy val decodePeriod: Decoder[Period] =
     new JavaTimeDecoder[Period]("Period") {
       protected[this] final def parseUnsafe(input: String): Period = Period.parse(input)
 
@@ -1175,7 +1175,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeZoneId: Decoder[ZoneId] =
+  implicit final lazy val decodeZoneId: Decoder[ZoneId] =
     new StandardJavaTimeDecoder[ZoneId]("ZoneId") {
       protected[this] final def parseUnsafe(input: String): ZoneId = ZoneId.of(input)
     }
@@ -1273,7 +1273,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeLocalDate: Decoder[LocalDate] =
+  implicit final lazy val decodeLocalDate: Decoder[LocalDate] =
     new StandardJavaTimeDecoder[LocalDate]("LocalDate") {
       protected[this] final def parseUnsafe(input: String): LocalDate =
         LocalDate.parse(input, ISO_LOCAL_DATE)
@@ -1282,7 +1282,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeLocalTime: Decoder[LocalTime] =
+  implicit final lazy val decodeLocalTime: Decoder[LocalTime] =
     new StandardJavaTimeDecoder[LocalTime]("LocalTime") {
       protected[this] final def parseUnsafe(input: String): LocalTime =
         LocalTime.parse(input, ISO_LOCAL_TIME)
@@ -1291,7 +1291,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeLocalDateTime: Decoder[LocalDateTime] =
+  implicit final lazy val decodeLocalDateTime: Decoder[LocalDateTime] =
     new StandardJavaTimeDecoder[LocalDateTime]("LocalDateTime") {
       protected[this] final def parseUnsafe(input: String): LocalDateTime =
         LocalDateTime.parse(input, ISO_LOCAL_DATE_TIME)
@@ -1300,7 +1300,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeMonthDay: Decoder[MonthDay] =
+  implicit final lazy val decodeMonthDay: Decoder[MonthDay] =
     new StandardJavaTimeDecoder[MonthDay]("MonthDay") {
       protected[this] final def parseUnsafe(input: String): MonthDay =
         MonthDay.parse(input)
@@ -1309,7 +1309,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeOffsetTime: Decoder[OffsetTime] =
+  implicit final lazy val decodeOffsetTime: Decoder[OffsetTime] =
     new StandardJavaTimeDecoder[OffsetTime]("OffsetTime") {
       protected[this] final def parseUnsafe(input: String): OffsetTime =
         OffsetTime.parse(input, ISO_OFFSET_TIME)
@@ -1318,7 +1318,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeOffsetDateTime: Decoder[OffsetDateTime] =
+  implicit final lazy val decodeOffsetDateTime: Decoder[OffsetDateTime] =
     new StandardJavaTimeDecoder[OffsetDateTime]("OffsetDateTime") {
       protected[this] final def parseUnsafe(input: String): OffsetDateTime =
         OffsetDateTime.parse(input, ISO_OFFSET_DATE_TIME)
@@ -1327,7 +1327,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeYear: Decoder[Year] =
+  implicit final lazy val decodeYear: Decoder[Year] =
     new StandardJavaTimeDecoder[Year]("Year") {
       protected[this] final def parseUnsafe(input: String): Year =
         Year.parse(input)
@@ -1336,7 +1336,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeYearMonth: Decoder[YearMonth] =
+  implicit final lazy val decodeYearMonth: Decoder[YearMonth] =
     new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
       protected[this] final def parseUnsafe(input: String): YearMonth =
         YearMonth.parse(input)
@@ -1345,7 +1345,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeZonedDateTime: Decoder[ZonedDateTime] =
+  implicit final lazy val decodeZonedDateTime: Decoder[ZonedDateTime] =
     new StandardJavaTimeDecoder[ZonedDateTime]("ZonedDateTime") {
       protected[this] final def parseUnsafe(input: String): ZonedDateTime =
         ZonedDateTime.parse(input, ISO_ZONED_DATE_TIME)
@@ -1354,7 +1354,7 @@ object Decoder
   /**
    * @group Time
    */
-  implicit final val decodeZoneOffset: Decoder[ZoneOffset] =
+  implicit final lazy val decodeZoneOffset: Decoder[ZoneOffset] =
     new StandardJavaTimeDecoder[ZoneOffset]("ZoneOffset") {
       protected[this] final def parseUnsafe(input: String): ZoneOffset = ZoneOffset.of(input)
     }
@@ -1362,7 +1362,7 @@ object Decoder
   /**
    * @group Instances
    */
-  implicit final val decoderInstances: SemigroupK[Decoder] with MonadError[Decoder, DecodingFailure] =
+  implicit final lazy val decoderInstances: SemigroupK[Decoder] with MonadError[Decoder, DecodingFailure] =
     new SemigroupK[Decoder] with MonadError[Decoder, DecodingFailure] {
       final def combineK[A](x: Decoder[A], y: Decoder[A]): Decoder[A] = x.or(y)
       final def pure[A](a: A): Decoder[A] = const(a)

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -621,7 +621,8 @@ object Decoder
    *
    * @group Decoding
    */
-  implicit final lazy val decodeJavaCharacter: Decoder[java.lang.Character] = decodeChar.map(java.lang.Character.valueOf)
+  implicit final lazy val decodeJavaCharacter: Decoder[java.lang.Character] =
+    decodeChar.map(java.lang.Character.valueOf)
 
   /**
    * Decode a JSON value into a [[scala.Float]].

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -179,7 +179,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaBoolean: Encoder[java.lang.Boolean] = encodeBoolean.contramap(_.booleanValue())
+  implicit final lazy val encodeJavaBoolean: Encoder[java.lang.Boolean] = encodeBoolean.contramap(_.booleanValue())
 
   /**
    * @group Encoding
@@ -191,7 +191,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaCharacter: Encoder[java.lang.Character] = encodeChar.contramap(_.charValue())
+  implicit final lazy val encodeJavaCharacter: Encoder[java.lang.Character] = encodeChar.contramap(_.charValue())
 
   /**
    * Note that on Scala.js the encoding of `Float` values is subject to the
@@ -200,14 +200,14 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
    *
    * @group Encoding
    */
-  implicit final val encodeFloat: Encoder[Float] = new Encoder[Float] {
+  implicit final lazy val encodeFloat: Encoder[Float] = new Encoder[Float] {
     final def apply(a: Float): Json = Json.fromFloatOrNull(a)
   }
 
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaFloat: Encoder[java.lang.Float] = encodeFloat.contramap(_.floatValue())
+  implicit final lazy val encodeJavaFloat: Encoder[java.lang.Float] = encodeFloat.contramap(_.floatValue())
 
   /**
    * @group Encoding
@@ -219,31 +219,31 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaDouble: Encoder[java.lang.Double] = encodeDouble.contramap(_.doubleValue())
+  implicit final lazy val encodeJavaDouble: Encoder[java.lang.Double] = encodeDouble.contramap(_.doubleValue())
 
   /**
    * @group Encoding
    */
-  implicit final val encodeByte: Encoder[Byte] = new Encoder[Byte] {
+  implicit final lazy val encodeByte: Encoder[Byte] = new Encoder[Byte] {
     final def apply(a: Byte): Json = Json.fromInt(a.toInt)
   }
 
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaByte: Encoder[java.lang.Byte] = encodeByte.contramap(_.byteValue())
+  implicit final lazy val encodeJavaByte: Encoder[java.lang.Byte] = encodeByte.contramap(_.byteValue())
 
   /**
    * @group Encoding
    */
-  implicit final val encodeShort: Encoder[Short] = new Encoder[Short] {
+  implicit final lazy val encodeShort: Encoder[Short] = new Encoder[Short] {
     final def apply(a: Short): Json = Json.fromInt(a.toInt)
   }
 
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaShort: Encoder[java.lang.Short] = encodeShort.contramap(_.shortValue())
+  implicit final lazy val encodeJavaShort: Encoder[java.lang.Short] = encodeShort.contramap(_.shortValue())
 
   /**
    * @group Encoding
@@ -255,7 +255,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaInteger: Encoder[java.lang.Integer] = encodeInt.contramap(_.intValue())
+  implicit final lazy val encodeJavaInteger: Encoder[java.lang.Integer] = encodeInt.contramap(_.intValue())
 
   /**
    * @group Encoding
@@ -267,36 +267,36 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaLong: Encoder[java.lang.Long] = encodeLong.contramap(_.longValue())
+  implicit final lazy val encodeJavaLong: Encoder[java.lang.Long] = encodeLong.contramap(_.longValue())
 
   /**
    * @group Encoding
    */
-  implicit final val encodeBigInt: Encoder[BigInt] = new Encoder[BigInt] {
+  implicit final lazy val encodeBigInt: Encoder[BigInt] = new Encoder[BigInt] {
     final def apply(a: BigInt): Json = Json.fromBigInt(a)
   }
 
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaBigInteger: Encoder[java.math.BigInteger] = encodeBigInt.contramap(BigInt.apply)
+  implicit final lazy val encodeJavaBigInteger: Encoder[java.math.BigInteger] = encodeBigInt.contramap(BigInt.apply)
 
   /**
    * @group Encoding
    */
-  implicit final val encodeBigDecimal: Encoder[BigDecimal] = new Encoder[BigDecimal] {
+  implicit final lazy val encodeBigDecimal: Encoder[BigDecimal] = new Encoder[BigDecimal] {
     final def apply(a: BigDecimal): Json = Json.fromBigDecimal(a)
   }
 
   /**
    * @group Encoding
    */
-  implicit final val encodeJavaBigDecimal: Encoder[java.math.BigDecimal] = encodeBigDecimal.contramap(BigDecimal.apply)
+  implicit final lazy val encodeJavaBigDecimal: Encoder[java.math.BigDecimal] = encodeBigDecimal.contramap(BigDecimal.apply)
 
   /**
    * @group Encoding
    */
-  implicit final val encodeUUID: Encoder[UUID] = new Encoder[UUID] {
+  implicit final lazy val encodeUUID: Encoder[UUID] = new Encoder[UUID] {
     final def apply(a: UUID): Json = Json.fromString(a.toString)
   }
 
@@ -318,7 +318,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final val encodeNone: Encoder[None.type] = new Encoder[None.type] {
+  implicit final lazy val encodeNone: Encoder[None.type] = new Encoder[None.type] {
     final def apply(a: None.type): Json = Json.Null
   }
 
@@ -475,7 +475,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Instances
    */
-  implicit final val encoderContravariant: Contravariant[Encoder] = new Contravariant[Encoder] {
+  implicit final lazy val encoderContravariant: Contravariant[Encoder] = new Contravariant[Encoder] {
     final def contramap[A, B](e: Encoder[A])(f: B => A): Encoder[B] = e.contramap(f)
   }
 
@@ -534,28 +534,28 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final val encodeDuration: Encoder[Duration] = new Encoder[Duration] {
+  implicit final lazy val encodeDuration: Encoder[Duration] = new Encoder[Duration] {
     final def apply(a: Duration) = Json.fromString(a.toString)
   }
 
   /**
    * @group Time
    */
-  implicit final val encodeInstant: Encoder[Instant] = new Encoder[Instant] {
+  implicit final lazy val encodeInstant: Encoder[Instant] = new Encoder[Instant] {
     final def apply(a: Instant): Json = Json.fromString(a.toString)
   }
 
   /**
    * @group Time
    */
-  implicit final val encodePeriod: Encoder[Period] = new Encoder[Period] {
+  implicit final lazy val encodePeriod: Encoder[Period] = new Encoder[Period] {
     final def apply(a: Period): Json = Json.fromString(a.toString)
   }
 
   /**
    * @group Time
    */
-  implicit final val encodeZoneId: Encoder[ZoneId] = new Encoder[ZoneId] {
+  implicit final lazy val encodeZoneId: Encoder[ZoneId] = new Encoder[ZoneId] {
     final def apply(a: ZoneId): Json = Json.fromString(a.getId)
   }
 
@@ -642,7 +642,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final val encodeLocalDate: Encoder[LocalDate] =
+  implicit final lazy val encodeLocalDate: Encoder[LocalDate] =
     new JavaTimeEncoder[LocalDate] {
       protected[this] final def format: DateTimeFormatter = ISO_LOCAL_DATE
     }
@@ -650,7 +650,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final val encodeLocalTime: Encoder[LocalTime] =
+  implicit final lazy val encodeLocalTime: Encoder[LocalTime] =
     new JavaTimeEncoder[LocalTime] {
       protected[this] final def format: DateTimeFormatter = ISO_LOCAL_TIME
     }
@@ -658,7 +658,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final val encodeLocalDateTime: Encoder[LocalDateTime] =
+  implicit final lazy val encodeLocalDateTime: Encoder[LocalDateTime] =
     new JavaTimeEncoder[LocalDateTime] {
       protected[this] final def format: DateTimeFormatter = ISO_LOCAL_DATE_TIME
     }
@@ -666,14 +666,14 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final val encodeMonthDay: Encoder[MonthDay] = new Encoder[MonthDay] {
+  implicit final lazy val encodeMonthDay: Encoder[MonthDay] = new Encoder[MonthDay] {
     final def apply(a: MonthDay): Json = Json.fromString(a.toString)
   }
 
   /**
    * @group Time
    */
-  implicit final val encodeOffsetTime: Encoder[OffsetTime] =
+  implicit final lazy val encodeOffsetTime: Encoder[OffsetTime] =
     new JavaTimeEncoder[OffsetTime] {
       protected final def format: DateTimeFormatter = ISO_OFFSET_TIME
     }
@@ -681,7 +681,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final val encodeOffsetDateTime: Encoder[OffsetDateTime] =
+  implicit final lazy val encodeOffsetDateTime: Encoder[OffsetDateTime] =
     new JavaTimeEncoder[OffsetDateTime] {
       protected final def format: DateTimeFormatter = ISO_OFFSET_DATE_TIME
     }
@@ -689,21 +689,21 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final val encodeYear: Encoder[Year] = new Encoder[Year] {
+  implicit final lazy val encodeYear: Encoder[Year] = new Encoder[Year] {
     final def apply(a: Year): Json = Json.fromString(a.toString)
   }
 
   /**
    * @group Time
    */
-  implicit final val encodeYearMonth: Encoder[YearMonth] = new Encoder[YearMonth] {
+  implicit final lazy val encodeYearMonth: Encoder[YearMonth] = new Encoder[YearMonth] {
     final def apply(a: YearMonth): Json = Json.fromString(a.toString)
   }
 
   /**
    * @group Time
    */
-  implicit final val encodeZonedDateTime: Encoder[ZonedDateTime] =
+  implicit final lazy val encodeZonedDateTime: Encoder[ZonedDateTime] =
     new JavaTimeEncoder[ZonedDateTime] {
       protected final def format: DateTimeFormatter = ISO_ZONED_DATE_TIME
     }
@@ -711,7 +711,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final val encodeZoneOffset: Encoder[ZoneOffset] = new Encoder[ZoneOffset] {
+  implicit final lazy val encodeZoneOffset: Encoder[ZoneOffset] = new Encoder[ZoneOffset] {
     final def apply(a: ZoneOffset): Json = Json.fromString(a.toString)
   }
 
@@ -819,7 +819,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
     /**
      * @group Instances
      */
-    implicit final val arrayEncoderContravariant: Contravariant[AsArray] = new Contravariant[AsArray] {
+    implicit final lazy val arrayEncoderContravariant: Contravariant[AsArray] = new Contravariant[AsArray] {
       final def contramap[A, B](e: AsArray[A])(f: B => A): AsArray[B] = e.contramapArray(f)
     }
   }
@@ -899,7 +899,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
     /**
      * @group Instances
      */
-    implicit final val objectEncoderContravariant: Contravariant[AsObject] = new Contravariant[AsObject] {
+    implicit final lazy val objectEncoderContravariant: Contravariant[AsObject] = new Contravariant[AsObject] {
       final def contramap[A, B](e: AsObject[A])(f: B => A): AsObject[B] = e.contramapObject(f)
     }
   }

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -200,7 +200,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
    *
    * @group Encoding
    */
-  implicit final lazy val encodeFloat: Encoder[Float] = new Encoder[Float] {
+  implicit final val encodeFloat: Encoder[Float] = new Encoder[Float] {
     final def apply(a: Float): Json = Json.fromFloatOrNull(a)
   }
 
@@ -224,7 +224,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final lazy val encodeByte: Encoder[Byte] = new Encoder[Byte] {
+  implicit final val encodeByte: Encoder[Byte] = new Encoder[Byte] {
     final def apply(a: Byte): Json = Json.fromInt(a.toInt)
   }
 
@@ -236,7 +236,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final lazy val encodeShort: Encoder[Short] = new Encoder[Short] {
+  implicit final val encodeShort: Encoder[Short] = new Encoder[Short] {
     final def apply(a: Short): Json = Json.fromInt(a.toInt)
   }
 
@@ -272,7 +272,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final lazy val encodeBigInt: Encoder[BigInt] = new Encoder[BigInt] {
+  implicit final val encodeBigInt: Encoder[BigInt] = new Encoder[BigInt] {
     final def apply(a: BigInt): Json = Json.fromBigInt(a)
   }
 
@@ -284,7 +284,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final lazy val encodeBigDecimal: Encoder[BigDecimal] = new Encoder[BigDecimal] {
+  implicit final val encodeBigDecimal: Encoder[BigDecimal] = new Encoder[BigDecimal] {
     final def apply(a: BigDecimal): Json = Json.fromBigDecimal(a)
   }
 
@@ -319,7 +319,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final lazy val encodeNone: Encoder[None.type] = new Encoder[None.type] {
+  implicit final val encodeNone: Encoder[None.type] = new Encoder[None.type] {
     final def apply(a: None.type): Json = Json.Null
   }
 
@@ -476,7 +476,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Instances
    */
-  implicit final lazy val encoderContravariant: Contravariant[Encoder] = new Contravariant[Encoder] {
+  implicit final val encoderContravariant: Contravariant[Encoder] = new Contravariant[Encoder] {
     final def contramap[A, B](e: Encoder[A])(f: B => A): Encoder[B] = e.contramap(f)
   }
 
@@ -820,7 +820,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
     /**
      * @group Instances
      */
-    implicit final lazy val arrayEncoderContravariant: Contravariant[AsArray] = new Contravariant[AsArray] {
+    implicit final val arrayEncoderContravariant: Contravariant[AsArray] = new Contravariant[AsArray] {
       final def contramap[A, B](e: AsArray[A])(f: B => A): AsArray[B] = e.contramapArray(f)
     }
   }
@@ -900,7 +900,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
     /**
      * @group Instances
      */
-    implicit final lazy val objectEncoderContravariant: Contravariant[AsObject] = new Contravariant[AsObject] {
+    implicit final val objectEncoderContravariant: Contravariant[AsObject] = new Contravariant[AsObject] {
       final def contramap[A, B](e: AsObject[A])(f: B => A): AsObject[B] = e.contramapObject(f)
     }
   }

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -291,7 +291,8 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Encoding
    */
-  implicit final lazy val encodeJavaBigDecimal: Encoder[java.math.BigDecimal] = encodeBigDecimal.contramap(BigDecimal.apply)
+  implicit final lazy val encodeJavaBigDecimal: Encoder[java.math.BigDecimal] =
+    encodeBigDecimal.contramap(BigDecimal.apply)
 
   /**
    * @group Encoding

--- a/modules/scalajs-java-time-test/src/test/scala/io/circe/no_java_time/NoJavaTimeTest.scala
+++ b/modules/scalajs-java-time-test/src/test/scala/io/circe/no_java_time/NoJavaTimeTest.scala
@@ -1,0 +1,15 @@
+package io.circe.no_java_time
+
+import io.circe.{ Decoder, Encoder, Json }
+import org.scalatest.FunSuite
+
+class NoJavaTimeTest extends FunSuite {
+  test("Using Decoder should not throw linking errors") {
+    assert(Decoder[List[String]].decodeJson(Json.arr()) === Right(Nil))
+  }
+
+  test("Using Encoder should not throw linking errors") {
+    assert(Encoder[List[String]].apply(Nil) === Json.arr())
+  }
+}
+

--- a/modules/scalajs-java-time-test/src/test/scala/io/circe/no_java_time/NoJavaTimeTest.scala
+++ b/modules/scalajs-java-time-test/src/test/scala/io/circe/no_java_time/NoJavaTimeTest.scala
@@ -12,4 +12,3 @@ class NoJavaTimeTest extends FunSuite {
     assert(Encoder[List[String]].apply(Nil) === Json.arr())
   }
 }
-


### PR DESCRIPTION
Includes @japgolly's commits from #1246 but makes the non-Java stuff strict again and adds a simple test. I've verified that the tests fail if any of the `java.time` instances are made non-lazy.