### PR TITLE
Document usages of CodecTests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,7 +175,7 @@ lazy val docSettings = allSettings ++ Seq(
 )
 
 lazy val docs = project
-  .dependsOn(core, parser, shapes)
+  .dependsOn(core, parser, shapes, testing)
   .settings(
     moduleName := "circe-docs",
     name := "Circe docs",

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -18,6 +18,8 @@ options:
       url: codecs/custom-codecs.html
     - title: ADT (Algebraic Data Types)
       url: codecs/adt.html
+    - title: Codec testing
+      url: codecs/testing.html
     - title: Warnings and known issues
       url: codecs/known-issues.html
 

--- a/docs/src/main/tut/codecs/testing.md
+++ b/docs/src/main/tut/codecs/testing.md
@@ -1,0 +1,86 @@
+---
+layout: docs
+title:  "Codec testing"
+---
+
+### Codec testing
+
+Suppose you have the following `Person` case class and hand-written encoders and decoders. In this
+case, your decoder includes a typo, `"mame"` instead of `"name"`.
+
+```scala mdoc
+import io.circe._
+import io.circe.syntax._
+
+case class Person(name: String)
+object Person {
+  implicit val encPerson: Encoder[Person] = Encoder.forProduct1("name")(_.name)
+  implicit val decPerson: Decoder[Person] = Decoder.forProduct1("mame")(Person.apply _)
+}
+```
+
+If you try to encode then decode a `Person`, you won't be succecssful:
+
+```scala mdoc
+Person("James").asJson.as[Person]
+```
+
+This process is an example of a round trip. We can think about this round trip at two
+different levels. Thinking about it for the particular case class `Person`, we can say
+that any `Person` should round trip. This is a property we expect about the `Person`
+case class.
+
+However, this is a common expectation for anything that has both an `Encoder` and `Decoder`.
+In that sense, round tripping is a property we expect about anything with a `Codec`. When
+we have expectations about all things that implement some typeclass, we have a _law_.
+
+### `Codec` laws
+
+To check `Codec` laws for your custom types, they'll need two implicits in scope -- `Arbitrary` and
+`Eq`.
+
+```scala mdoc
+import cats.Eq
+import io.circe.testing.ArbitraryInstances
+import org.scalacheck.{Arbitrary, Gen}
+
+object Implicits extends ArbitraryInstances {
+  implicit val eqPerson: Eq[Person] = Eq.fromUniversalEquals
+  implicit val arbPerson: Arbitrary[Person] = Arbitrary {
+    Gen.listOf(Gen.alphaChar) map { chars => Person(chars.mkString("")) }
+  }
+}
+```
+
+The presence of those implicit values and an import from the `circe-testing` module
+will allow you to create a `CodecTests[Person]`:
+
+```scala mdoc
+import io.circe.testing.CodecTests
+
+val personCodecTests = CodecTests[Person]
+```
+
+`CodecTests[T]` expose two ["rule sets"](https://typelevel.org/blog/2013/11/17/discipline.html#interface)
+that can be used with [`Discipline`](https://github.com/typelevel/discipline). The less restrictive set
+is `unserializableCodec`.
+
+```scala mdoc
+import Implicits._
+personCodecTests.unserializableCodec
+```
+
+It checks whether the `Codec` for your type successfully round trips through json serialization and
+deserialization and whether your decoder satisfies consistent error accumulation.
+
+The more restrictive set is `codec`:
+
+```scala mdoc
+personCodecTests.codec
+```
+
+It checks the laws from `unserializableCodec` and ensures that your encoder and decoder can be serialized
+to and from Java byte array streams. It is generally a good idea to use the stronger laws from `.codec`, and
+you definitely should use them if you're in a setting where the JVM has to ship a lot of data around, for
+example in a Spark application. However, if you're not in a distributed setting and the serializability laws
+are getting in your way, it's fine to skip them with the `unserializableCodec`.


### PR DESCRIPTION
Overview
----

This PR adds documentation for usage of `CodecTests[T]`.

Notes
-----

discussed [on gitter](https://gitter.im/circe/circe?at=5e722fea86710916a582af0c)

Assumed audience is someone who's interested in testing their `Codec`s but who might not already be familiar with laws testing / discipline. `circe` was my entrypoint to Typelevel / cats when someone told a project team I'm on that we could derive json de-/serialization instead of writing out huge spray json formats and my guess is that the circe + akka-http crowd includes other people who are just trying out some Typelevel-flavored things for the first time.

Testing
----

- I'm not familiar with `sbt-microsites` so I'm not sure if I've done something extremely wrong. I think I wired up the menu correctly but I don't have styles, assets, etc. when I follow the `sbt-microsites` instructions for viewing the site locally, so it's tough to see how this looks :man_shrugging: 