### PR TITLE
Remove GC options from .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,3 @@
-# Same JVM opts as cats
-
-# see https://weblogs.java.net/blog/kcpeppe/archive/2013/12/11/case-study-jvm-hotspot-flags
 -Dfile.encoding=UTF8
 -Xms1G
 -Xmx3G
@@ -8,7 +5,3 @@
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
-# effectively adds GC to Perm space
--XX:+CMSClassUnloadingEnabled
-# must be enabled for CMSClassUnloadingEnabled to work
--XX:+UseConcMarkSweepGC


### PR DESCRIPTION
  * ConcMarkSweepGC is deprecated on newer JVMs
  * GraalVM doesn't support it
  * It clashes with locally defined `SBT_OPTS`
  * It's not the same as cats
  * Link is outdated

If it's important for CI, could add it in `SBT_OPTS` environment variable.