### PR TITLE
Add Instances ISO 4217 Currency Values

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -13,6 +13,7 @@ import cats.data.{
   Validated,
   ValidatedNel
 }
+import cats.syntax.either._
 import cats.data.Validated.{ Invalid, Valid }
 import cats.instances.either.{ catsStdInstancesForEither, catsStdSemigroupKForEither }
 import cats.kernel.Order
@@ -36,6 +37,7 @@ import java.time.{
   ZonedDateTime
 }
 import java.time.format.DateTimeFormatter
+import java.util.Currency
 import java.util.UUID
 import scala.annotation.tailrec
 import scala.collection.immutable.{ Map => ImmutableMap, Set, SortedMap, SortedSet }
@@ -1393,6 +1395,19 @@ object Decoder
         final def apply(c: HCursor): Result[B] = step(c, a)
       }
     }
+
+  implicit final lazy val currencyDecoder: Decoder[Currency] =
+    Decoder[String].emap(value =>
+      catsStdInstancesForEither[Throwable]
+        .catchNonFatal(
+          Currency.getInstance(value)
+        )
+        .leftMap((t: Throwable) =>
+          // As of JRE 15 `.getMessage` and `.getLocalizedMessage` return
+          // `null`, but that doesn't mean they always will.
+          Option(t.getLocalizedMessage()).getOrElse(s"Unknown or unimplemented currency value: $value")
+        )
+    )
 
   /**
    * Helper methods for working with [[cats.data.StateT]] values that transform

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -29,6 +29,7 @@ import java.time.format.DateTimeFormatter.{
   ISO_ZONED_DATE_TIME
 }
 import java.time.temporal.TemporalAccessor
+import java.util.Currency
 import java.util.UUID
 import scala.Predef._
 import scala.collection.Map
@@ -691,6 +692,9 @@ object Encoder
   implicit final lazy val encodeZoneOffset: Encoder[ZoneOffset] = new Encoder[ZoneOffset] {
     final def apply(a: ZoneOffset): Json = Json.fromString(a.toString)
   }
+
+  implicit final lazy val currencyEncoder: Encoder[Currency] =
+    Encoder[String].contramap(_.getCurrencyCode())
 
   /**
    * A subtype of `Encoder` that statically verifies that the instance encodes

--- a/modules/tests/shared/src/test/scala/io/circe/JavaCurrencySuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JavaCurrencySuite.scala
@@ -1,0 +1,27 @@
+package io.circe
+
+import cats._
+import io.circe.testing.CodecTests
+import io.circe.tests.CirceSuite
+import java.util.Currency
+import org.scalacheck._
+import scala.collection.JavaConverters._
+
+final class JavaCurrencySuite extends CirceSuite {
+  import JavaCurrencySuite._
+
+  checkAll("Codec[Currency]", CodecTests[Currency].codec)
+}
+
+object JavaCurrencySuite {
+
+  lazy val availableCurrencies: Set[Currency] =
+    Currency.getAvailableCurrencies.asScala.toSet
+
+  implicit lazy val arbitraryCurrency: Arbitrary[Currency] =
+    Arbitrary(Gen.oneOf(availableCurrencies))
+
+  // Orphans
+  implicit private lazy val eqInstance: Eq[Currency] =
+    Eq.fromUniversalEquals
+}


### PR DESCRIPTION
This commit adds an Encoder and Decoder instance for ISO 4217 currency values, as modeled by the JRE as `java.util.Currency`.