### PR TITLE
Temporarily add deprecated methods for value class vals

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/syntax/package.scala
+++ b/modules/core/shared/src/main/scala/io/circe/syntax/package.scala
@@ -4,12 +4,16 @@ package io.circe
  * This package provides syntax via enrichment classes.
  */
 package object syntax {
-  implicit final class EncoderOps[A](private val wrappedEncodeable: A) extends AnyVal {
-    final def asJson(implicit encoder: Encoder[A]): Json = encoder(wrappedEncodeable)
+  implicit final class EncoderOps[A](private val value: A) extends AnyVal {
+    @deprecated("Do not use", "0.12.3")
+    def wrappedEncodeable: A = value
+    final def asJson(implicit encoder: Encoder[A]): Json = encoder(value)
     final def asJsonObject(implicit encoder: Encoder.AsObject[A]): JsonObject =
-      encoder.encodeObject(wrappedEncodeable)
+      encoder.encodeObject(value)
   }
-  implicit final class KeyOps[K](private val key: K) extends AnyVal {
-    final def :=[A: Encoder](a: A)(implicit keyEncoder: KeyEncoder[K]): (String, Json) = (keyEncoder(key), a.asJson)
+  implicit final class KeyOps[K](private val value: K) extends AnyVal {
+    @deprecated("Do not use", "0.12.3")
+    def key: K = value
+    final def :=[A: Encoder](a: A)(implicit keyEncoder: KeyEncoder[K]): (String, Json) = (keyEncoder(value), a.asJson)
   }
 }

--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -57,8 +57,10 @@ package object scalajs {
    */
   final def convertJsonToJs(input: Json): js.Any = input.foldWith(toJsAnyFolder)
 
-  implicit final class EncoderJsOps[A](private val wrappedEncodeable: A) extends AnyVal {
-    def asJsAny(implicit encoder: Encoder[A]): js.Any = convertJsonToJs(encoder(wrappedEncodeable))
+  implicit final class EncoderJsOps[A](private val value: A) extends AnyVal {
+    @deprecated("Do not use", "0.12.3")
+    def wrappedEncodeable: A = value
+    def asJsAny(implicit encoder: Encoder[A]): js.Any = convertJsonToJs(encoder(value))
   }
 
   implicit final def decodeJsUndefOr[A](implicit d: Decoder[A]): Decoder[js.UndefOr[A]] =


### PR DESCRIPTION
Follow-up to #1291 to provide binary compatibility until the next breaking release.