### PR TITLE
Make value of the implicit class private

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/io/circe/syntax/package.scala
@@ -4,12 +4,12 @@ package io.circe
  * This package provides syntax via enrichment classes.
  */
 package object syntax {
-  implicit final class EncoderOps[A](val wrappedEncodeable: A) extends AnyVal {
+  implicit final class EncoderOps[A](private val wrappedEncodeable: A) extends AnyVal {
     final def asJson(implicit encoder: Encoder[A]): Json = encoder(wrappedEncodeable)
     final def asJsonObject(implicit encoder: Encoder.AsObject[A]): JsonObject =
       encoder.encodeObject(wrappedEncodeable)
   }
-  implicit final class KeyOps[K](val key: K) extends AnyVal {
+  implicit final class KeyOps[K](private val key: K) extends AnyVal {
     final def :=[A: Encoder](a: A)(implicit keyEncoder: KeyEncoder[K]): (String, Json) = (keyEncoder(key), a.asJson)
   }
 }

--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -57,7 +57,7 @@ package object scalajs {
    */
   final def convertJsonToJs(input: Json): js.Any = input.foldWith(toJsAnyFolder)
 
-  implicit final class EncoderJsOps[A](val wrappedEncodeable: A) extends AnyVal {
+  implicit final class EncoderJsOps[A](private val wrappedEncodeable: A) extends AnyVal {
     def asJsAny(implicit encoder: Encoder[A]): js.Any = convertJsonToJs(encoder(wrappedEncodeable))
   }
 


### PR DESCRIPTION
Since circe has dropped support for scala 2.10, there is no reason to use public val's in AnyVal implicit classes. 
This should fix potential collisions with user defined fields (key, wrappedEncodeable)

[See](https://github.com/typelevel/cats/issues/2514) a similar issue in cats