### PR TITLE
Provide circe-generic in default root REPL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,7 +244,7 @@ lazy val circe = project
       """.stripMargin
   )
   .aggregate(aggregatedProjects: _*)
-  .dependsOn(core, literal, parser, rs)
+  .dependsOn(core, generic, literal, parser, rs)
 
 lazy val numbersTestingBase = circeCrossModule("numbers-testing", mima = previousCirceVersion, CrossType.Pure).settings(
   scalacOptions ~= {


### PR DESCRIPTION
After #1254 `sbt console` will give an import error because of `initialCommands`.