### PR TITLE
Add decoder for untagged ArraySeq

### DIFF
--- a/modules/core/shared/src/main/scala-2.13+/io/circe/CollectionDecoders.scala
+++ b/modules/core/shared/src/main/scala-2.13+/io/circe/CollectionDecoders.scala
@@ -57,6 +57,9 @@ private[circe] trait CollectionDecoders extends LowPriorityCollectionDecoders {
     final protected val create: (A, C[A]) => OneAnd[C, A] = (h, t) => OneAnd(h, t)
   }
 
+  /**
+   * @group Collection
+   */
   implicit final def decodeArraySeq[A](implicit decodeA: Decoder[A], classTag: ClassTag[A]): Decoder[ArraySeq[A]] =
     new SeqDecoder[A, ArraySeq](decodeA) {
       final protected def createBuilder(): Builder[A, ArraySeq[A]] = ArraySeq.newBuilder[A]
@@ -66,6 +69,9 @@ private[circe] trait CollectionDecoders extends LowPriorityCollectionDecoders {
 
 trait LowPriorityCollectionDecoders {
 
+  /**
+   * @group Collection
+   */
   implicit final def decodeUntaggedArraySeq[A](implicit decodeA: Decoder[A]): Decoder[ArraySeq[A]] =
     new SeqDecoder[A, ArraySeq](decodeA) {
       override protected def createBuilder(): Builder[A, ArraySeq[A]] = ArraySeq.untagged.newBuilder

--- a/modules/core/shared/src/main/scala-2.13+/io/circe/CollectionDecoders.scala
+++ b/modules/core/shared/src/main/scala-2.13+/io/circe/CollectionDecoders.scala
@@ -67,7 +67,7 @@ private[circe] trait CollectionDecoders extends LowPriorityCollectionDecoders {
 
 }
 
-trait LowPriorityCollectionDecoders {
+private trait LowPriorityCollectionDecoders {
 
   /**
    * @group Collection

--- a/modules/tests/shared/src/test/scala-2.13/io/circe/ArraySeqSuite.scala
+++ b/modules/tests/shared/src/test/scala-2.13/io/circe/ArraySeqSuite.scala
@@ -1,0 +1,44 @@
+package io.circe
+
+import cats.Eq
+import io.circe.tests.CirceSuite
+import io.circe.syntax.EncoderOps
+import cats.instances.list.catsKernelStdEqForList
+import cats.instances.int.catsKernelStdOrderForInt
+import cats.instances.string.catsKernelStdOrderForString
+import io.circe.testing.CodecTests
+
+import scala.collection.immutable.ArraySeq
+
+class ArraySeqSuite extends CirceSuite {
+
+  // TODO this can be removed once Cats 2.2.0 is used
+  implicit def eqForArraySeq[A: Eq]: Eq[ArraySeq[A]] = Eq.by(_.toList)
+
+  def decodeArraySeqWithoutClassTag[A: Decoder](json: Json): Decoder.Result[ArraySeq[A]] =
+    json.as[ArraySeq[A]]
+
+  "decoding an arraySeq" should "succeed when the type is fully specified" in forAll { int: Int =>
+    assert(Json.arr(int.asJson).as[ArraySeq[Int]] === Right(ArraySeq(int)))
+  }
+
+  it should "succeed for polymorphic decoders" in forAll { string: String =>
+    assert(decodeArraySeqWithoutClassTag[String](Json.arr(string.asJson)) === Right(ArraySeq(string)))
+  }
+
+  it should "specialise the array type where a class tag is available" in forAll { intArray: Array[Int] =>
+    val jsonArray = Json.arr(intArray.map(_.asJson): _*)
+
+    assert(jsonArray.as[ArraySeq[Int]].map(_.getClass) == Right(classOf[ArraySeq.ofInt]))
+  }
+
+  it should "not specialise the array type where no class tag is available" in forAll { intArray: Array[Int] =>
+    val jsonArray = Json.arr(intArray.map(_.asJson): _*)
+
+    assert(decodeArraySeqWithoutClassTag[Int](jsonArray).map(_.getClass) == Right(classOf[ArraySeq.ofRef[_]]))
+  }
+
+  checkAll("Codec[ArraySeq[Int]]", CodecTests[ArraySeq[Int]].codec)
+  checkAll("Codec[ArraySeq[String]]", CodecTests[ArraySeq[String]].codec)
+
+}


### PR DESCRIPTION
Currently, Circe does not implicitly resolve a decoder for the immutable [`ArraySeq`](https://www.scala-lang.org/api/current/scala/collection/immutable/ArraySeq.html) where a `ClassTag` is not available. The [`CollectionDecoders.decodeIterable`](https://github.com/circe/circe/blob/v0.13.0/modules/core/shared/src/main/scala-2.13+/io/circe/CollectionDecoders.scala#L28) decoder is resolved where a `ClassTag` is available. But `ArraySeq` has no implicit `Factory` without an implicit `ClassTag`, so that decoder is not implicitly resolved when none is available.

An example of code that does not currently compile is available in the [`decodeUntaggedArraySeq` method](https://github.com/circe/circe/pull/1479/files#diff-d3ec9f95b90a735f8f1698aa3d2a5238R18) in the Spec for this PR.

This PR adds a dedicated decoder for `ArraySeq` in the case where a `ClassTag` is present, and a lower-priority decoder that uses the [`ArraySeq.untagged`](https://www.scala-lang.org/api/current/scala/collection/immutable/ArraySeq$.html#untagged:scala.collection.SeqFactory[scala.collection.immutable.ArraySeq]) factory in the case where there is no `ClassTag`.

I probably should have raised an issue to discuss this solution first, so please feel free to ask for a complete rework.