### PR TITLE
Use implementation of show as getMessage for Errors

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Error.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Error.scala
@@ -25,7 +25,7 @@ final case class Errors(errors: NonEmptyList[Error]) extends Exception {
  * provided by the parsing library.
  */
 final case class ParsingFailure(message: String, underlying: Throwable) extends Error {
-  final override def getMessage: String = message
+  final override def getMessage: String = ParsingFailure.showParsingFailure.show(this)
 }
 
 object ParsingFailure {
@@ -46,7 +46,7 @@ sealed abstract class DecodingFailure(val message: String) extends Error {
   def history: List[CursorOp]
 
   final override def getMessage: String =
-    if (history.isEmpty) message else s"$message: ${history.mkString(",")}"
+    if (history.isEmpty) message else DecodingFailure.showDecodingFailure.show(this)
 
   final def copy(message: String = message, history: => List[CursorOp] = history): DecodingFailure = {
     def newHistory = history


### PR DESCRIPTION
## Rational

We are using tapir and it integrates nicely with circe. The circe decoding errors are passed up to the api layer and at that point all we have is a throwable. Ideally we want to call getMessage and return it to our user but it shows the default implementation which basically prints out the case classes used internally in Circe. The show implementation is really nice and we like that to be to the default.

Making this the default would mean we can avoid doing a reflection pattern match on the type of the throwable.

Additionally i think this is a bit nicer for the new comers to the library.