### PR TITLE
Adding missing operations in the JawnParser

### DIFF
--- a/modules/jawn/src/main/scala/io/circe/jawn/JawnParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/JawnParser.scala
@@ -4,6 +4,8 @@ import cats.data.ValidatedNel
 import io.circe.{ Decoder, Error, Json, Parser, ParsingFailure }
 import java.io.File
 import java.nio.ByteBuffer
+import java.nio.channels.ReadableByteChannel
+import java.nio.file.{ Files, Path }
 import scala.util.{ Failure, Success, Try }
 
 object JawnParser {
@@ -65,14 +67,47 @@ class JawnParser(maxValueSize: Option[Int], allowDuplicateKeys: Boolean) extends
     case Failure(error) => Left(ParsingFailure(error.getMessage, error))
   }
 
-  final def parse(input: String): Either[ParsingFailure, Json] =
-    fromTry(supportParser.parseFromString(input))
+  final def parse(str: String): Either[ParsingFailure, Json] =
+    fromTry(supportParser.parseFromString(str))
+
+  final def parseCharSequence(cs: CharSequence): Either[ParsingFailure, Json] =
+    fromTry(supportParser.parseFromCharSequence(cs))
+
+  final def parsePath(path: Path): Either[ParsingFailure, Json] =
+    parseChannel(Files.newByteChannel(path))
 
   final def parseFile(file: File): Either[ParsingFailure, Json] =
     fromTry(supportParser.parseFromFile(file))
 
+  final def parseChannel(ch: ReadableByteChannel): Either[ParsingFailure, Json] =
+    fromTry(supportParser.parseFromChannel(ch))
+
   final def parseByteBuffer(buffer: ByteBuffer): Either[ParsingFailure, Json] =
     fromTry(supportParser.parseFromByteBuffer(buffer))
+
+  final def decodeCharSequence[A: Decoder](cs: CharSequence): Either[Error, A] =
+    finishDecode[A](parseCharSequence(cs))
+
+  final def decodeCharSequenceAccumulating[A: Decoder](cs: CharSequence): ValidatedNel[Error, A] =
+    finishDecodeAccumulating[A](parseCharSequence(cs))
+
+  final def decodePath[A: Decoder](path: Path): Either[Error, A] =
+    finishDecode[A](parsePath(path))
+
+  final def decodePathAccumulating[A: Decoder](path: Path): ValidatedNel[Error, A] =
+    finishDecodeAccumulating[A](parsePath(path))
+
+  final def decodeFile[A: Decoder](file: File): Either[Error, A] =
+    finishDecode[A](parseFile(file))
+
+  final def decodeFileAccumulating[A: Decoder](file: File): ValidatedNel[Error, A] =
+    finishDecodeAccumulating[A](parseFile(file))
+
+  final def decodeChannel[A: Decoder](ch: ReadableByteChannel): Either[Error, A] =
+    finishDecode[A](parseChannel(ch))
+
+  final def decodeChannelAccumulating[A: Decoder](ch: ReadableByteChannel): ValidatedNel[Error, A] =
+    finishDecodeAccumulating[A](parseChannel(ch))
 
   final def parseByteArray(bytes: Array[Byte]): Either[ParsingFailure, Json] =
     fromTry(supportParser.parseFromByteArray(bytes))
@@ -88,10 +123,4 @@ class JawnParser(maxValueSize: Option[Int], allowDuplicateKeys: Boolean) extends
 
   final def decodeByteArrayAccumulating[A: Decoder](bytes: Array[Byte]): ValidatedNel[Error, A] =
     finishDecodeAccumulating[A](parseByteArray(bytes))
-
-  final def decodeFile[A: Decoder](file: File): Either[Error, A] =
-    finishDecode[A](parseFile(file))
-
-  final def decodeFileAccumulating[A: Decoder](file: File): ValidatedNel[Error, A] =
-    finishDecodeAccumulating[A](parseFile(file))
 }


### PR DESCRIPTION
This is a simple PR which adds a couple of extra operations to the JawnParser.

-----

# Edit.

I am not sure if I should or not add tests for the new methods.
For what I see [here](https://github.com/circe/circe/blob/master/modules/jawn/src/test/scala/io/circe/jawn/JawnParserSuite.scala) it didn't include tests for the file and bytes methods since those would mostly be redundant; some would also require creating some json files in the resources folder.
