### PR TITLE
Add MUnit dependency and example migration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,10 @@ val paradiseVersion = "2.1.1"
 
 val scalaTestVersion = "3.2.3"
 val scalaCheckVersion = "1.15.1"
+val munitVersion = "0.7.19"
 val disciplineVersion = "1.1.2"
 val disciplineScalaTestVersion = "2.1.0"
+val disciplineMunitVersion = "1.0.3"
 val scalaJavaTimeVersion = "2.0.0"
 
 /**
@@ -75,7 +77,9 @@ lazy val baseSettings = Seq(
   (scalastyleSources in Compile) ++= (unmanagedSourceDirectories in Compile).value,
   ivyConfigurations += CompileTime.hide,
   unmanagedClasspath in Compile ++= update.value.select(configurationFilter(CompileTime.name)),
-  unmanagedClasspath in Test ++= update.value.select(configurationFilter(CompileTime.name))
+  unmanagedClasspath in Test ++= update.value.select(configurationFilter(CompileTime.name)),
+  testFrameworks += new TestFramework("munit.Framework"),
+  scalaJSLinkerConfig in Test ~= (_.withModuleKind(ModuleKind.CommonJSModule))
 )
 
 lazy val allSettings = baseSettings ++ publishSettings
@@ -465,7 +469,8 @@ lazy val testsBase = circeCrossModule("tests", mima = None)
     scalacOptions in Test += "-language:implicitConversions",
     libraryDependencies ++= Seq(
       "com.chuusai" %%% "shapeless" % shapelessVersion,
-      "org.typelevel" %%% "discipline-scalatest" % disciplineScalaTestVersion
+      "org.typelevel" %%% "discipline-scalatest" % disciplineScalaTestVersion,
+      "org.typelevel" %%% "discipline-munit" % disciplineMunitVersion
     ).map(_.withDottyCompat(scalaVersion.value)),
     sourceGenerators in Test += (sourceManaged in Test).map(Boilerplate.genTests).taskValue,
     unmanagedResourceDirectories in Compile +=

--- a/modules/tests/shared/src/test/scala/io/circe/ShowErrorSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/ShowErrorSuite.scala
@@ -5,7 +5,8 @@ import cats.syntax.eq._
 import cats.syntax.show._
 import io.circe.CursorOp._
 import io.circe.tests.CirceSuite
-import org.scalacheck.Gen
+import munit.ScalaCheckSuite
+import org.scalacheck.{ Gen, Prop }
 
 trait GenCursorOps {
   val arrayMoves: Gen[List[CursorOp]] = Gen.listOf(
@@ -20,18 +21,18 @@ trait GenCursorOps {
   val downFields: Gen[List[CursorOp]] = Gen.listOf(Gen.identifier.map(DownField))
 }
 
-class ShowErrorSuite extends CirceSuite with GenCursorOps {
-  "Show[ParsingFailure]" should "produce the expected output" in {
+class ShowErrorSuite extends ScalaCheckSuite with GenCursorOps {
+  test("Show[ParsingFailure] should produce the expected output") {
     assert(ParsingFailure("the message", new Exception()).show === "ParsingFailure: the message")
   }
 
-  "Show[DecodingFailure]" should "produce the expected output on a small example" in {
+  test("Show[DecodingFailure] should produce the expected output on a small example") {
     val ops = List(MoveRight, MoveRight, DownArray, DownField("bar"), DownField("foo"))
 
     assert(DecodingFailure("the message", ops).show === "DecodingFailure at .foo.bar[2]: the message")
   }
 
-  it should "produce the expected output on a larger example" in {
+  test("Show[DecodingFailure] should produce the expected output on a larger example") {
     val ops = List(
       MoveLeft,
       LeftN(2),
@@ -50,27 +51,31 @@ class ShowErrorSuite extends CirceSuite with GenCursorOps {
     assert(DecodingFailure("the message", ops).show === expected)
   }
 
-  it should "display field selection" in forAll(downFields) { moves =>
-    val selection = moves.foldRight("") {
-      case (DownField(f), s) => s"$s.$f"
-      case (_, s)            => s
-    }
+  test("Show[DecodingFailure] should display field selection") {
+    Prop.forAll(downFields) { moves =>
+      val selection = moves.foldRight("") {
+        case (DownField(f), s) => s"$s.$f"
+        case (_, s)            => s
+      }
 
-    val expected = s"DecodingFailure at $selection: the message"
-    assert(DecodingFailure("the message", moves).show === expected)
+      val expected = s"DecodingFailure at $selection: the message"
+      DecodingFailure("the message", moves).show === expected
+    }
   }
 
-  it should "display array indexing" in forAll(arrayMoves) { moves =>
-    val ops = moves :+ DownArray
-    val index = moves.foldLeft(0) {
-      case (i, MoveLeft)  => i - 1
-      case (i, MoveRight) => i + 1
-      case (i, LeftN(n))  => i - n
-      case (i, RightN(n)) => i + n
-      case (i, _)         => i
-    }
+  test("Show[DecodingFailure] should display array indexing") {
+    Prop.forAll(arrayMoves) { moves =>
+      val ops = moves :+ DownArray
+      val index = moves.foldLeft(0) {
+        case (i, MoveLeft)  => i - 1
+        case (i, MoveRight) => i + 1
+        case (i, LeftN(n))  => i - n
+        case (i, RightN(n)) => i + n
+        case (i, _)         => i
+      }
 
-    val expected = s"DecodingFailure at [$index]: the message"
-    assert(DecodingFailure("the message", ops).show === expected)
+      val expected = s"DecodingFailure at [$index]: the message"
+      DecodingFailure("the message", ops).show === expected
+    }
   }
 }


### PR DESCRIPTION
See #1582. In some cases the migration will be more complicated (for example you may need to mix in `io.circe.testing.{ArbitraryInstances, EqInstances}` or `io.circe.tests.MissingInstances` if you're migrating a suite that extends `CirceSuite`), but the `ShowErrorSuite` change here shows the basics.