### PR TITLE
no default codec for option of option, a partial solution for #1540

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -952,6 +952,22 @@ object Decoder
     }
   }
 
+  implicit final def decodeOptionOption[A](implicit d: Decoder[A]): Decoder[Option[Option[A]]] =
+    new Decoder[Option[Option[A]]] {
+      private val message = "Option[Option[_]] has no default Decoder. Please write a custom Decoder."
+
+      final def apply(c: HCursor): Result[Option[Option[A]]] = tryDecode(c)
+
+      final override def tryDecode(c: ACursor): Decoder.Result[Option[Option[A]]] =
+        Left(DecodingFailure(message, c.history))
+
+      final override def decodeAccumulating(c: HCursor): AccumulatingResult[Option[Option[A]]] =
+        tryDecodeAccumulating(c)
+
+      final override def tryDecodeAccumulating(c: ACursor): AccumulatingResult[Option[Option[A]]] =
+        Validated.invalidNel(DecodingFailure(message, c.history))
+    }
+
   /**
    * @group Decoding
    */

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -316,6 +316,15 @@ object Encoder
   }
 
   /**
+   * `Option[Option[_]]` has no default Encoder. Please write a custom Encoder.
+   *
+   * This implicit collides with implicit [[encodeOption]] for types of the form `Option[Option[A]]`, and therefore
+   * causes a compiler error for such types.
+   */
+  implicit final def encodeOptionOption[A](implicit e: Encoder[A]): Encoder[Option[Option[A]]] =
+    (a: Option[Option[A]]) => Json.Null
+
+  /**
    * @group Encoding
    */
   implicit final def encodeSome[A](implicit e: Encoder[A]): Encoder[Some[A]] = e.contramap(_.get)

--- a/modules/generic-simple/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/modules/generic-simple/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -198,6 +198,24 @@ class SemiautoDerivedSuite extends CirceSuite {
     }
   }
 
+  "Decoder[Option[Option[A]]" should "not be automatically derived" in {
+    assertDoesNotCompile {
+      """
+        case class Bat(field: Option[Option[String]])
+        val decoder: Decoder[Bat] = deriveDecoder
+      """
+    }
+  }
+
+  "Encoder[Option[Option[A]]" should "not be automatically derived" in {
+    assertDoesNotCompile {
+      """
+        case class Bat(field: Option[Option[String]])
+        val encoder: Encoder[Bat] = deriveEncoder
+      """
+    }
+  }
+
   "A generically derived codec" should "not interfere with base instances" in forAll { (is: List[Int]) =>
     val json = Encoder[List[Int]].apply(is)
 


### PR DESCRIPTION
Unfortunately `sbt +validateJVM` fails on an unrelated issue. 

This code is therefore just provided as a suggestion to be used in any way you wish.