### PR TITLE
Put find back into HCursor

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -45,6 +45,16 @@ abstract class HCursor(lastCursor: HCursor, lastOp: CursorOp) extends ACursor(la
     case _ => fail(CursorOp.DownArray)
   }
 
+  final def find(p: Json => Boolean): ACursor = {
+    @tailrec
+    def go(c: ACursor): ACursor = c match {
+      case success: HCursor => if (p(success.value)) success else go(success.right)
+      case other            => other
+    }
+
+    go(this)
+  }
+
   final def downField(k: String): ACursor = value match {
     case Json.JObject(o) =>
       if (!o.contains(k)) fail(CursorOp.DownField(k))


### PR DESCRIPTION
As discussed at https://gitter.im/circe/circe?at=5dfa18d549314a1d459c0a1c this PR puts the `find` method back into `HCursor`.