### PR TITLE
Add at method to Decoder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ def priorTo2_13(scalaVersion: String): Boolean =
     case _                              => false
   }
 
-val previousCirceVersion = Some("0.11.0")
+val previousCirceVersion = Some("0.12.1")
 val scalaFiddleCirceVersion = "0.9.1"
 
 lazy val baseSettings = Seq(

--- a/modules/benchmark/src/main/scala/io/circe/benchmark/AtBenchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/AtBenchmark.scala
@@ -1,0 +1,30 @@
+package io.circe.benchmark
+
+import io.circe.{ Decoder, Json }
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+/**
+ * Compare the performance of various ways of folding JSON values.
+ *
+ * The following command will run the benchmarks with reasonable settings:
+ *
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.AtBenchmark"
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class AtBenchmark extends ExampleData {
+  val item: Json = Json.obj("a" -> Json.fromString("foo"), "b" -> Json.fromInt(101))
+  val doc: Json = Json.fromValues(List.fill(256)(item))
+
+  @Benchmark
+  def at: Decoder.Result[List[(String, Int)]] = {
+    val decoder = for {
+      a <- Decoder[String].at("a")
+      b <- Decoder[Int].at("b")
+    } yield (a, b)
+
+    Decoder.decodeList(decoder).decodeJson(doc)
+  }
+}

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -299,6 +299,20 @@ trait Decoder[A] extends Serializable { self =>
   }
 
   /**
+   * Create a new decoder that attempts to navigate to the specified field
+   * before decoding.
+   */
+  final def at(field: String): Decoder[A] = new Decoder[A] {
+    private[this] val f: String = field
+    final def apply(c: HCursor): Decoder.Result[A] = tryDecode(c)
+    override def tryDecode(c: ACursor): Decoder.Result[A] = self.tryDecode(c.downField(f))
+    override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
+      tryDecodeAccumulating(c)
+    override def tryDecodeAccumulating(c: ACursor): Decoder.AccumulatingResult[A] =
+      self.tryDecodeAccumulating(c.downField(f))
+  }
+
+  /**
    * Create a new decoder that performs some operation on the result if this one succeeds.
    *
    * @param f a function returning either a value or an error message

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -75,7 +75,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
   }
 
   it should "accumulate errors" in forAll { (k: String, x: Boolean, xs: List[Boolean], m: Map[String, Int]) =>
-    val json = m.mapValues(_.asJson).updated(k, (x :: xs).asJson).asJson
+    val json = m.mapValues(_.asJson).toMap.updated(k, (x :: xs).asJson).asJson
 
     assert(Decoder[List[Int]].at(k).decodeAccumulating(json.hcursor).leftMap(_.size) === Validated.invalid(xs.size + 1))
   }

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -74,6 +74,12 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     assert(Decoder[Int].at(k).decodeJson(m.updated(k, i).asJson) === Right(i))
   }
 
+  it should "accumulate errors" in forAll { (k: String, x: Boolean, xs: List[Boolean], m: Map[String, Int]) =>
+    val json = m.mapValues(_.asJson).updated(k, (x :: xs).asJson).asJson
+
+    assert(Decoder[List[Int]].at(k).decodeAccumulating(json.hcursor).leftMap(_.size) === Validated.invalid(xs.size + 1))
+  }
+
   "emap" should "appropriately transform the result with an operation that can't fail" in forAll { (i: Int) =>
     assert(Decoder[Int].emap(v => Right(v + 1)).decodeJson(i.asJson) === Right(i + 1))
   }

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -70,6 +70,10 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     assert(Decoder[Int].prepare(_.downField(k)).decodeJson(m.updated(k, i).asJson) === Right(i))
   }
 
+  "at" should "move appropriately" in forAll { (i: Int, k: String, m: Map[String, Int]) =>
+    assert(Decoder[Int].at(k).decodeJson(m.updated(k, i).asJson) === Right(i))
+  }
+
   "emap" should "appropriately transform the result with an operation that can't fail" in forAll { (i: Int) =>
     assert(Decoder[Int].emap(v => Right(v + 1)).decodeJson(i.asJson) === Right(i + 1))
   }


### PR DESCRIPTION
I feel like I write `.prepare(_.downField(whatever))` at least a couple of times a week:

```scala
import io.circe.Decoder, io.circe.generic.semiauto.deriveDecoder
import cats.syntax.apply._
case class Bar(name: String)
case class Foo(bar: Bar, age: Int)

implicit val decodeBar: Decoder[Foo] =
  (deriveDecoder[Bar], Decoder[Int].prepare(_.downField("age"))).mapN(Foo)

io.circe.jawn.decode[Foo]("""{"age" : 123, "name" : "something"}""")
```
I've been meaning to add a convenience method for this case for the past several releases, and keep forgetting, so here it is. Now you can save like 18 characters:

```scala
implicit val decodeBar: Decoder[Foo] =
  (deriveDecoder[Bar], Decoder[Int].at("age")).mapN(Foo)
```

Note that the slightly more verbose definition is intentional—I've included a benchmark that I ran against `= prepare(_.downField(field))` and there's a 10-15% difference in throughput, which seemed to me like enough to justify the verbosity.

This is a binary compatible change and I'll probably be publishing an 0.12.2 that will include it.