### PR TITLE
Update Jawn to 1.0.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val compilerOptions = Seq(
 )
 
 val catsVersion = "2.0.0"
-val jawnVersion = "1.0.0-RC1"
+val jawnVersion = "1.0.0-RC2"
 val shapelessVersion = "2.3.3"
 val refinedVersion = "0.9.10"
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val compilerOptions = Seq(
 )
 
 val catsVersion = "2.0.0"
-val jawnVersion = "0.14.2"
+val jawnVersion = "1.0.0-RC1"
 val shapelessVersion = "2.3.3"
 val refinedVersion = "0.9.10"
 


### PR DESCRIPTION
See [the release notes](https://github.com/typelevel/jawn/releases/tag/v1.0.0-RC1).