### PR TITLE
Fix bug in optics example

### DIFF
--- a/docs/src/main/tut/optics.md
+++ b/docs/src/main/tut/optics.md
@@ -128,7 +128,7 @@ import io.circe.optics.JsonOptics._
 import monocle.function.Plated
 
 Plated.transform[Json] { j =>
-  json.asNumber match {
+  j.asNumber match {
     case Some(n) => Json.fromString(n.toString)
     case None    => j
   }


### PR DESCRIPTION
Changed ```json.asNumber``` to ```j.asNumber``` in Recursively modifying JSON. Now correctly converts the numbers to string.