### PR TITLE
Introduce reason for DecodingFailure, improve error messages

### DIFF
--- a/modules/core/shared/src/main/scala-2/io/circe/EnumerationCodecs.scala
+++ b/modules/core/shared/src/main/scala-2/io/circe/EnumerationCodecs.scala
@@ -15,7 +15,14 @@ private[circe] trait EnumerationCodecs {
     final def apply(c: HCursor): Decoder.Result[E#Value] = Decoder.decodeString(c).flatMap { str =>
       Try(enumeration.withName(str)) match {
         case Success(a) => Right(a)
-        case Failure(t) => Left(DecodingFailure(t.getMessage, c.history))
+        case Failure(t) =>
+          Left(
+            DecodingFailure(
+              s"Couldn't decode value '$str'. " +
+                s"Allowed values: '${enumeration.values.mkString(",")}'",
+              c.history
+            )
+          )
       }
     }
     final def apply(e: E#Value): Json = Encoder.encodeString(e.toString)

--- a/modules/core/shared/src/main/scala-2/io/circe/EnumerationDecoders.scala
+++ b/modules/core/shared/src/main/scala-2/io/circe/EnumerationDecoders.scala
@@ -16,7 +16,14 @@ private[circe] trait EnumerationDecoders {
     final def apply(c: HCursor): Decoder.Result[E#Value] = Decoder.decodeString(c).flatMap { str =>
       Try(enumeration.withName(str)) match {
         case Success(a) => Right(a)
-        case Failure(t) => Left(DecodingFailure(t.getMessage, c.history))
+        case Failure(_) =>
+          Left(
+            DecodingFailure(
+              s"Couldn't decode value '$str'. " +
+                s"Allowed values: '${enumeration.values.mkString(",")}'",
+              c.history
+            )
+          )
       }
     }
   }

--- a/modules/core/shared/src/main/scala/io/circe/Error.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Error.scala
@@ -1,7 +1,9 @@
 package io.circe
 
-import cats.{ Eq, Show }
 import cats.data.NonEmptyList
+import cats.{ Eq, Show }
+import io.circe.DecodingFailure.Reason
+import io.circe.DecodingFailure.Reason.{ CustomReason, MissingField, WrongTypeExpectation }
 
 /**
  * The base exception type for both decoding and parsing errors.
@@ -42,20 +44,33 @@ object ParsingFailure {
  * An exception representing a decoding failure and (lazily) capturing the
  * decoding history resulting in the failure.
  */
-sealed abstract class DecodingFailure(val message: String) extends Error {
+sealed abstract class DecodingFailure(val reason: Reason) extends Error {
   def history: List[CursorOp]
+
+  val message: String = reason match {
+    case WrongTypeExpectation(expJsType, v) => s"Got value '${v.noSpaces}' with wrong type, expecting $expJsType"
+    case MissingField                       => "Missing required field"
+    case CustomReason(message)              => message
+  }
 
   final override def getMessage: String =
     if (history.isEmpty) message else s"$message: ${history.mkString(",")}"
 
   final def copy(message: String = message, history: => List[CursorOp] = history): DecodingFailure = {
     def newHistory = history
-    new DecodingFailure(message) {
+    new DecodingFailure(CustomReason(message)) {
       final lazy val history: List[CursorOp] = newHistory
     }
   }
 
   final def withMessage(message: String): DecodingFailure = copy(message = message)
+
+  final def withReason(reason: Reason): DecodingFailure = {
+    def newHistory: List[CursorOp] = history
+    new DecodingFailure(reason) {
+      override def history: List[CursorOp] = newHistory
+    }
+  }
 
   override final def toString: String = s"DecodingFailure($message, $history)"
   override final def equals(that: Any): Boolean = that match {
@@ -66,7 +81,11 @@ sealed abstract class DecodingFailure(val message: String) extends Error {
 }
 
 object DecodingFailure {
-  def apply(message: String, ops: => List[CursorOp]): DecodingFailure = new DecodingFailure(message) {
+  def apply(message: String, ops: => List[CursorOp]): DecodingFailure = new DecodingFailure(CustomReason(message)) {
+    final lazy val history: List[CursorOp] = ops
+  }
+
+  def apply(reason: Reason, ops: => List[CursorOp]): DecodingFailure = new DecodingFailure(reason) {
     final lazy val history: List[CursorOp] = ops
   }
 
@@ -85,7 +104,7 @@ object DecodingFailure {
   }
 
   implicit final val eqDecodingFailure: Eq[DecodingFailure] = Eq.instance { (a, b) =>
-    a.message == b.message && CursorOp.eqCursorOpList.eqv(a.history, b.history)
+    a.reason == b.reason && CursorOp.eqCursorOpList.eqv(a.history, b.history)
   }
 
   /**
@@ -95,6 +114,13 @@ object DecodingFailure {
   implicit final val showDecodingFailure: Show[DecodingFailure] = Show.show { failure =>
     val path = CursorOp.opsToPath(failure.history)
     s"DecodingFailure at ${path}: ${failure.message}"
+  }
+
+  sealed abstract class Reason
+  object Reason {
+    case object MissingField extends Reason
+    case class WrongTypeExpectation(expectedJsonFieldType: String, jsonValue: Json) extends Reason
+    case class CustomReason(message: String) extends Reason
   }
 }
 

--- a/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
@@ -1,6 +1,8 @@
 package io.circe
 
 import cats.data.{ NonEmptyList, Validated }
+import io.circe.DecodingFailure.Reason.WrongTypeExpectation
+
 import scala.collection.mutable.Builder
 
 private[circe] abstract class SeqDecoder[A, C[_]](decodeA: Decoder[A]) extends Decoder[C[A]] {
@@ -26,7 +28,7 @@ private[circe] abstract class SeqDecoder[A, C[_]](decodeA: Decoder[A]) extends D
     } else {
       if (c.value.isArray) Right(createBuilder().result())
       else {
-        Left(DecodingFailure("C[A]", c.history))
+        Left(DecodingFailure(WrongTypeExpectation("array", c.value), c.history))
       }
     }
   }
@@ -61,7 +63,7 @@ private[circe] abstract class SeqDecoder[A, C[_]](decodeA: Decoder[A]) extends D
     } else {
       if (c.value.isArray) Validated.valid(createBuilder().result())
       else {
-        Validated.invalidNel(DecodingFailure("C[A]", c.history))
+        Validated.invalidNel(DecodingFailure(WrongTypeExpectation("array", c.value), c.history))
       }
     }
   }

--- a/modules/generic-simple/src/main/scala/io/circe/generic/simple/codec/ReprAsObjectCodec.scala
+++ b/modules/generic-simple/src/main/scala/io/circe/generic/simple/codec/ReprAsObjectCodec.scala
@@ -13,8 +13,8 @@ import shapeless.labelled.{ FieldType, field }
 abstract class ReprAsObjectCodec[A] extends Codec.AsObject[A]
 
 object ReprAsObjectCodec {
-  private[this] def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(
-    implicit F: Apply[F]
+  private[this] def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(implicit
+    F: Apply[F]
   ): F[FieldType[K, V] :: T] =
     F.map2(hv, tr)((v, t) => field[K].apply[V](v) :: t)
 
@@ -23,8 +23,7 @@ object ReprAsObjectCodec {
     def encodeObject(a: HNil): JsonObject = JsonObject.empty
   }
 
-  implicit def codecForHCons[K <: Symbol, H, T <: HList](
-    implicit
+  implicit def codecForHCons[K <: Symbol, H, T <: HList](implicit
     key: Witness.Aux[K],
     decodeH: Decoder[H],
     encodeH: Encoder[H],
@@ -47,13 +46,14 @@ object ReprAsObjectCodec {
   }
 
   implicit val codecForCNil: ReprAsObjectCodec[CNil] = new ReprAsObjectCodec[CNil] {
-    def apply(c: HCursor): Decoder.Result[CNil] = Left(DecodingFailure("CNil", c.history))
+    def apply(c: HCursor): Decoder.Result[CNil] = Left(
+      DecodingFailure("JSON decoding to CNil should never happen", c.history)
+    )
     def encodeObject(a: CNil): JsonObject =
       sys.error("No JSON representation of CNil (this shouldn't happen)")
   }
 
-  implicit def codecForCoproduct[K <: Symbol, L, R <: Coproduct](
-    implicit
+  implicit def codecForCoproduct[K <: Symbol, L, R <: Coproduct](implicit
     key: Witness.Aux[K],
     decodeL: Decoder[L],
     encodeL: Encoder[L],

--- a/modules/generic/shared/src/main/scala-2/io/circe/generic/codec/ReprAsObjectCodec.scala
+++ b/modules/generic/shared/src/main/scala-2/io/circe/generic/codec/ReprAsObjectCodec.scala
@@ -1,7 +1,9 @@
 package io.circe.generic.codec
 
+import io.circe.DecodingFailure.Reason.WrongTypeExpectation
 import io.circe.{ Codec, Decoder, DecodingFailure, HCursor, JsonObject }
 import io.circe.generic.Deriver
+
 import scala.language.experimental.macros
 import shapeless.HNil
 
@@ -17,7 +19,8 @@ object ReprAsObjectCodec {
 
   val hnilReprCodec: ReprAsObjectCodec[HNil] = new ReprAsObjectCodec[HNil] {
     def apply(c: HCursor): Decoder.Result[HNil] =
-      if (c.value.isObject) Right(HNil) else Left(DecodingFailure("HNil", c.history))
+      if (c.value.isObject) Right(HNil)
+      else Left(DecodingFailure(WrongTypeExpectation("object", c.value), c.history))
     def encodeObject(a: HNil): JsonObject = JsonObject.empty
   }
 }

--- a/modules/generic/shared/src/main/scala-2/io/circe/generic/decoding/ReprDecoder.scala
+++ b/modules/generic/shared/src/main/scala-2/io/circe/generic/decoding/ReprDecoder.scala
@@ -2,8 +2,10 @@ package io.circe.generic.decoding
 
 import cats.Apply
 import cats.data.Validated
+import io.circe.DecodingFailure.Reason.WrongTypeExpectation
 import io.circe.{ Decoder, DecodingFailure, HCursor }
 import io.circe.generic.Deriver
+
 import scala.language.experimental.macros
 import shapeless.{ :+:, ::, Coproduct, HList, HNil, Inl }
 import shapeless.labelled.{ FieldType, field }
@@ -20,7 +22,8 @@ object ReprDecoder {
 
   val hnilReprDecoder: ReprDecoder[HNil] = new ReprDecoder[HNil] {
     def apply(c: HCursor): Decoder.Result[HNil] =
-      if (c.value.isObject) Right(HNil) else Left(DecodingFailure("HNil", c.history))
+      if (c.value.isObject) Right(HNil)
+      else Left(DecodingFailure(WrongTypeExpectation("object", c.value), c.history))
   }
 
   def consResults[F[_], K, V, T <: HList](hv: F[V], tr: F[T])(implicit F: Apply[F]): F[FieldType[K, V] :: T] =

--- a/modules/generic/shared/src/main/scala-2/io/circe/generic/util/macros/DerivationMacros.scala
+++ b/modules/generic/shared/src/main/scala-2/io/circe/generic/util/macros/DerivationMacros.scala
@@ -214,13 +214,13 @@ abstract class DerivationMacros[RD[_], RE[_], RC[_], DD[_], DE[_], DC[_]] {
 
   private[this] val cnilResult: Tree = q"""
     _root_.scala.util.Left[_root_.io.circe.DecodingFailure, _root_.shapeless.CNil](
-      _root_.io.circe.DecodingFailure("CNil", c.history)
+      _root_.io.circe.DecodingFailure("JSON decoding to CNil should never happen", c.history)
     ): _root_.scala.util.Either[_root_.io.circe.DecodingFailure, _root_.shapeless.CNil]
   """
 
   private[this] val cnilResultAccumulating: Tree = q"""
     _root_.cats.data.Validated.invalidNel[_root_.io.circe.DecodingFailure, _root_.shapeless.CNil](
-      _root_.io.circe.DecodingFailure("CNil", c.history)
+      _root_.io.circe.DecodingFailure("JSON decoding to CNil should never happen", c.history)
     )
   """
 

--- a/modules/literal/src/main/scala/io/circe/literal/LiteralInstanceMacros.scala
+++ b/modules/literal/src/main/scala/io/circe/literal/LiteralInstanceMacros.scala
@@ -16,7 +16,8 @@ class LiteralInstanceMacros(val c: whitebox.Context) {
               _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
             } else {
               _root_.scala.util.Left(
-                _root_.io.circe.DecodingFailure($name, c.history)
+                _root_.io.circe.DecodingFailure(
+                  "Couldn't decode '" + $lit + "' string literal", c.history)
               )
             }
           }
@@ -34,7 +35,8 @@ class LiteralInstanceMacros(val c: whitebox.Context) {
               _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
             } else {
               _root_.scala.util.Left(
-                _root_.io.circe.DecodingFailure($name, c.history)
+                _root_.io.circe.DecodingFailure(
+                  "Couldn't decode '" + $lit + "' double literal", c.history)
               )
             }
           }
@@ -52,7 +54,8 @@ class LiteralInstanceMacros(val c: whitebox.Context) {
               _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
             } else {
               _root_.scala.util.Left(
-                _root_.io.circe.DecodingFailure($name, c.history)
+                _root_.io.circe.DecodingFailure(
+                  "Couldn't decode '" + $lit + "' float literal", c.history)
               )
             }
           }
@@ -70,7 +73,8 @@ class LiteralInstanceMacros(val c: whitebox.Context) {
               _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
             } else {
               _root_.scala.util.Left(
-                _root_.io.circe.DecodingFailure($name, c.history)
+                _root_.io.circe.DecodingFailure(
+                  "Couldn't decode '" + $lit + "' long literal", c.history)
               )
             }
           }
@@ -88,7 +92,8 @@ class LiteralInstanceMacros(val c: whitebox.Context) {
               _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
             } else {
               _root_.scala.util.Left(
-                _root_.io.circe.DecodingFailure($name, c.history)
+                _root_.io.circe.DecodingFailure(
+                  "Couldn't decode '" + $lit + "' int literal", c.history)
               )
             }
           }
@@ -106,7 +111,8 @@ class LiteralInstanceMacros(val c: whitebox.Context) {
               _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
             } else {
               _root_.scala.util.Left(
-                _root_.io.circe.DecodingFailure($name, c.history)
+                _root_.io.circe.DecodingFailure(
+                  "Couldn't decode '" + $lit + "' char literal", c.history)
               )
             }
           }
@@ -124,7 +130,8 @@ class LiteralInstanceMacros(val c: whitebox.Context) {
               _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
             } else {
               _root_.scala.util.Left(
-                _root_.io.circe.DecodingFailure($name, c.history)
+                _root_.io.circe.DecodingFailure(
+                  "Couldn't decode '" + $lit + "' boolean literal", c.history)
               )
             }
           }

--- a/modules/shapes/src/main/scala/io/circe/shapes/CoproductInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/CoproductInstances.scala
@@ -5,7 +5,8 @@ import shapeless.{ :+:, CNil, Coproduct, Inl, Inr }
 
 trait CoproductInstances {
   implicit final val decodeCNil: Decoder[CNil] = new Decoder[CNil] {
-    def apply(c: HCursor): Decoder.Result[CNil] = Left(DecodingFailure("CNil", c.history))
+    def apply(c: HCursor): Decoder.Result[CNil] =
+      Left(DecodingFailure("JSON decoding to CNil should never happen", c.history))
   }
 
   implicit final val encodeCNil: Encoder[CNil] = new Encoder[CNil] {

--- a/modules/shapes/src/main/scala/io/circe/shapes/HListInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/HListInstances.scala
@@ -1,5 +1,6 @@
 package io.circe.shapes
 
+import io.circe.DecodingFailure.Reason.WrongTypeExpectation
 import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json, JsonObject }
 import shapeless.{ ::, HList, HNil }
 
@@ -16,7 +17,8 @@ trait HListInstances extends LowPriorityHListInstances {
 private[shapes] trait LowPriorityHListInstances {
   implicit final val decodeHNil: Decoder[HNil] = new Decoder[HNil] {
     def apply(c: HCursor): Decoder.Result[HNil] =
-      if (c.value.isObject) Right(HNil) else Left(DecodingFailure("HNil", c.history))
+      if (c.value.isObject) Right(HNil)
+      else Left(DecodingFailure(WrongTypeExpectation("object", c.value), c.history))
   }
 
   implicit final val encodeHNil: Encoder.AsObject[HNil] = new Encoder.AsObject[HNil] {

--- a/modules/shapes/src/main/scala/io/circe/shapes/SizedInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/SizedInstances.scala
@@ -2,6 +2,7 @@ package io.circe.shapes
 
 import cats.data.Validated
 import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor }
+
 import scala.collection.GenTraversable
 import shapeless.{ AdditiveCollection, Nat, Sized }
 import shapeless.ops.nat.ToInt
@@ -15,7 +16,8 @@ trait SizedInstances {
     private[this] def checkSize(coll: C[A]): Option[Sized[C[A], L]] =
       if (coll.size == toInt()) Some(Sized.wrap[C[A], L](coll)) else None
 
-    private[this] def failure(c: HCursor): DecodingFailure = DecodingFailure(s"Sized[C[A], _${toInt()}]", c.history)
+    private[this] def failure(c: HCursor): DecodingFailure =
+      DecodingFailure("Couldn't decode sized collection", c.history)
 
     def apply(c: HCursor): Decoder.Result[Sized[C[A], L]] =
       decodeCA(c) match {

--- a/modules/tests/shared/src/test/scala-2/io/circe/EnumerationSuite.scala
+++ b/modules/tests/shared/src/test/scala-2/io/circe/EnumerationSuite.scala
@@ -28,7 +28,9 @@ class EnumerationSuite extends CirceMunitSuite {
     val decoder = Decoder.decodeEnumeration(WeekDay)
     val Right(friday) = parse("\"Friday\"")
 
-    assert(decoder.apply(friday.hcursor).isLeft)
+    val result = decoder.apply(friday.hcursor)
+    assert(result.isLeft)
+    assert(result.swap.exists(_.message.contains("Couldn't decode value 'Friday'. Allowed values:")))
   }
 
   test("Encoder[Enumeration] should write Scala Enumerations") {

--- a/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
@@ -138,9 +138,11 @@ class JavaTimeCodecSuite extends CirceMunitSuite {
         val decodingResult = Decoder[ZoneId].decodeJson(Json.fromString(s))
 
         assert(decodingResult.isLeft)
-        // The middle part of the message depends on the type of zone.
-        assert(decodingResult.swap.exists(_.message.contains("ZoneId (Invalid")))
-        assert(decodingResult.swap.exists(_.message.contains(s", invalid format: $s)")))
+        assert(decodingResult.swap.right.get.reason match {
+          case DecodingFailure.Reason.CustomReason(_) => true
+          case _                                      => false
+        })
+        assert(decodingResult.swap.exists(_.message.contains("invalid format")))
       }
     )
   }
@@ -323,6 +325,10 @@ class JavaTimeCodecSuite extends CirceMunitSuite {
     val decodingResult = Decoder[ZoneOffset].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
-    assert(decodingResult.swap.exists(_.message.contains("ZoneOffset (Invalid ID for ZoneOffset, ")))
+    assert(decodingResult.swap.right.get.reason match {
+      case DecodingFailure.Reason.CustomReason(_) => true
+      case _                                      => false
+    })
+    assert(decodingResult.swap.exists(_.message.contains(invalidText)))
   }
 }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -126,6 +126,7 @@ object Boilerplate {
         |package io.circe
         |
         |import cats.data.Validated
+        |import io.circe.DecodingFailure.Reason.WrongTypeExpectation
         |
         |private[circe] trait TupleDecoders {
         -  /**
@@ -135,13 +136,15 @@ object Boilerplate {
         -    new Decoder[${`(A..N)`}] {
         -      final def apply(c: HCursor): Decoder.Result[${`(A..N)`}] = c.value match {
         -        case Json.JArray(values) if values.size == $arity => $result
-        -        case _ => Left(DecodingFailure("${`(A..N)`}", c.history))
+        -        case json => Left(DecodingFailure(WrongTypeExpectation("array", json), c.history))
         -      }
         -
-        -      override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[${`(A..N)`}] = c.value match {
-        -        case Json.JArray(values) if values.size == $arity => $accumulatingResult
-        -        case _ => Validated.invalidNel(DecodingFailure("${`(A..N)`}", c.history))
-        -      }
+        -      override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[${`(A..N)`}] =
+        -        c.value match {
+        -          case Json.JArray(values) if values.size == $arity => $accumulatingResult
+        -          case json => Validated.invalidNel(
+        -            DecodingFailure(WrongTypeExpectation("array", json), c.history))
+        -        }
         -    }
         |}
       """


### PR DESCRIPTION
This PR is an attempt to offer a way to interpret `DecodingFailure` outcomes and let the user build a human-readable error message.
I've been a user of circe for years and I never needed this feature before. Now I have a use-case in which a good error message is required (a public REST endpoint).

Basically, I'm introducing an explicit encoding of the reason to complement the message field in DecodingFailure:

```scala
  sealed trait Reason
  case object MissingField extends Reason
  case class WrongTypeExpectation(expectedJsonFieldType: String, jsonValue: Json) extends Reason // the JSON contained the field, but the field has the wrong JSON type
  case class CustomReason(message: String) extends Reason // a validation failed while decoding or a custom string error message
```

And a default implementation for the `message` field which should be good enough for most cases.

```scala
sealed abstract class DecodingFailure(val reason: Reason) extends Error {
  def history: List[CursorOp]

  val message: String = reason match {
    case WrongTypeExpectation(expJsType, v) => s"Got value '${v.noSpaces}' with wrong type, expecting $expJsType"
    case MissingField                                        => "Missing required field"
    case CustomReason(message)                 => message
  }
  ...
}
```

I then updated all the instances available, so that the `DecodingFailure`s they return will be reflecting what I believe is the right `Reason`.

This predates mostly from these issues/PR, so most of the credits should go to the original authors/participants: https://github.com/circe/circe/issues/188, https://github.com/circe/circe/issues/588, https://github.com/circe/circe/pull/1081, https://github.com/circe/circe/issues/306.

I'd be more than open to any adjustment needed for a smoother migration or for a better encoding.
Hope you may find this useful :)