### PR TITLE
More verbose error messages when decoding refined types

### DIFF
--- a/modules/refined/jvm/src/main/scala/io/circe/refined/info/impl/TypeTagImplicits.scala
+++ b/modules/refined/jvm/src/main/scala/io/circe/refined/info/impl/TypeTagImplicits.scala
@@ -1,0 +1,23 @@
+package io.circe.refined.info.impl
+
+import io.circe.refined.info.TypeInfo
+import io.circe.refined.info.instances.{ TypeTagBasedHK2Info, TypeTagBasedHKInfo, TypeTagBasedInfo }
+import scala.reflect.runtime.universe.TypeTag
+
+trait TypeTagImplicits extends LowPriorityTypeTagTypeInfo0
+
+trait LowPriorityTypeTagTypeInfo0 extends LowPriorityTypeTagTypeInfo1 {
+  implicit def fromTypeTagHK[F[_], A](implicit F: TypeTag[F[Any]], A: TypeTag[A]): TypeInfo[F[A]] =
+    new TypeTagBasedHKInfo(F, A)
+
+  implicit def fromTypeTagHK2[F[_, _], A, B](
+    implicit F: TypeTag[F[Any, Any]],
+    A: TypeTag[A],
+    B: TypeTag[B]
+  ): TypeInfo[F[A, B]] =
+    new TypeTagBasedHK2Info(F, A, B)
+}
+
+trait LowPriorityTypeTagTypeInfo1 extends Serializable {
+  implicit def fromTypeTag[A](implicit A: TypeTag[A]): TypeInfo[A] = new TypeTagBasedInfo(A)
+}

--- a/modules/refined/jvm/src/main/scala/io/circe/refined/info/typeTag.scala
+++ b/modules/refined/jvm/src/main/scala/io/circe/refined/info/typeTag.scala
@@ -1,0 +1,3 @@
+package io.circe.refined.info
+
+object typeTag extends impl.TypeTagImplicits

--- a/modules/refined/jvm/src/test/scala/io/circe/refined/info/RefinedTypeTagInfoSuite.scala
+++ b/modules/refined/jvm/src/test/scala/io/circe/refined/info/RefinedTypeTagInfoSuite.scala
@@ -1,0 +1,27 @@
+package io.circe.refined.info
+
+import io.circe.syntax._
+import io.circe.tests.CirceSuite
+import io.circe._
+import io.circe.refined._
+import io.circe.refined.info.typeTag._
+import org.scalatest.EitherValues
+
+class RefinedTypeTagInfoSuite extends CirceSuite with EitherValues {
+  private val nameDecoder = Decoder[Person.Name]
+  private val ageDecoder = Decoder[Person.Age]
+
+  "A refined decoder with ClassTag type info" should "provide verbose error message" in {
+    assert(
+      nameDecoder.decodeJson("x".asJson).left.value.message ==
+        "Failed to verify eu.timepit.refined.string.MatchesRegex[Any][String(\"[A-z-]{2,}\")] refinement " +
+          "for value x of raw type String - Predicate failed: \"x\".matches(\"[A-z-]{2,}\")."
+    )
+
+    assert(
+      ageDecoder.decodeJson((-2).asJson).left.value.message ==
+        "Failed to verify eu.timepit.refined.boolean.Not[Any][eu.timepit.refined.numeric.Negative] refinement " +
+          "for value -2 of raw type Int - Predicate (-2 < 0) did not fail."
+    )
+  }
+}

--- a/modules/refined/shared/src/main/scala/io/circe/refined/info/TypeInfo.scala
+++ b/modules/refined/shared/src/main/scala/io/circe/refined/info/TypeInfo.scala
@@ -1,0 +1,13 @@
+package io.circe.refined.info
+
+import io.circe.refined.info.instances.EmptyTypeInfo
+
+trait TypeInfo[A] extends Serializable {
+  def describe: String
+}
+
+object TypeInfo {
+  def apply[A](implicit A: TypeInfo[A]): A.type = A
+
+  def empty[A]: TypeInfo[A] = EmptyTypeInfo.asInstanceOf[TypeInfo[A]]
+}

--- a/modules/refined/shared/src/main/scala/io/circe/refined/info/classTag.scala
+++ b/modules/refined/shared/src/main/scala/io/circe/refined/info/classTag.scala
@@ -1,0 +1,3 @@
+package io.circe.refined.info
+
+object classTag extends impl.ClassTagImplicits

--- a/modules/refined/shared/src/main/scala/io/circe/refined/info/impl/ClassTagImplicits.scala
+++ b/modules/refined/shared/src/main/scala/io/circe/refined/info/impl/ClassTagImplicits.scala
@@ -1,0 +1,23 @@
+package io.circe.refined.info.impl
+
+import io.circe.refined.info.TypeInfo
+import io.circe.refined.info.instances.{ ClassTagBasedHK2Info, ClassTagBasedHKInfo, ClassTagBasedInfo }
+import scala.reflect.ClassTag
+
+trait ClassTagImplicits extends LowPriorityClassTagTypeInfo0
+
+trait LowPriorityClassTagTypeInfo0 extends LowPriorityClassTagTypeInfo1 {
+  implicit def fromClassTagHK[F[_], A](implicit F: ClassTag[F[Any]], A: ClassTag[A]): TypeInfo[F[A]] =
+    new ClassTagBasedHKInfo(F, A)
+
+  implicit def fromClassTagHK2[F[_, _], A, B](
+    implicit F: ClassTag[F[Any, Any]],
+    A: ClassTag[A],
+    B: ClassTag[B]
+  ): TypeInfo[F[A, B]] =
+    new ClassTagBasedHK2Info(F, A, B)
+}
+
+trait LowPriorityClassTagTypeInfo1 extends Serializable {
+  implicit def fromClassTag[A](implicit A: ClassTag[A]): TypeInfo[A] = new ClassTagBasedInfo(A)
+}

--- a/modules/refined/shared/src/main/scala/io/circe/refined/info/instances/ClassTagBasedInfo.scala
+++ b/modules/refined/shared/src/main/scala/io/circe/refined/info/instances/ClassTagBasedInfo.scala
@@ -1,0 +1,17 @@
+package io.circe.refined.info.instances
+
+import io.circe.refined.info.TypeInfo
+import scala.reflect.ClassTag
+
+class ClassTagBasedInfo[A](A: ClassTag[A]) extends TypeInfo[A] {
+  override val describe: String = A.runtimeClass.getName
+}
+
+class ClassTagBasedHKInfo[F[_], A](F: ClassTag[F[Any]], A: ClassTag[A]) extends TypeInfo[F[A]] {
+  override def describe: String = s"${F.runtimeClass.getName}[${A.runtimeClass.getName}]"
+}
+
+class ClassTagBasedHK2Info[F[_, _], A, B](F: ClassTag[F[Any, Any]], A: ClassTag[A], B: ClassTag[B])
+    extends TypeInfo[F[A, B]] {
+  override def describe: String = s"${F.runtimeClass.getName}[${A.runtimeClass.getName}, ${B.runtimeClass.getName}]"
+}

--- a/modules/refined/shared/src/main/scala/io/circe/refined/info/instances/EmptyTypeInfo.scala
+++ b/modules/refined/shared/src/main/scala/io/circe/refined/info/instances/EmptyTypeInfo.scala
@@ -1,0 +1,7 @@
+package io.circe.refined.info.instances
+
+import io.circe.refined.info.TypeInfo
+
+object EmptyTypeInfo extends TypeInfo[Any] {
+  override val describe: String = ""
+}

--- a/modules/refined/shared/src/main/scala/io/circe/refined/info/instances/TypeTagBasedInstances.scala
+++ b/modules/refined/shared/src/main/scala/io/circe/refined/info/instances/TypeTagBasedInstances.scala
@@ -1,0 +1,17 @@
+package io.circe.refined.info.instances
+
+import io.circe.refined.info.TypeInfo
+import scala.reflect.runtime.universe.TypeTag
+
+class TypeTagBasedInfo[A](A: TypeTag[A]) extends TypeInfo[A] {
+  override val describe: String = A.tpe.toString
+}
+
+class TypeTagBasedHKInfo[F[_], A](F: TypeTag[F[Any]], A: TypeTag[A]) extends TypeInfo[F[A]] {
+  override def describe: String = s"${F.tpe.toString}[${A.tpe.toString}]"
+}
+
+class TypeTagBasedHK2Info[F[_, _], A, B](F: TypeTag[F[Any, Any]], A: TypeTag[A], B: TypeTag[B])
+    extends TypeInfo[F[A, B]] {
+  override def describe: String = s"${F.tpe.toString}[${A.tpe.toString}, ${B.tpe.toString}]"
+}

--- a/modules/refined/shared/src/test/scala/io/circe/refined/info/Person.scala
+++ b/modules/refined/shared/src/test/scala/io/circe/refined/info/Person.scala
@@ -1,0 +1,11 @@
+package io.circe.refined.info
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.NonNegative
+import eu.timepit.refined.string.MatchesRegex
+import shapeless.{ Witness => W }
+
+object Person {
+  type Name = String Refined MatchesRegex[W.`"[A-z-]{2,}"`.T]
+  type Age = Int Refined NonNegative
+}

--- a/modules/refined/shared/src/test/scala/io/circe/refined/info/RefinedClassTagInfoSuite.scala
+++ b/modules/refined/shared/src/test/scala/io/circe/refined/info/RefinedClassTagInfoSuite.scala
@@ -1,0 +1,27 @@
+package io.circe.refined.info
+
+import io.circe.syntax._
+import io.circe.tests.CirceSuite
+import io.circe._
+import io.circe.refined._
+import io.circe.refined.info.classTag._
+import org.scalatest.EitherValues
+
+class RefinedClassTagInfoSuite extends CirceSuite with EitherValues {
+  private val nameDecoder = Decoder[Person.Name]
+  private val ageDecoder = Decoder[Person.Age]
+
+  "A refined decoder with ClassTag type info" should "provide verbose error message" in {
+    assert(
+      nameDecoder.decodeJson("x".asJson).left.value.message ==
+        "Failed to verify eu.timepit.refined.string$MatchesRegex[java.lang.String] refinement " +
+          """for value x of raw type java.lang.String - Predicate failed: "x".matches("[A-z-]{2,}")."""
+    )
+
+    assert(
+      ageDecoder.decodeJson((-2).asJson).left.value.message ==
+        "Failed to verify eu.timepit.refined.boolean$Not[eu.timepit.refined.numeric$Less] refinement " +
+          "for value -2 of raw type int - Predicate (-2 < 0) did not fail."
+    )
+  }
+}


### PR DESCRIPTION
Hi there! I've got an issue with error message verbosity when using circe with refined types.
This PR provides API to chose the verbosity level:
- default which (I suppose) doesn't break source compatibility 
- more verbose classTag based (both ScalaJS, JVM)
- the most verbose type tag based implementation (JVM only)

If it looks fine I'll provide some scaladoc =) 