### PR TITLE
~2x speed up in serialization of `java.time.*` instances by default encoders

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -36,14 +36,6 @@ import java.time.{
   ZonedDateTime
 }
 import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeFormatter.{
-  ISO_LOCAL_DATE,
-  ISO_LOCAL_DATE_TIME,
-  ISO_LOCAL_TIME,
-  ISO_OFFSET_DATE_TIME,
-  ISO_OFFSET_TIME,
-  ISO_ZONED_DATE_TIME
-}
 import java.util.UUID
 import scala.annotation.tailrec
 import scala.collection.immutable.{ Map => ImmutableMap, Set, SortedMap, SortedSet }
@@ -1267,8 +1259,7 @@ object Decoder
    */
   final def decodeZoneOffsetWithFormatter(formatter: DateTimeFormatter): Decoder[ZoneOffset] =
     new StandardJavaTimeDecoder[ZoneOffset]("ZoneOffset") {
-      protected[this] final def parseUnsafe(input: String): ZoneOffset =
-        ZoneOffset.of(input)
+      protected[this] final def parseUnsafe(input: String): ZoneOffset = ZoneOffset.of(input)
     }
 
   /**
@@ -1276,8 +1267,7 @@ object Decoder
    */
   implicit final lazy val decodeLocalDate: Decoder[LocalDate] =
     new StandardJavaTimeDecoder[LocalDate]("LocalDate") {
-      protected[this] final def parseUnsafe(input: String): LocalDate =
-        LocalDate.parse(input, ISO_LOCAL_DATE)
+      protected[this] final def parseUnsafe(input: String): LocalDate = LocalDate.parse(input)
     }
 
   /**
@@ -1285,8 +1275,7 @@ object Decoder
    */
   implicit final lazy val decodeLocalTime: Decoder[LocalTime] =
     new StandardJavaTimeDecoder[LocalTime]("LocalTime") {
-      protected[this] final def parseUnsafe(input: String): LocalTime =
-        LocalTime.parse(input, ISO_LOCAL_TIME)
+      protected[this] final def parseUnsafe(input: String): LocalTime = LocalTime.parse(input)
     }
 
   /**
@@ -1294,8 +1283,7 @@ object Decoder
    */
   implicit final lazy val decodeLocalDateTime: Decoder[LocalDateTime] =
     new StandardJavaTimeDecoder[LocalDateTime]("LocalDateTime") {
-      protected[this] final def parseUnsafe(input: String): LocalDateTime =
-        LocalDateTime.parse(input, ISO_LOCAL_DATE_TIME)
+      protected[this] final def parseUnsafe(input: String): LocalDateTime = LocalDateTime.parse(input)
     }
 
   /**
@@ -1303,8 +1291,7 @@ object Decoder
    */
   implicit final lazy val decodeMonthDay: Decoder[MonthDay] =
     new StandardJavaTimeDecoder[MonthDay]("MonthDay") {
-      protected[this] final def parseUnsafe(input: String): MonthDay =
-        MonthDay.parse(input)
+      protected[this] final def parseUnsafe(input: String): MonthDay = MonthDay.parse(input)
     }
 
   /**
@@ -1312,8 +1299,7 @@ object Decoder
    */
   implicit final lazy val decodeOffsetTime: Decoder[OffsetTime] =
     new StandardJavaTimeDecoder[OffsetTime]("OffsetTime") {
-      protected[this] final def parseUnsafe(input: String): OffsetTime =
-        OffsetTime.parse(input, ISO_OFFSET_TIME)
+      protected[this] final def parseUnsafe(input: String): OffsetTime = OffsetTime.parse(input)
     }
 
   /**
@@ -1321,8 +1307,7 @@ object Decoder
    */
   implicit final lazy val decodeOffsetDateTime: Decoder[OffsetDateTime] =
     new StandardJavaTimeDecoder[OffsetDateTime]("OffsetDateTime") {
-      protected[this] final def parseUnsafe(input: String): OffsetDateTime =
-        OffsetDateTime.parse(input, ISO_OFFSET_DATE_TIME)
+      protected[this] final def parseUnsafe(input: String): OffsetDateTime = OffsetDateTime.parse(input)
     }
 
   /**
@@ -1330,8 +1315,7 @@ object Decoder
    */
   implicit final lazy val decodeYear: Decoder[Year] =
     new StandardJavaTimeDecoder[Year]("Year") {
-      protected[this] final def parseUnsafe(input: String): Year =
-        Year.parse(input)
+      protected[this] final def parseUnsafe(input: String): Year = Year.parse(input)
     }
 
   /**
@@ -1339,8 +1323,7 @@ object Decoder
    */
   implicit final lazy val decodeYearMonth: Decoder[YearMonth] =
     new StandardJavaTimeDecoder[YearMonth]("YearMonth") {
-      protected[this] final def parseUnsafe(input: String): YearMonth =
-        YearMonth.parse(input)
+      protected[this] final def parseUnsafe(input: String): YearMonth = YearMonth.parse(input)
     }
 
   /**
@@ -1348,8 +1331,7 @@ object Decoder
    */
   implicit final lazy val decodeZonedDateTime: Decoder[ZonedDateTime] =
     new StandardJavaTimeDecoder[ZonedDateTime]("ZonedDateTime") {
-      protected[this] final def parseUnsafe(input: String): ZonedDateTime =
-        ZonedDateTime.parse(input, ISO_ZONED_DATE_TIME)
+      protected[this] final def parseUnsafe(input: String): ZonedDateTime = ZonedDateTime.parse(input)
     }
 
   /**

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -44,7 +44,7 @@ trait Encoder[A] extends Serializable { self =>
    * `A`.
    */
   final def contramap[B](f: B => A): Encoder[B] = new Encoder[B] {
-    final def apply(a: B) = self(f(a))
+    final def apply(a: B): Json = self(f(a))
   }
 
   /**
@@ -759,7 +759,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
      * an `A`.
      */
     final def contramapArray[B](f: B => A): AsArray[B] = new AsArray[B] {
-      final def encodeArray(a: B) = self.encodeArray(f(a))
+      final def encodeArray(a: B): Vector[Json] = self.encodeArray(f(a))
     }
 
     /**
@@ -839,7 +839,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
      * `A`.
      */
     final def contramapObject[B](f: B => A): AsObject[B] = new AsObject[B] {
-      final def encodeObject(a: B) = self.encodeObject(f(a))
+      final def encodeObject(a: B): JsonObject = self.encodeObject(f(a))
     }
 
     /**

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -21,14 +21,6 @@ import java.time.{
   ZonedDateTime
 }
 import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeFormatter.{
-  ISO_LOCAL_DATE,
-  ISO_LOCAL_DATE_TIME,
-  ISO_LOCAL_TIME,
-  ISO_OFFSET_DATE_TIME,
-  ISO_OFFSET_TIME,
-  ISO_ZONED_DATE_TIME
-}
 import java.time.temporal.TemporalAccessor
 import java.util.UUID
 import scala.Predef._
@@ -536,7 +528,7 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
    * @group Time
    */
   implicit final lazy val encodeDuration: Encoder[Duration] = new Encoder[Duration] {
-    final def apply(a: Duration) = Json.fromString(a.toString)
+    final def apply(a: Duration): Json = Json.fromString(a.toString)
   }
 
   /**
@@ -643,26 +635,23 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final lazy val encodeLocalDate: Encoder[LocalDate] =
-    new JavaTimeEncoder[LocalDate] {
-      protected[this] final def format: DateTimeFormatter = ISO_LOCAL_DATE
-    }
+  implicit final lazy val encodeLocalDate: Encoder[LocalDate] = new Encoder[LocalDate] {
+    final def apply(a: LocalDate): Json = Json.fromString(a.toString)
+  }
 
   /**
    * @group Time
    */
-  implicit final lazy val encodeLocalTime: Encoder[LocalTime] =
-    new JavaTimeEncoder[LocalTime] {
-      protected[this] final def format: DateTimeFormatter = ISO_LOCAL_TIME
-    }
+  implicit final lazy val encodeLocalTime: Encoder[LocalTime] = new Encoder[LocalTime] {
+    final def apply(a: LocalTime): Json = Json.fromString(a.toString)
+  }
 
   /**
    * @group Time
    */
-  implicit final lazy val encodeLocalDateTime: Encoder[LocalDateTime] =
-    new JavaTimeEncoder[LocalDateTime] {
-      protected[this] final def format: DateTimeFormatter = ISO_LOCAL_DATE_TIME
-    }
+  implicit final lazy val encodeLocalDateTime: Encoder[LocalDateTime] = new Encoder[LocalDateTime] {
+    final def apply(a: LocalDateTime): Json = Json.fromString(a.toString)
+  }
 
   /**
    * @group Time
@@ -674,18 +663,16 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final lazy val encodeOffsetTime: Encoder[OffsetTime] =
-    new JavaTimeEncoder[OffsetTime] {
-      protected final def format: DateTimeFormatter = ISO_OFFSET_TIME
-    }
+  implicit final lazy val encodeOffsetTime: Encoder[OffsetTime] = new Encoder[OffsetTime] {
+    final def apply(a: OffsetTime): Json = Json.fromString(a.toString)
+  }
 
   /**
    * @group Time
    */
-  implicit final lazy val encodeOffsetDateTime: Encoder[OffsetDateTime] =
-    new JavaTimeEncoder[OffsetDateTime] {
-      protected final def format: DateTimeFormatter = ISO_OFFSET_DATE_TIME
-    }
+  implicit final lazy val encodeOffsetDateTime: Encoder[OffsetDateTime] = new Encoder[OffsetDateTime] {
+    final def apply(a: OffsetDateTime): Json = Json.fromString(a.toString)
+  }
 
   /**
    * @group Time
@@ -704,10 +691,9 @@ object Encoder extends TupleEncoders with ProductEncoders with LiteralEncoders w
   /**
    * @group Time
    */
-  implicit final lazy val encodeZonedDateTime: Encoder[ZonedDateTime] =
-    new JavaTimeEncoder[ZonedDateTime] {
-      protected final def format: DateTimeFormatter = ISO_ZONED_DATE_TIME
-    }
+  implicit final lazy val encodeZonedDateTime: Encoder[ZonedDateTime] = new Encoder[ZonedDateTime] {
+    final def apply(a: ZonedDateTime): Json = Json.fromString(a.toString)
+  }
 
   /**
    * @group Time

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -198,7 +198,7 @@ sealed abstract class Json extends Product with Serializable {
   /**
    * Use implementations provided by case classes.
    */
-  override def hashCode(): Int
+  def hashCode(): Int
 
   // Alias for `findAllByKey`.
   final def \\(key: String): List[Json] = findAllByKey(key)
@@ -510,8 +510,7 @@ object Json {
    * The result is a JSON null if the argument cannot be represented as a JSON
    * number.
    */
-  final def fromFloatOrNull(value: Float): Json =
-    if (isReal(value)) JNumber(JsonFloat(value)) else Null
+  final def fromFloatOrNull(value: Float): Json = if (isReal(value)) JNumber(JsonFloat(value)) else Null
 
   /**
    * Create a `Json` value representing a JSON number or string from a `Double`.
@@ -544,18 +543,14 @@ object Json {
   final def fromBigDecimal(value: BigDecimal): Json = JNumber(JsonBigDecimal(value.underlying))
 
   /**
-   * Calling `.isNaN` and `.isInfinity` directly on the value boxes; we
-   * explicitly avoid that here.
+   * Calling `.isFinite` directly on the value boxes; we explicitly avoid that here.
    */
-  private[this] def isReal(value: Double): Boolean =
-    (!java.lang.Double.isNaN(value)) && (!java.lang.Double.isInfinite(value))
+  private[this] def isReal(value: Double): Boolean = java.lang.Double.isFinite(value)
 
   /**
-   * Calling `.isNaN` and `.isInfinity` directly on the value boxes; we
-   * explicitly avoid that here.
+   * Calling `.isFinite` directly on the value boxes; we explicitly avoid that here.
    */
-  private[this] def isReal(value: Float): Boolean =
-    (!java.lang.Float.isNaN(value)) && (!java.lang.Float.isInfinite(value))
+  private[this] def isReal(value: Float): Boolean = java.lang.Float.isFinite(value)
 
   private[this] final def arrayEq(x: Seq[Json], y: Seq[Json]): Boolean = {
     val it0 = x.iterator


### PR DESCRIPTION
Bellow are results of benchmarks which writes an array of 128 `java.time.*` instances as a JSON array of strings:

##Before
```
[info] Benchmark                            (size)   Mode  Cnt      Score      Error  Units
[info] ArrayOfLocalDateTimesWriting.circe      128  thrpt    5  17828.304 ± 2224.497  ops/s
[info] ArrayOfLocalTimesWriting.circe          128  thrpt    5  28257.429 ± 2637.814  ops/s
[info] ArrayOfOffsetDateTimesWriting.circe     128  thrpt    5  14812.471 ±  745.845  ops/s
[info] ArrayOfOffsetTimesWriting.circe         128  thrpt    5  21762.077 ± 2176.789  ops/s
[info] ArrayOfZonedDateTimesWriting.circe      128  thrpt    5  12016.890 ± 1583.515  ops/s
```
##After
```
[info] Benchmark                            (size)   Mode  Cnt      Score      Error  Units
[info] ArrayOfLocalDateTimesWriting.circe      128  thrpt    5  29355.954 ± 2920.523  ops/s
[info] ArrayOfLocalTimesWriting.circe          128  thrpt    5  58263.162 ± 8294.110  ops/s
[info] ArrayOfOffsetDateTimesWriting.circe     128  thrpt    5  25150.080 ± 2462.175  ops/s
[info] ArrayOfOffsetTimesWriting.circe         128  thrpt    5  41273.528 ± 7187.940  ops/s
[info] ArrayOfZonedDateTimesWriting.circe      128  thrpt    5  20173.697 ± 2366.075  ops/s
```
