### PR TITLE
Laws for key codecs

### DIFF
--- a/modules/testing/shared/src/main/scala/io/circe/testing/KeyCodecLaws.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/KeyCodecLaws.scala
@@ -2,11 +2,11 @@ package io.circe.testing
 
 import cats.instances.option._
 import cats.kernel.Eq
-import cats.kernel.laws.{IsEq, SerializableLaws}
+import cats.kernel.laws.{ IsEq, SerializableLaws }
 import cats.laws._
 import cats.laws.discipline._
-import io.circe.{KeyDecoder, KeyEncoder}
-import org.scalacheck.{Arbitrary, Prop, Shrink}
+import io.circe.{ KeyDecoder, KeyEncoder }
+import org.scalacheck.{ Arbitrary, Prop, Shrink }
 import org.typelevel.discipline.Laws
 
 trait KeyCodecLaws[A] {

--- a/modules/testing/shared/src/main/scala/io/circe/testing/KeyCodecLaws.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/KeyCodecLaws.scala
@@ -1,0 +1,67 @@
+package io.circe.testing
+
+import cats.instances.option._
+import cats.kernel.Eq
+import cats.kernel.laws.{IsEq, SerializableLaws}
+import cats.laws._
+import cats.laws.discipline._
+import io.circe.{KeyDecoder, KeyEncoder}
+import org.scalacheck.{Arbitrary, Prop, Shrink}
+import org.typelevel.discipline.Laws
+
+trait KeyCodecLaws[A] {
+
+  def decodeKey: KeyDecoder[A]
+  def encodeKey: KeyEncoder[A]
+
+  def keyCodecRoundTrip(a: A): IsEq[Option[A]] =
+    decodeKey(encodeKey(a)) <-> Some(a)
+
+}
+
+object KeyCodecLaws {
+  def apply[A: KeyDecoder: KeyEncoder]: KeyCodecLaws[A] = new KeyCodecLaws[A] {
+    override val decodeKey: KeyDecoder[A] = KeyDecoder[A]
+    override val encodeKey: KeyEncoder[A] = KeyEncoder[A]
+  }
+}
+
+trait KeyCodecTests[A] extends Laws {
+  def laws: KeyCodecLaws[A]
+
+  def keyCodec(implicit
+    arbitraryA: Arbitrary[A],
+    shrinkA: Shrink[A],
+    eqA: Eq[A],
+    arbitraryString: Arbitrary[String],
+    shrinkString: Shrink[String]
+  ): RuleSet = new DefaultRuleSet(
+    name = "keyCodec",
+    parent = None,
+    "roundTrip" -> Prop.forAll { (a: A) =>
+      laws.keyCodecRoundTrip(a)
+    },
+    "keyDecoder serializability" -> SerializableLaws.serializable(laws.decodeKey),
+    "keyEncoder serializability" -> SerializableLaws.serializable(laws.encodeKey)
+  )
+
+  def unserializableKeyCodec(implicit
+    arbitraryA: Arbitrary[A],
+    shrinkA: Shrink[A],
+    eqA: Eq[A],
+    arbitraryString: Arbitrary[String],
+    shrinkString: Shrink[String]
+  ): RuleSet = new DefaultRuleSet(
+    name = "keyCodec",
+    parent = None,
+    "roundTrip" -> Prop.forAll { (a: A) =>
+      laws.keyCodecRoundTrip(a)
+    }
+  )
+}
+
+object KeyCodecTests {
+  def apply[A: KeyDecoder: KeyEncoder]: KeyCodecTests[A] = new KeyCodecTests[A] {
+    override def laws: KeyCodecLaws[A] = KeyCodecLaws[A]
+  }
+}

--- a/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
@@ -1,0 +1,19 @@
+package io.circe
+
+import java.util.UUID
+
+import cats.instances.all._
+import io.circe.testing.KeyCodecTests
+import io.circe.tests.CirceSuite
+
+class KeyCodecSuite extends CirceSuite {
+
+  checkAll("KeyCodec[String]", KeyCodecTests[String].keyCodec)
+  checkAll("KeyCodec[Symbol]", KeyCodecTests[Symbol].keyCodec)
+  checkAll("KeyCodec[UUID]", KeyCodecTests[UUID].keyCodec)
+  checkAll("KeyCodec[Byte]", KeyCodecTests[Byte].keyCodec)
+  checkAll("KeyCodec[Short]", KeyCodecTests[Short].keyCodec)
+  checkAll("KeyCodec[Int]", KeyCodecTests[Int].keyCodec)
+  checkAll("KeyCodec[Long]", KeyCodecTests[Long].keyCodec)
+
+}


### PR DESCRIPTION
This PR adds laws testing for the `KeyEncoder` and `KeyDecoder` classes, as suggested by #1342. The only law added is the "round trip" law, although I have followed the lead of the [`CodecTests`](https://github.com/circe/circe/blob/6d6f70e/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala#L48) and added tests for serialisation too.

I have added checks for the `KeyCodecLaws` for all existing instances.