### PR TITLE
Update broken link in optics documentation

### DIFF
--- a/docs/src/main/resources/microsite/includes/references.md
+++ b/docs/src/main/resources/microsite/includes/references.md
@@ -43,7 +43,7 @@
 [jsactor]: https://github.com/codemettle/jsactor
 [json-schema]: http://json-schema.org/
 [json.parse]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-[jsonpath]: https://github.com/circe/circe/blob/master/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
+[jsonpath]: https://github.com/circe/circe-optics/blob/master/optics/src/main/scala/io/circe/optics/JsonPath.scala
 [jwt]: https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32
 [jwt-circe]: http://pauldijou.fr/jwt-scala/samples/jwt-circe/
 [kadai-log]: https://bitbucket.org/atlassian/kadai-log


### PR DESCRIPTION
The `JsonPath` link on this page https://circe.github.io/circe/optics.html return a `404`.
Update the link with the correct location