### PR TITLE
Tests: migrate from ScalaTest to MUnit.

### DIFF
--- a/modules/extras/src/test/scala/io/circe/ExtrasSpec.scala
+++ b/modules/extras/src/test/scala/io/circe/ExtrasSpec.scala
@@ -1,12 +1,12 @@
 package io.circe
 
 import io.circe.syntax._
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import org.scalacheck.{ Arbitrary, Gen }
 
-class ExtrasSpec extends CirceSuite {
+class ExtrasSpec extends CirceMunitSuite {
 
-  "sanitizeKeys" should "return input JSON if all of the JSON Object's keys are in the approvedList" in {
+  property("sanitizeKeys should return input JSON if all of the JSON Object's keys are in the approvedList") {
     forAll[Set[String], String, Boolean](Gen.listOf(Gen.alphaNumStr).map(_.toSet), Gen.alphaNumStr) {
       (keys: Set[String], str: String) =>
 
@@ -31,7 +31,7 @@ class ExtrasSpec extends CirceSuite {
     }
   }
 
-  "sanitizeKeys" should "return sanitized values for keys' values of a JSON Object" in {
+  property("sanitizeKeys should return sanitized values for keys' values of a JSON Object") {
     forAll[Boolean, String, JsonNumber, Boolean](
       Arbitrary.arbBool.arbitrary,
       Gen.alphaNumStr,
@@ -70,7 +70,7 @@ class ExtrasSpec extends CirceSuite {
     }
   }
 
-  "sanitizeKeys" should "sanitize each value within an array" in {
+  property("sanitizeKeys should sanitize each value within an array") {
     forAll[Boolean, String, JsonNumber, Boolean](
       Arbitrary.arbBool.arbitrary,
       Gen.alphaNumStr,
@@ -125,7 +125,7 @@ class ExtrasSpec extends CirceSuite {
     }
   }
 
-  "sanitizeKeys" should "sanitize arrays and objects of approved and non-approved keys' values" in {
+  property("sanitizeKeys should sanitize arrays and objects of approved and non-approved keys' values") {
     forAll[Boolean, String, Boolean](
       Arbitrary.arbBool.arbitrary,
       Gen.alphaNumStr

--- a/modules/generic/shared/src/test/scala-0/io/circe/generic/AutoDerivedSuite.scala
+++ b/modules/generic/shared/src/test/scala-0/io/circe/generic/AutoDerivedSuite.scala
@@ -6,9 +6,9 @@ import cats.syntax.eq._
 import io.circe.{ Decoder, Encoder, Json }
 import io.circe.generic.auto._
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import io.circe.tests.examples._
-import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.{ Arbitrary, Gen, Prop }
 
 object AutoDerivedSuite {
   case class InnerCaseClassExample(a: String, b: String, c: String, d: String)
@@ -39,7 +39,7 @@ object AutoDerivedSuite {
   }
 }
 
-class AutoDerivedSuite extends CirceSuite {
+class AutoDerivedSuite extends CirceMunitSuite {
   import AutoDerivedSuite._
 
   checkAll("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
@@ -50,31 +50,37 @@ class AutoDerivedSuite extends CirceSuite {
   checkAll("Codec[Foo]", CodecTests[Foo].codec)
   checkAll("Codec[OuterCaseClassExample]", CodecTests[OuterCaseClassExample].codec)
 
-  "A generically derived codec" should "not interfere with base instances" in forAll { (is: List[Int]) =>
-    val json = Encoder[List[Int]].apply(is)
+  property("A generically derived codec should not interfere with base instances"){
+    Prop.forAll { (is: List[Int]) =>
+      val json = Encoder[List[Int]].apply(is)
 
-    assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Right(is))
+      assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Right(is))
+    }
   }
 
-  it should "not be derived for Object" in {
+  test("A generically derived codec should not be derived for Object") {
     assertTypeError("Decoder[Object]")
     assertTypeError("Encoder[Object]")
   }
 
-  it should "not be derived for AnyRef" in {
+  test("A generically derived codec should not be derived for AnyRef"){
     assertTypeError("Decoder[AnyRef]")
     assertTypeError("Encoder[AnyRef]")
   }
 
-  "Generic decoders" should "not interfere with defined decoders" in forAll { (xs: List[String]) =>
-    val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
+  property("Generic decoders should not interfere with defined decoders"){
+    Prop.forAll { (xs: List[String]) =>
+      val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
 
-    assert(Decoder[Foo].apply(json.hcursor) === Right(Baz(xs): Foo))
+      assert(Decoder[Foo].apply(json.hcursor) === Right(Baz(xs): Foo))
+    }
   }
 
-  "Generic encoders" should "not interfere with defined encoders" in forAll { (xs: List[String]) =>
-    val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
+  property("Generic encoders should not interfere with defined encoders"){
+    Prop.forAll { (xs: List[String]) =>
+      val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
 
-    assert(Encoder[Foo].apply(Baz(xs): Foo) === json)
+      assert(Encoder[Foo].apply(Baz(xs): Foo) === json)
+    }
   }
 }

--- a/modules/generic/shared/src/test/scala-0/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/modules/generic/shared/src/test/scala-0/io/circe/generic/SemiautoDerivedSuite.scala
@@ -5,9 +5,9 @@ import cats.syntax.eq._
 import io.circe.{ Codec, Decoder, Encoder, Json }
 import io.circe.generic.semiauto._
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import io.circe.tests.examples._
-import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.{ Arbitrary, Gen , Prop}
 
 object SemiautoDerivedSuite {
   implicit def decodeBox[A: Decoder]: Decoder[Box[A]] = deriveDecoder
@@ -79,7 +79,7 @@ object SemiautoDerivedSuite {
   case class OvergenerationExampleOuter1(oi: Option[OvergenerationExampleInner])
 }
 
-class SemiautoDerivedSuite extends CirceSuite {
+class SemiautoDerivedSuite extends CirceMunitSuite {
   import SemiautoDerivedSuite._
 
   checkAll("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
@@ -131,13 +131,15 @@ class SemiautoDerivedSuite extends CirceSuite {
     CodecTests[RecursiveWithOptionExample](RecursiveWithOptionExample.codecForRecursiveWithOptionExample, implicitly).codec
   )
 
-  "A generically derived codec" should "not interfere with base instances" in forAll { (is: List[Int]) =>
-    val json = Encoder[List[Int]].apply(is)
+  property("A generically derived codec should not interfere with base instances"){
+    Prop.forAll { (is: List[Int]) =>
+      val json = Encoder[List[Int]].apply(is)
 
-    assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Right(is))
+      assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Right(is))
+    }
   }
 
-  it should "not come from nowhere" in {
+  test("A generically derived codec should not come from nowhere") {
     assertTypeError("Decoder[OvergenerationExampleInner]")
 
     assertTypeError("Encoder.AsObject[OvergenerationExampleInner]")
@@ -148,17 +150,19 @@ class SemiautoDerivedSuite extends CirceSuite {
     assertTypeError("Encoder.AsObject[OvergenerationExampleOuter1]")
   }
 
-  it should "require instances for all parts" in {
+  test("A generically derived codec should require instances for all parts"){
     assertTypeError("deriveDecoder[OvergenerationExampleInner0]")
     assertTypeError("deriveDecoder[OvergenerationExampleInner1]")
     assertTypeError("deriveEncoder[OvergenerationExampleInner0]")
     assertTypeError("deriveEncoder[OvergenerationExampleInner1]")
   }
 
-  "A generically derived codec for an empty case class" should "not accept non-objects" in forAll { (j: Json) =>
-    case class EmptyCc()
+  property("A generically derived codec for an empty case class should not accept non-objects"){
+    Prop.forAll { (j: Json) =>
+      case class EmptyCc()
 
-    assert(deriveDecoder[EmptyCc].decodeJson(j).isRight == j.isObject)
-    assert(deriveCodec[EmptyCc].decodeJson(j).isRight == j.isObject)
+      assert(deriveDecoder[EmptyCc].decodeJson(j).isRight == j.isObject)
+      assert(deriveCodec[EmptyCc].decodeJson(j).isRight == j.isObject)
+    }
   }
 }

--- a/modules/refined/shared/src/test/scala/io/circe/refined/RefinedSuite.scala
+++ b/modules/refined/shared/src/test/scala/io/circe/refined/RefinedSuite.scala
@@ -12,12 +12,12 @@ import eu.timepit.refined.scalacheck.numeric.greaterArbitrary
 import eu.timepit.refined.scalacheck.string.startsWithArbitrary
 import io.circe.{ Decoder, Encoder, Json, KeyDecoder, KeyEncoder }
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import io.circe.syntax._
 import org.scalacheck.{ Arbitrary, Gen }
 import shapeless.{ Nat, Witness => W }
 
-class RefinedSuite extends CirceSuite {
+class RefinedSuite extends CirceMunitSuite {
   implicit def refinedEq[T, P, F[_, _]](implicit refType: RefType[F]): Eq[F[T, P]] = Eq.fromUniversalEquals
 
   type Gt2 = Greater[W.`2`.T]
@@ -32,7 +32,7 @@ class RefinedSuite extends CirceSuite {
     CodecTests[String Refined StartsWith[W.`"a"`.T]].codec
   )
 
-  "A refined encoder" should "encode as the underlying type" in {
+  test("A refined encoder should encode as the underlying type") {
     val n = refineMV[Gt2](5)
     assert(n.asJson === 5.asJson)
 
@@ -43,7 +43,7 @@ class RefinedSuite extends CirceSuite {
     assert(expected === refinedList.map(_.asJson))
   }
 
-  "A refined decoder" should "refuse to decode wrong values" in {
+  test("A refined decoder should refuse to decode wrong values") {
     assert(Decoder[Int Refined Gt2].decodeJson(3.asJson).isRight)
     assert(Decoder[Int Refined Gt2].decodeJson(1.asJson).isLeft)
 
@@ -51,7 +51,7 @@ class RefinedSuite extends CirceSuite {
     assert(Decoder[String Refined StartsWith[W.`"a"`.T]].decodeJson("ba".asJson).isLeft)
   }
 
-  "A refined key encoder" should "encode as string" in {
+  test("A refined key encoder should encode as string") {
     val n = refineMV[Gt2](5)
     val s = refineMV[NonEmpty]("a")
 
@@ -59,7 +59,7 @@ class RefinedSuite extends CirceSuite {
     assert(KeyEncoder[String Refined NonEmpty].apply(s) === "a")
   }
 
-  "A refined key decoder" should "refuse to decode wrong values" in {
+  test("A refined key decoder should refuse to decode wrong values") {
     assert(KeyDecoder[Int Refined Gt2].apply("3").isDefined)
     assert(KeyDecoder[Int Refined Gt2].apply("1").isEmpty)
 
@@ -98,12 +98,12 @@ object RefinedFieldsSuite {
   }
 }
 
-class RefinedFieldsSuite extends CirceSuite {
+class RefinedFieldsSuite extends CirceMunitSuite {
   import RefinedFieldsSuite._
 
   checkAll("Codec[RefinedFields]", CodecTests[RefinedFields].codec)
 
-  "Refined fields" should "be encoded as simple fields" in {
+  test("Refined fields should be encoded as simple fields") {
     val json = Encoder[RefinedFields].apply(
       RefinedFields(
         refineMV(3),
@@ -122,8 +122,8 @@ class RefinedFieldsSuite extends CirceSuite {
   }
 }
 
-class RefinedKeysSuite extends CirceSuite {
-  "Refined keys" should "be encoded as Map keys" in {
+class RefinedKeysSuite extends CirceMunitSuite {
+  test("Refined keys should be encoded as Map keys") {
     val example: Map[String Refined NonEmpty, Int] = Map(refineMV[NonEmpty]("a") -> 1, refineMV[NonEmpty]("b") -> 2)
 
     val expectedJson = Json.obj("a" -> 1.asJson, "b" -> 2.asJson)
@@ -131,13 +131,13 @@ class RefinedKeysSuite extends CirceSuite {
     assert(example.asJson === expectedJson)
   }
 
-  it should "decode when valid" in {
+  test("Refined Keys should decode when valid") {
     val json = Json.obj("a" -> 1.asJson, "b" -> 2.asJson)
     val expected: Map[String Refined NonEmpty, Int] = Map(refineMV[NonEmpty]("a") -> 1, refineMV[NonEmpty]("b") -> 2)
     assert(json.as[Map[String Refined NonEmpty, Int]] === Right(expected))
   }
 
-  it should "not decode when invalid" in {
+  test("Refined Keys should not decode when invalid") {
     val json = Json.obj("a" -> 1.asJson, "" -> 2.asJson)
     assert(json.as[Map[String Refined NonEmpty, Int]].isLeft)
   }

--- a/modules/scodec/shared/src/test/scala/io/circe/scodec/ScodecSuite.scala
+++ b/modules/scodec/shared/src/test/scala/io/circe/scodec/ScodecSuite.scala
@@ -1,14 +1,15 @@
 package io.circe.scodec
 
 import cats.kernel.Eq
+import cats.syntax.eq._
 import io.circe.Json
 import io.circe.parser.decode
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import org.scalacheck.Arbitrary
 import _root_.scodec.bits._
 
-class ScodecSuite extends CirceSuite {
+class ScodecSuite extends CirceMunitSuite {
   implicit val arbitraryBitVector: Arbitrary[BitVector] =
     Arbitrary(Arbitrary.arbitrary[Iterable[Boolean]].map(BitVector.bits))
 
@@ -21,12 +22,12 @@ class ScodecSuite extends CirceSuite {
   checkAll("Codec[BitVector]", CodecTests[BitVector].codec)
   checkAll("Codec[ByteVector]", CodecTests[ByteVector].codec)
 
-  "Codec[ByteVector]" should "return failure for Json String" in {
+  test("Codec[ByteVector] should return failure for Json String") {
     val json = Json.fromString("mA==")
     assert(decodeBitVector.decodeJson(json).isLeft)
   }
 
-  "Codec[ByteVector]" should "return failure in case input is an incomplete object" in {
+  test("Codec[ByteVector] should return failure in case input is an incomplete object") {
     assert(decode("{}")(decodeBitVector).isLeft)
     assert(decode("""{"bits": "mA=="}""")(decodeBitVector).isLeft)
     assert(decode("""{"length": 6}""")(decodeBitVector).isLeft)
@@ -34,7 +35,7 @@ class ScodecSuite extends CirceSuite {
 
   // this test shows that decoder is to some extend liberal
   // even though such input could not have been produced by BitVector encoder it's getting decoded to BitVector
-  "Codec[ByteVector]" should "return empty BitVector in case contains only non-zero header" in {
+  test("Codec[ByteVector] should return empty BitVector in case contains only non-zero header") {
     assert(decode("""{"bits": "mA==", "length": 8}""")(decodeBitVector) === Right(bin"10011000"))
     assert(decode("""{"bits": "mA==", "length": 16}""")(decodeBitVector) === Right(bin"10011000"))
     assert(decode("""{"bits": "mA==", "length": 0}""")(decodeBitVector) === Right(BitVector.empty))

--- a/modules/tests/js/src/test/scala/io/circe/FloatJsonTests.scala
+++ b/modules/tests/js/src/test/scala/io/circe/FloatJsonTests.scala
@@ -1,9 +1,9 @@
 package io.circe
 
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 
 /**
  * On the JVM this trait contains tests that fail because of limitations on
  * Scala.js.
  */
-trait FloatJsonTests { this: CirceSuite => }
+trait FloatJsonTests { this: CirceMunitSuite => }

--- a/modules/tests/jvm/src/test/scala/io/circe/FloatJsonTests.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/FloatJsonTests.scala
@@ -1,13 +1,13 @@
 package io.circe
 
 import cats.syntax.eq._
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 
 /**
  * Tests that fail because of limitations on Scala.js.
  */
-trait FloatJsonTests { this: CirceSuite =>
-  "fromFloatOrString" should "return a Json number for valid Floats" in {
+trait FloatJsonTests { this: CirceMunitSuite =>
+  test("fromFloatOrString should return a Json number for valid Floats") {
     assert(Json.fromFloatOrString(1.1f) === Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe("1.1")))
     assert(Json.fromFloatOrString(-1.2f) === Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe("-1.2")))
   }

--- a/modules/tests/jvm/src/test/scala/io/circe/PrinterWriterReuseSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/PrinterWriterReuseSuite.scala
@@ -1,27 +1,24 @@
 package io.circe
 
-import cats.instances.all._
-import cats.syntax.eq._
-import io.circe.tests.CirceSuite
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{ Millis, Span }
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import io.circe.tests.CirceMunitSuite
+import org.scalacheck.Prop
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration._
 
-class PrinterWriterReuseSuite extends CirceSuite with ScalaFutures {
-  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(1000, Millis))
+class PrinterWriterReuseSuite extends CirceMunitSuite {
+  implicit val ec: ExecutionContext = ExecutionContext.global
 
-  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(
-    sizeRange = 100
-  )
+  override protected val scalaCheckTestParameters =
+    super.scalaCheckTestParameters.withMaxSize(100)
 
-  "Printer#reuseWriters" should "not change the behavior of print" in forAll { (values: List[Json]) =>
+  property("Printer#reuseWriters should not change the behavior of print")(reuseWritersProp)
+
+  val reuseWritersProp: Prop = Prop.forAll { (values: List[Json]) =>
     val default = Printer.spaces4
     val reusing = default.copy(reuseWriters = true)
     val expected = values.map(default.print)
 
-    whenReady(Future.traverse(values)(value => Future(reusing.print(value)))) { result =>
-      assert(result === expected)
-    }
+    val merged = Future.traverse(values)(value => Future(reusing.print(value)))
+    assertEquals(Await.result(merged, 1.second), expected)
   }
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala
@@ -23,7 +23,7 @@ trait Spaces2PrinterExample { this: Spaces2PrinterSuite =>
   val expected = source.mkString
   source.close()
 
-  "Printer.spaces2" should "generate the expected output for the example doc" in {
+  test("Printer.spaces2 should generate the expected output for the example doc") {
     val printed = Printer.spaces2.print(doc) + "\n"
 
     assert(printed === expected)

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CirceMunitSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CirceMunitSuite.scala
@@ -1,0 +1,9 @@
+package io.circe.tests
+
+import io.circe.testing.{ ArbitraryInstances, EqInstances }
+import munit.DisciplineSuite
+
+/**
+ * An opinionated stack of traits to improve consistency and reduce boilerplate in circe tests.
+ */
+trait CirceMunitSuite extends DisciplineSuite with ArbitraryInstances with EqInstances with MissingInstances

--- a/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -4,8 +4,9 @@ import cats.kernel.instances.all._
 import io.circe.{ Json, Parser, Printer }
 import io.circe.testing.PrinterTests
 import java.nio.charset.StandardCharsets.UTF_8
+import org.scalacheck.Prop.forAll
 
-class PrinterSuite(val printer: Printer, val parser: Parser) extends CirceSuite with PlatformSpecificPrinterTests {
+class PrinterSuite(val printer: Printer, val parser: Parser) extends CirceMunitSuite with PlatformSpecificPrinterTests {
   checkAll("Printing Unit", PrinterTests[Unit].printer(printer, parser))
   checkAll("Printing Boolean", PrinterTests[Boolean].printer(printer, parser))
   checkAll("Printing Char", PrinterTests[Char].printer(printer, parser))
@@ -15,7 +16,8 @@ class PrinterSuite(val printer: Printer, val parser: Parser) extends CirceSuite 
   checkAll("Printing Int", PrinterTests[Int].printer(printer, parser))
   checkAll("Printing Map", PrinterTests[Map[String, List[Int]]].printer(printer, parser))
 
-  "printToByteBuffer" should "match print" in forAll { (json: Json, predictSize: Boolean) =>
+  property("printToByteBuffer should match print")(printToBufferProp)
+  private lazy val printToBufferProp = forAll { (json: Json, predictSize: Boolean) =>
     val buffer = printer.copy(predictSize = predictSize).printToByteBuffer(json)
 
     val bytes = new Array[Byte](buffer.limit)

--- a/modules/tests/shared/src/test/scala-0/io/circe/DerivesSuite.scala
+++ b/modules/tests/shared/src/test/scala-0/io/circe/DerivesSuite.scala
@@ -5,7 +5,7 @@ import cats.kernel.instances.all._
 import cats.syntax.eq._
 import io.circe.{ Codec, Decoder, Encoder, Json }
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import org.scalacheck.{ Arbitrary, Gen }
 
 object DerivesSuite {
@@ -128,7 +128,7 @@ object DerivesSuite {
   }
 }
 
-class DerivesSuite extends CirceSuite {
+class DerivesSuite extends CirceMunitSuite {
   import DerivesSuite._
 
   checkAll("Codec[Box[Wub]]", CodecTests[Box[Wub]].codec)

--- a/modules/tests/shared/src/test/scala-2.13/io/circe/ArraySeqSuite.scala
+++ b/modules/tests/shared/src/test/scala-2.13/io/circe/ArraySeqSuite.scala
@@ -1,41 +1,45 @@
 package io.circe
 
-import cats.Eq
-import io.circe.tests.CirceSuite
+import cats.syntax.eq._
+import io.circe.tests.CirceMunitSuite
 import io.circe.syntax.EncoderOps
-import cats.instances.list.catsKernelStdEqForList
 import cats.instances.int.catsKernelStdOrderForInt
 import cats.instances.string.catsKernelStdOrderForString
 import io.circe.testing.CodecTests
-
+import org.scalacheck.Prop.forAll
 import scala.collection.immutable.ArraySeq
 
-class ArraySeqSuite extends CirceSuite {
-
-  // TODO this can be removed once Cats 2.2.0 is used
-  implicit def eqForArraySeq[A: Eq]: Eq[ArraySeq[A]] = Eq.by(_.toList)
+class ArraySeqSuite extends CirceMunitSuite {
 
   def decodeArraySeqWithoutClassTag[A: Decoder](json: Json): Decoder.Result[ArraySeq[A]] =
     json.as[ArraySeq[A]]
 
-  "decoding an arraySeq" should "succeed when the type is fully specified" in forAll { int: Int =>
-    assert(Json.arr(int.asJson).as[ArraySeq[Int]] === Right(ArraySeq(int)))
+  property("decoding an arraySeq should succeed when the type is fully specified") {
+    forAll { int: Int =>
+      assert(Json.arr(int.asJson).as[ArraySeq[Int]] === Right(ArraySeq(int)))
+    }
   }
 
-  it should "succeed for polymorphic decoders" in forAll { string: String =>
-    assert(decodeArraySeqWithoutClassTag[String](Json.arr(string.asJson)) === Right(ArraySeq(string)))
+  property("decoding an arraySeq should succeed for polymorphic decoders") {
+    forAll { string: String =>
+      assert(decodeArraySeqWithoutClassTag[String](Json.arr(string.asJson)) === Right(ArraySeq(string)))
+    }
   }
 
-  it should "specialise the array type where a class tag is available" in forAll { intArray: Array[Int] =>
-    val jsonArray = Json.arr(intArray.map(_.asJson): _*)
+  property("decoding an arraySeq should specialise the array type where a class tag is available") {
+    forAll { intArray: Array[Int] =>
+      val jsonArray = Json.arr(intArray.map(_.asJson): _*)
 
-    assert(jsonArray.as[ArraySeq[Int]].map(_.getClass) == Right(classOf[ArraySeq.ofInt]))
+      assert(jsonArray.as[ArraySeq[Int]].map(_.getClass) == Right(classOf[ArraySeq.ofInt]))
+    }
   }
 
-  it should "not specialise the array type where no class tag is available" in forAll { intArray: Array[Int] =>
-    val jsonArray = Json.arr(intArray.map(_.asJson): _*)
+  property("decoding an arraySeq should not specialise the array type where no class tag is available") {
+    forAll { intArray: Array[Int] =>
+      val jsonArray = Json.arr(intArray.map(_.asJson): _*)
 
-    assert(decodeArraySeqWithoutClassTag[Int](jsonArray).map(_.getClass) == Right(classOf[ArraySeq.ofRef[_]]))
+      assert(decodeArraySeqWithoutClassTag[Int](jsonArray).map(_.getClass) == Right(classOf[ArraySeq.ofRef[_]]))
+    }
   }
 
   checkAll("Codec[ArraySeq[Int]]", CodecTests[ArraySeq[Int]].codec)

--- a/modules/tests/shared/src/test/scala-2.13/io/circe/LiteralSuite.scala
+++ b/modules/tests/shared/src/test/scala-2.13/io/circe/LiteralSuite.scala
@@ -3,10 +3,10 @@ package io.circe
 import cats.kernel.Eq
 import cats.kernel.instances.all._
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import org.scalacheck.{ Arbitrary, Gen }
 
-class LiteralCodecSuite extends CirceSuite {
+class LiteralCodecSuite extends CirceMunitSuite {
   implicit def arbitraryLiteral[L](implicit L: ValueOf[L]): Arbitrary[L] = Arbitrary(Gen.const(L.value))
   implicit def eqLiteral[A, L <: A](implicit A: Eq[A], L: ValueOf[L]): Eq[L] = Eq.by[L, A](identity)
 

--- a/modules/tests/shared/src/test/scala-2/io/circe/EnumerationSuite.scala
+++ b/modules/tests/shared/src/test/scala-2/io/circe/EnumerationSuite.scala
@@ -4,11 +4,11 @@ import cats.kernel.Eq
 import io.circe.parser.parse
 import io.circe.syntax._
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import org.scalacheck.{ Arbitrary, Gen }
 
-class EnumerationSuite extends CirceSuite {
-  "Decoder[Enumeration]" should "parse Scala Enumerations" in {
+class EnumerationSuite extends CirceMunitSuite {
+  test("Decoder[Enumeration] should parse Scala Enumerations") {
     object WeekDay extends Enumeration {
       type WeekDay = Value
       val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
@@ -19,7 +19,7 @@ class EnumerationSuite extends CirceSuite {
     assert(decoder.apply(friday.hcursor) == Right(WeekDay.Fri))
   }
 
-  "Decoder[Enumeration]" should "fail on unknown values in Scala Enumerations" in {
+  test("Decoder[Enumeration] should fail on unknown values in Scala Enumerations") {
     object WeekDay extends Enumeration {
       type WeekDay = Value
       val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
@@ -31,7 +31,7 @@ class EnumerationSuite extends CirceSuite {
     assert(decoder.apply(friday.hcursor).isLeft)
   }
 
-  "Encoder[Enumeration]" should "write Scala Enumerations" in {
+  test("Encoder[Enumeration] should write Scala Enumerations") {
     object WeekDay extends Enumeration {
       type WeekDay = Value
       val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
@@ -44,7 +44,7 @@ class EnumerationSuite extends CirceSuite {
   }
 }
 
-class EnumerationCodecSuite extends CirceSuite {
+class EnumerationCodecSuite extends CirceMunitSuite {
   object WeekDay extends Enumeration {
     type WeekDay = Value
     val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value

--- a/modules/tests/shared/src/test/scala/io/circe/ACursorSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/ACursorSuite.scala
@@ -3,9 +3,10 @@ package io.circe
 import cats.instances.all._
 import cats.syntax.eq._
 import io.circe.syntax._
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
+import org.scalacheck.Prop.forAll
 
-class ACursorSuite extends CirceSuite {
+class ACursorSuite extends CirceMunitSuite {
   val j1: Json = Json.obj(
     "a" -> (1 to 5).toList.asJson,
     "b" -> Map("d" -> List(true, false, true)).asJson,
@@ -31,11 +32,14 @@ class ACursorSuite extends CirceSuite {
 
   val cursor: ACursor = HCursor.fromJson(j1)
 
-  "focus" should "return the JSON value in a newly created cursor" in forAll { (j: Json) =>
-    assert(HCursor.fromJson(j).focus === Some(j))
+  property("focus should return the JSON value in a newly created cursor") {
+    forAll { (j: Json) =>
+      assert(HCursor.fromJson(j).focus === Some(j))
+    }
   }
 
-  "top" should "return from navigation into an object" in forAll { (j: Json) =>
+  property("top should return from navigation into an object")(topProp)
+  private lazy val topProp = forAll { (j: Json) =>
     val c = HCursor.fromJson(j)
 
     val intoObject = for {
@@ -47,11 +51,14 @@ class ACursorSuite extends CirceSuite {
     assert(intoObject.forall(atFirst => atFirst.top === Some(j)))
   }
 
-  it should "return from navigation into an array" in forAll { (j: Json) =>
-    assert(HCursor.fromJson(j).downArray.success.forall(atFirst => atFirst.top === Some(j)))
+  property("top should return from navigation into an array") {
+    forAll { (j: Json) =>
+      assert(HCursor.fromJson(j).downArray.success.forall(atFirst => atFirst.top === Some(j)))
+    }
   }
 
-  "up" should "undo navigation into an object" in forAll { (j: Json) =>
+  property("up should undo navigation into an object")(upUndoObjectProp)
+  lazy val upUndoObjectProp = forAll { (j: Json) =>
     val c = HCursor.fromJson(j)
 
     val intoObject = for {
@@ -63,23 +70,27 @@ class ACursorSuite extends CirceSuite {
     assert(intoObject.forall(_.up.success.flatMap(_.focus) === Some(j)))
   }
 
-  it should "undo navigation into an array" in forAll { (j: Json) =>
-    assert(
-      HCursor.fromJson(j).downArray.success.forall(atFirst => atFirst.up.success.flatMap(_.focus) === Some(j))
-    )
+  property("up should undo navigation into an array") {
+    forAll { (j: Json) =>
+      val success = HCursor.fromJson(j).downArray.success
+      assert(success.forall(atFirst => atFirst.up.success.flatMap(_.focus) === Some(j)))
+    }
   }
 
-  it should "fail at the top" in forAll { (j: Json) =>
-    val result = HCursor.fromJson(j).up
-
-    assert(result.failed && result.history === List(CursorOp.MoveUp))
+  property("up should fail at the top") {
+    forAll { (j: Json) =>
+      val result = HCursor.fromJson(j).up
+      assert(result.failed && result.history === List(CursorOp.MoveUp))
+    }
   }
 
-  "withFocus" should "have no effect when given the identity function" in forAll { (j: Json) =>
-    assert(HCursor.fromJson(j).withFocus(identity).focus === Some(j))
+  property("withFocus should have no effect when given the identity function") {
+    forAll { (j: Json) =>
+      assert(HCursor.fromJson(j).withFocus(identity).focus === Some(j))
+    }
   }
 
-  it should "support adding an element to an array" in {
+  test("withFocus should support adding an element to an array") {
     val result = cursor
       .downField("a")
       .success
@@ -90,17 +101,20 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.top) === Some(j2))
   }
 
-  "withFocusM" should "lift a value into a List" in forAll { (j: Json) =>
-    assert(HCursor.fromJson(j).withFocusM[List](List(_)).head.focus === Some(j))
+  property("withFocusM should lift a value into a List") {
+    forAll { (j: Json) =>
+      assert(HCursor.fromJson(j).withFocusM[List](List(_)).head.focus === Some(j))
+    }
   }
 
-  "delete" should "remove a value from an object" in {
+  test("delete should remove a value from an object") {
     val result = cursor.downField("b").success.flatMap(_.delete.success)
 
     assert(result.flatMap(_.top) === Some(j4))
   }
 
-  it should "remove a value from an array" in forAll { (h: Json, t: List[Json]) =>
+  property("delete should remove a value from an array")(deleteArrayProp)
+  private lazy val deleteArrayProp = forAll { (h: Json, t: List[Json]) =>
     val result = for {
       f <- HCursor.fromJson(Json.fromValues(h :: t)).downArray.success
       u <- f.delete.success
@@ -109,27 +123,29 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.focus) === Some(Json.fromValues(t)))
   }
 
-  it should "fail at the top" in forAll { (j: Json) =>
-    val result = HCursor.fromJson(j).delete
+  property("delete should fail at the top") {
+    forAll { (j: Json) =>
+      val result = HCursor.fromJson(j).delete
 
-    assert(result.failed && result.history === List(CursorOp.DeleteGoParent))
+      assert(result.failed && result.history === List(CursorOp.DeleteGoParent))
+    }
   }
 
-  "set" should "replace an element" in {
+  test("set should replace an element") {
     val result = cursor.downField("b").success.map(_.set(10.asJson))
 
     assert(result.flatMap(_.top) === Some(j3))
   }
 
-  "values" should "return the expected values" in {
+  test("values should return the expected values") {
     assert(cursor.downField("a").values.map(_.toVector) === Some((1 to 5).toVector.map(_.asJson)))
   }
 
-  "keys" should "return the expected values" in {
+  test("keys should return the expected values") {
     assert(cursor.keys.map(_.toVector) === Some(Vector("a", "b", "c")))
   }
 
-  "left" should "successfully select an existing value" in {
+  test("left should successfully select an existing value") {
     val result = for {
       c <- cursor.downField("a").success
       a <- c.downN(3).success
@@ -139,7 +155,7 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.focus) === Some(3.asJson))
   }
 
-  it should "fail to select a value that doesn't exist" in {
+  test("left should fail to select a value that doesn't exist") {
     val result = for {
       c <- cursor.downField("b").success
       l <- c.left.success
@@ -148,13 +164,14 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.focus) === None)
   }
 
-  it should "fail at the top" in forAll { (j: Json) =>
-    val result = HCursor.fromJson(j).left
-
-    assert(result.failed && result.history === List(CursorOp.MoveLeft))
+  property("left should fail at the top") {
+    forAll { (j: Json) =>
+      val result = HCursor.fromJson(j).left
+      assert(result.failed && result.history === List(CursorOp.MoveLeft))
+    }
   }
 
-  "right" should "successfully select an existing value" in {
+  test("right should successfully select an existing value") {
     val result = for {
       c <- cursor.downField("a").success
       a <- c.downN(3).success
@@ -164,7 +181,7 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.focus) === Some(5.asJson))
   }
 
-  it should "fail to select a value that doesn't exist" in {
+  test("right should fail to select a value that doesn't exist") {
     val result = for {
       c <- cursor.downField("b").success
       r <- c.right.success
@@ -173,13 +190,14 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.focus) === None)
   }
 
-  it should "fail at the top" in forAll { (j: Json) =>
-    val result = HCursor.fromJson(j).right
-
-    assert(result.failed && result.history === List(CursorOp.MoveRight))
+  property("right should fail at the top") {
+    forAll { (j: Json) =>
+      val result = HCursor.fromJson(j).right
+      assert(result.failed && result.history === List(CursorOp.MoveRight))
+    }
   }
 
-  "first" should "successfully select an existing value" in {
+  test("first should successfully select an existing value") {
     val result = for {
       c <- cursor.downField("a").success
       a <- c.downN(3).success
@@ -189,7 +207,7 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.focus) === Some(1.asJson))
   }
 
-  it should "fail to select a value that doesn't exist" in {
+  test("first should fail to select a value that doesn't exist") {
     val result = for {
       c <- cursor.downField("b").success
       f <- c.first.success
@@ -198,13 +216,14 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.focus) === None)
   }
 
-  it should "fail at the top" in forAll { (j: Json) =>
-    val result = HCursor.fromJson(j).first
-
-    assert(result.failed && result.history === List(CursorOp.MoveFirst))
+  property("first should fail at the top") {
+    forAll { (j: Json) =>
+      val result = HCursor.fromJson(j).first
+      assert(result.failed && result.history === List(CursorOp.MoveFirst))
+    }
   }
 
-  "field" should "successfully select an existing value" in {
+  test("field should successfully select an existing value") {
     val result = for {
       c <- cursor.downField("c").success
       e <- c.downField("e").success
@@ -214,27 +233,28 @@ class ACursorSuite extends CirceSuite {
     assert(result.flatMap(_.focus) === Some(200.2.asJson))
   }
 
-  it should "fail at the top" in forAll { (j: Json, key: String) =>
-    val result = HCursor.fromJson(j).field(key)
-
-    assert(result.failed && result.history === List(CursorOp.Field(key)))
+  property("field should fail at the top") {
+    forAll { (j: Json, key: String) =>
+      val result = HCursor.fromJson(j).field(key)
+      assert(result.failed && result.history === List(CursorOp.Field(key)))
+    }
   }
 
-  "getOrElse" should "successfully decode an existing field" in {
+  test("getOrElse should successfully decode an existing field") {
     val result = for {
       b <- cursor.downField("b").success
     } yield b.getOrElse[List[Boolean]]("d")(Nil)
     assert(result === Some(Right(List(true, false, true))))
   }
 
-  it should "use the fallback if field is missing" in {
+  test("getOrElse should use the fallback if field is missing") {
     val result = for {
       b <- cursor.downField("b").success
     } yield b.getOrElse[List[Boolean]]("z")(Nil)
     assert(result === Some(Right(Nil)))
   }
 
-  it should "fail if the field is the wrong type" in {
+  test("getOrElse should fail if the field is the wrong type") {
     val result = for {
       b <- cursor.downField("b").success
     } yield b.getOrElse[List[Int]]("d")(Nil)

--- a/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
@@ -2,10 +2,11 @@ package io.circe
 
 import cats.kernel.Eq
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import java.time._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
 import scala.collection.JavaConverters._
 
 case class JavaTimeCaseClass(foo: Duration, bar: Option[LocalTime], baz: List[ZoneId])
@@ -20,7 +21,7 @@ object JavaTimeCaseClass {
     }
 }
 
-class JavaTimeCodecSuite extends CirceSuite {
+class JavaTimeCodecSuite extends CirceMunitSuite {
   private[this] val minInstant: Instant = Instant.EPOCH
   private[this] val maxInstant: Instant = Instant.parse("3000-01-01T00:00:00.00Z")
 
@@ -131,9 +132,9 @@ class JavaTimeCodecSuite extends CirceSuite {
   val invalidJson: Json = Json.fromString(invalidText)
   val parseExceptionMessage = s"Text '$invalidText'"
 
-  "Decoder[ZoneId]" should "fail for invalid ZoneId" in {
+  property("Decoder[ZoneId] should fail for invalid ZoneId") {
     forAll((s: String) =>
-      whenever(!ZoneId.getAvailableZoneIds.contains(s)) {
+      if (!ZoneId.getAvailableZoneIds.contains(s)) {
         val decodingResult = Decoder[ZoneId].decodeJson(Json.fromString(s))
 
         assert(decodingResult.isLeft)
@@ -144,14 +145,14 @@ class JavaTimeCodecSuite extends CirceSuite {
     )
   }
 
-  "Decoder[Instant]" should "fail on invalid values" in {
+  test("Decoder[Instant] should fail on invalid values") {
     val decodingResult = Decoder[Instant].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Encoder[Instant]" should "serialize 00 seconds and drop zeroes in nanos to millis or micros" in {
+  test("Encoder[Instant] should serialize 00 seconds and drop zeroes in nanos to millis or micros") {
     def check(s: String): Unit =
       assert(Encoder[Instant].apply(Instant.parse(s)) == Json.fromString(s))
 
@@ -166,14 +167,14 @@ class JavaTimeCodecSuite extends CirceSuite {
     check("2018-07-10T00:00:00.000000010Z")
   }
 
-  "Decoder[LocalDateTime]" should "fail on invalid values" in {
+  test("Decoder[LocalDateTime] should fail on invalid values") {
     val decodingResult = Decoder[LocalDateTime].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Encoder[LocalDateTime]" should "serialize 00 seconds and drop all remaining zeroes in nanos" in {
+  test("Encoder[LocalDateTime] should serialize 00 seconds and drop all remaining zeroes in nanos") {
     def check(s: String): Unit =
       assert(Encoder[LocalDateTime].apply(LocalDateTime.parse(s)) == Json.fromString(s))
 
@@ -188,14 +189,14 @@ class JavaTimeCodecSuite extends CirceSuite {
     check("2018-07-10T00:00:00.00000001")
   }
 
-  "Decoder[ZonedDateTime]" should "fail on invalid values" in {
+  test("Decoder[ZonedDateTime] should fail on invalid values") {
     val decodingResult = Decoder[ZonedDateTime].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Encoder[ZonedDateTime]" should "serialize 00 seconds and drop all remaining zeroes in nanos" in {
+  test("Encoder[ZonedDateTime] should serialize 00 seconds and drop all remaining zeroes in nanos") {
     def check(s: String): Unit =
       assert(Encoder[ZonedDateTime].apply(ZonedDateTime.parse(s)) == Json.fromString(s))
 
@@ -210,14 +211,14 @@ class JavaTimeCodecSuite extends CirceSuite {
     check("2018-07-10T00:00:00.00000001Z[UTC]")
   }
 
-  "Decoder[OffsetDateTime]" should "fail on invalid values" in {
+  test("Decoder[OffsetDateTime] should fail on invalid values") {
     val decodingResult = Decoder[OffsetDateTime].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Encoder[OffsetDateTime]" should "serialize 00 seconds and drop all remaining zeroes in nanos" in {
+  test("Encoder[OffsetDateTime] should serialize 00 seconds and drop all remaining zeroes in nanos") {
     def check(s: String): Unit =
       assert(Encoder[OffsetDateTime].apply(OffsetDateTime.parse(s)) == Json.fromString(s))
 
@@ -232,21 +233,21 @@ class JavaTimeCodecSuite extends CirceSuite {
     check("2018-07-10T00:00:00.00000001Z")
   }
 
-  "Decoder[LocalDate]" should "fail on invalid values" in {
+  test("Decoder[LocalDate] should fail on invalid values") {
     val decodingResult = Decoder[LocalDate].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Decoder[LocalTime]" should "fail on invalid values" in {
+  test("Decoder[LocalTime] should fail on invalid values") {
     val decodingResult = Decoder[LocalTime].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Encoder[LocalTime]" should "serialize 00 seconds and drop all remaining zeroes in nanos" in {
+  test("Encoder[LocalTime] should serialize 00 seconds and drop all remaining zeroes in nanos") {
     def check(s: String): Unit =
       assert(Encoder[LocalTime].apply(LocalTime.parse(s)) == Json.fromString(s))
 
@@ -261,21 +262,21 @@ class JavaTimeCodecSuite extends CirceSuite {
     check("00:00:00.00000001")
   }
 
-  "Decoder[MonthDay]" should "fail on invalid values" in {
+  test("Decoder[MonthDay] should fail on invalid values") {
     val decodingResult = Decoder[MonthDay].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Decoder[OffsetTime]" should "fail on invalid values" in {
+  test("Decoder[OffsetTime] should fail on invalid values") {
     val decodingResult = Decoder[OffsetTime].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Encoder[OffsetTime]" should "serialize 00 seconds and drop all remaining zeroes in nanos" in {
+  test("Encoder[OffsetTime] should serialize 00 seconds and drop all remaining zeroes in nanos") {
     def check(s: String): Unit =
       assert(Encoder[OffsetTime].apply(OffsetTime.parse(s)) == Json.fromString(s))
 
@@ -290,35 +291,35 @@ class JavaTimeCodecSuite extends CirceSuite {
     check("00:00:00.00000001Z")
   }
 
-  "Decoder[Period]" should "fail on invalid values" in {
+  test("Decoder[Period] should fail on invalid values") {
     val decodingResult = Decoder[Period].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(s"Text '$invalidText' cannot be parsed to a Period")))
   }
 
-  "Decoder[Year]" should "fail on invalid values" in {
+  test("Decoder[Year] should fail on invalid values") {
     val decodingResult = Decoder[Year].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Decoder[YearMonth]" should "fail on invalid values" in {
+  test("Decoder[YearMonth] should fail on invalid values") {
     val decodingResult = Decoder[YearMonth].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(parseExceptionMessage)))
   }
 
-  "Decoder[Duration]" should "fail on invalid values" in {
+  test("Decoder[Duration] should fail on invalid values") {
     val decodingResult = Decoder[Duration].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)
     assert(decodingResult.swap.exists(_.message.contains(s"Text '$invalidText' cannot be parsed to a Duration")))
   }
 
-  "Decoder[ZoneOffset]" should "fail on invalid values" in {
+  test("Decoder[ZoneOffset] should fail on invalid values") {
     val decodingResult = Decoder[ZoneOffset].apply(invalidJson.hcursor)
 
     assert(decodingResult.isLeft)

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -4,13 +4,11 @@ import cats.data.Const
 import cats.instances.all._
 import cats.kernel.Eq
 import cats.syntax.eq._
-import io.circe.tests.CirceMunitSuite
-import org.scalacheck.Prop.forAll
+import io.circe.tests.CirceSuite
 import org.scalatest.exceptions.TestFailedException
 
-class JsonObjectSuite extends CirceMunitSuite {
-
-  property("JsonObject.fromIterable should drop all but the last instance when fields have the same key") {
+class JsonObjectSuite extends CirceSuite {
+  "JsonObject.fromIterable" should "drop all but the last instance when fields have the same key" in {
     forAll { (key: String, values: List[Json]) =>
       val result = JsonObject.fromIterable(values.map(key -> _))
       val expected = if (values.isEmpty) JsonObject.empty else JsonObject.singleton(key, values.last)
@@ -19,15 +17,14 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  test("JsonObject.fromIterable should maintain the first position when keys are duplicated") {
+  it should "maintain the first position when keys are duplicated" in {
     val fields = List("a" -> Json.fromInt(0), "b" -> Json.fromInt(1), "c" -> Json.fromInt(2), "b" -> Json.fromInt(3))
     val expected = JsonObject("a" -> Json.fromInt(0), "b" -> Json.fromInt(3), "c" -> Json.fromInt(2))
 
     assert(JsonObject.fromIterable(fields) === expected)
   }
 
-  property("JsonObject.fromFoldable should match JsonObject.fromIterable")(fromFoldableProp)
-  private lazy val fromFoldableProp = forAll { (fields: List[(String, Json)]) =>
+  "JsonObject.fromFoldable" should "match JsonObject.fromIterable" in { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
 
@@ -35,7 +32,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result1 === result2)
   }
 
-  property("JsonObject.fromFoldable should drop all but the last instance when fields have the same key") {
+  it should "drop all but the last instance when fields have the same key" in {
     forAll { (key: String, values: List[Json]) =>
       val result = JsonObject.fromFoldable(values.map(key -> _))
       val expected = if (values.isEmpty) JsonObject.empty else JsonObject.singleton(key, values.last)
@@ -44,21 +41,18 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  test("JsonObject.fromFoldable should maintain the first position when keys are duplicated") {
+  it should "maintain the first position when keys are duplicated" in {
     val fields = List("a" -> Json.fromInt(0), "b" -> Json.fromInt(1), "c" -> Json.fromInt(2), "b" -> Json.fromInt(3))
     val expected = JsonObject("a" -> Json.fromInt(0), "b" -> Json.fromInt(3), "c" -> Json.fromInt(2))
 
     assert(JsonObject.fromFoldable(fields) === expected)
   }
 
-  property("JsonObject.apply should match JsonObject.fromIterable") {
-    forAll { (fields: List[(String, Json)]) =>
-      assert(JsonObject(fields: _*) === JsonObject.fromIterable(fields))
-    }
+  "JsonObject.apply" should "match JsonObject.fromIterable" in { (fields: List[(String, Json)]) =>
+    assert(JsonObject(fields: _*) === JsonObject.fromIterable(fields))
   }
 
-  property("apply should find fields if they exist")(applyProp)
-  private lazy val applyProp = forAll { (fields: List[(String, Json)], key: String) =>
+  "apply" should "find fields if they exist" in { (fields: List[(String, Json)], key: String) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.find(_._1 == key).map(_._2)
@@ -67,8 +61,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2(key) === expected)
   }
 
-  property("contains should find fields if they exist")(containsProp)
-  private lazy val containsProp = forAll { (fields: List[(String, Json)], key: String) =>
+  "contains" should "find fields if they exist" in { (fields: List[(String, Json)], key: String) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.find(_._1 == key).nonEmpty
@@ -77,8 +70,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.contains(key) === expected)
   }
 
-  property("size should return the expected result")(sizeProp)
-  private lazy val sizeProp = forAll { (fields: List[(String, Json)]) =>
+  "size" should "return the expected result" in { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.toMap.size
@@ -87,8 +79,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.size === expected)
   }
 
-  property("isEmpty should return the expected result")(isEmptyProp)
-  private lazy val isEmptyProp = forAll { (fields: List[(String, Json)]) =>
+  "isEmpty" should "return the expected result" in { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.isEmpty
@@ -97,8 +88,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.isEmpty === expected)
   }
 
-  property("nonEmpty should return the expected result")(nonEmptyProp)
-  private lazy val nonEmptyProp = forAll { (fields: List[(String, Json)]) =>
+  "nonEmpty" should "return the expected result" in { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.nonEmpty
@@ -107,8 +97,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.nonEmpty === expected)
   }
 
-  property("kleisli should find fields if they exist")(kleisliProp)
-  lazy val kleisliProp = forAll { (fields: List[(String, Json)], key: String) =>
+  "kleisli" should "find fields if they exist" in { (fields: List[(String, Json)], key: String) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.find(_._1 == key).map(_._2)
@@ -117,8 +106,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.kleisli(key) === expected)
   }
 
-  property("keys should return all keys")(keysProp)
-  private lazy val keysProp = forAll { (fields: List[(String, Json)]) =>
+  "keys" should "return all keys" in forAll { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected = fields.map(_._1).distinct
@@ -127,8 +115,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.keys.toList === expected)
   }
 
-  property("values should return all values")(ValuesExhaustiveProp)
-  lazy val ValuesExhaustiveProp = forAll { (fields: List[(String, Json)]) =>
+  "values" should "return all values" in forAll { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected: List[Json] = fields
@@ -148,8 +135,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.values.toList === expected)
   }
 
-  property("toMap should round-trip through JsonObject.fromMap")(toMapProp)
-  private lazy val toMapProp = forAll { (fields: List[(String, Json)]) =>
+  "toMap" should "round-trip through JsonObject.fromMap" in forAll { (fields: List[(String, Json)]) =>
     val result1 = JsonObject.fromIterable(fields)
     val result2 = JsonObject.fromFoldable(fields)
     val expected = result1
@@ -158,8 +144,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(JsonObject.fromMap(result2.toMap) === expected)
   }
 
-  property("toIterable should return all fields")(toIterableExhaustiveProp)
-  lazy val toIterableExhaustiveProp = forAll { (values: List[Json]) =>
+  "toIterable" should "return all fields" in forAll { (values: List[Json]) =>
     val fields = values.zipWithIndex.map {
       case (value, i) => i.toString -> value
     }.reverse
@@ -171,8 +156,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.toIterable.toList === fields)
   }
 
-  property("toList should return all fields")(toListExhaustiveProp)
-  lazy val toListExhaustiveProp = forAll { (values: List[Json]) =>
+  "toList" should "return all fields" in forAll { (values: List[Json]) =>
     val fields = values.zipWithIndex.map {
       case (value, i) => i.toString -> value
     }.reverse
@@ -184,8 +168,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.toList === fields)
   }
 
-  property("toVector should return all fields")(toVectorProp)
-  private lazy val toVectorProp = forAll { (values: Vector[Json]) =>
+  "toVector" should "return all fields" in forAll { (values: Vector[Json]) =>
     val fields = values.zipWithIndex.map {
       case (value, i) => i.toString -> value
     }.reverse
@@ -197,7 +180,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2.toVector === fields)
   }
 
-  property("add should replace existing fields with the same key") {
+  "add" should "replace existing fields with the same key" in {
     forAll { (head: Json, tail: List[Json], replacement: Json) =>
       val fields = (head :: tail).zipWithIndex.map {
         case (value, i) => i.toString -> value
@@ -212,7 +195,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  property("add should replace existing fields with the same key in the correct position") {
+  it should "replace existing fields with the same key in the correct position" in {
     forAll { (head: Json, tail: List[Json], replacement: Json) =>
       val fields = (head :: tail).zipWithIndex.map {
         case (value, i) => i.toString -> value
@@ -227,7 +210,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  property("add, +:, and remove should be applied correctly") {
+  "add, +:, and remove" should "be applied correctly" in {
     forAll { (original: JsonObject, operations: List[Either[String, (String, Json, Boolean)]]) =>
       val result = operations.foldLeft(original) {
         case (acc, Right((key, value, true)))  => acc.add(key, value)
@@ -259,7 +242,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  property("+: should replace existing fields with the same key") {
+  "+:" should "replace existing fields with the same key" in {
     forAll { (head: Json, tail: List[Json], replacement: Json) =>
       val fields = (head :: tail).zipWithIndex.map {
         case (value, i) => i.toString -> value
@@ -274,7 +257,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  property("+: should replace existing fields with the same key in the correct position") {
+  it should "replace existing fields with the same key in the correct position" in {
     forAll { (head: Json, tail: List[Json], replacement: Json) =>
       val fields = (head :: tail).zipWithIndex.map {
         case (value, i) => i.toString -> value
@@ -289,8 +272,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  property("mapValues should transform the JSON object appropriately")(mapValuesTransformProp)
-  lazy val mapValuesTransformProp = forAll { (values: List[Json], replacement: Json) =>
+  "mapValues" should "transform the JSON object appropriately" in forAll { (values: List[Json], replacement: Json) =>
     val fields = values.zipWithIndex.map {
       case (value, i) => i.toString -> value
     }
@@ -303,8 +285,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2 === expected)
   }
 
-  property("traverse should transform the JSON object appropriately")(traverseTransformProp)
-  lazy val traverseTransformProp = forAll { (values: List[Json]) =>
+  "traverse" should "transform the JSON object appropriately" in forAll { (values: List[Json]) =>
     val fields = values.zipWithIndex.map {
       case (value, i) => i.toString -> value
     }
@@ -317,25 +298,21 @@ class JsonObjectSuite extends CirceMunitSuite {
     assert(result2 === Some(expected))
   }
 
-  property("traverse should return values in order")(traverseProp)
-  private lazy val traverseProp = forAll { (value: JsonObject) =>
+  it should "return values in order" in forAll { (value: JsonObject) =>
     val result = value.traverse[({ type L[x] = Const[List[Json], x] })#L](a => Const(List(a))).getConst
 
     assert(result === value.values.toList)
   }
 
-  property("filter should be consistent with Map#filter")(filterProp)
-  private lazy val filterProp = forAll { (value: JsonObject, pred: ((String, Json)) => Boolean) =>
+  "filter" should "be consistent with Map#filter" in forAll { (value: JsonObject, pred: ((String, Json)) => Boolean) =>
     assert(value.filter(pred).toMap === value.toMap.filter(pred))
   }
 
-  property("filterKeys should be consistent with Map#filterKeys") {
-    forAll { (value: JsonObject, pred: String => Boolean) =>
-      assert(value.filterKeys(pred).toMap === value.toMap.filterKeys(pred).toMap)
-    }
+  "filterKeys" should "be consistent with Map#filterKeys" in forAll { (value: JsonObject, pred: String => Boolean) =>
+    assert(value.filterKeys(pred).toMap === value.toMap.filterKeys(pred).toMap)
   }
 
-  property("Eq[JsonObject] should be consistent with comparing fields") {
+  "Eq[JsonObject]" should "be consistent with comparing fields" in {
     forAll { (fields1: List[(String, Json)], fields2: List[(String, Json)]) =>
       val result = Eq[JsonObject].eqv(JsonObject.fromIterable(fields1), JsonObject.fromIterable(fields2))
       val expected = fields1 == fields2
@@ -344,8 +321,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  property("deepMerge should merge correctly")(deepMergeCorrecProp)
-  lazy val deepMergeCorrecProp = forAll { (left: JsonObject, right: JsonObject) =>
+  "deepMerge" should "merge correctly" in forAll { (left: JsonObject, right: JsonObject) =>
     val merged = left.deepMerge(right)
 
     assert(merged.keys.toSet === (left.keys.toSet ++ right.keys.toSet))
@@ -360,8 +336,7 @@ class JsonObjectSuite extends CirceMunitSuite {
     }
   }
 
-  property("deepMerge should preserve argument order")(deepMergePreserveArgOrderProp)
-  lazy val deepMergePreserveArgOrderProp = forAll { (js: List[Json]) =>
+  it should "preserve argument order" in forAll { (js: List[Json]) =>
     val fields = js.zipWithIndex.map {
       case (j, i) => i.toString -> j
     }

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -3,10 +3,15 @@ package io.circe
 import cats.instances.all._
 import cats.syntax.eq._
 import io.circe.syntax._
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
+import org.scalacheck.Prop
+import org.scalacheck.Prop.forAll
 
-class JsonSuite extends CirceSuite with FloatJsonTests {
-  "foldWith" should "give the same result as fold" in forAll { (json: Json) =>
+class JsonSuite extends CirceMunitSuite with FloatJsonTests {
+
+  property("foldWith should give the same result as fold")(foldWithProp)
+
+  lazy val foldWithProp: Prop = Prop.forAll { (json: Json) =>
     val z: Int = 0
     val b: Boolean => Int = if (_) 1 else 2
     val n: JsonNumber => Int = _.toDouble.toInt
@@ -28,55 +33,80 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     assert(result === json.fold(z, b, n, s, a, o))
   }
 
-  "asNull" should "give the same result as fold" in forAll { (json: Json) =>
+  property("asNull should give the same result as fold")(asNullProp)
+
+  lazy val asNullProp: Prop = Prop.forAll { (json: Json) =>
     assert(json.asNull === json.fold(Some(()), _ => None, _ => None, _ => None, _ => None, _ => None))
   }
 
-  "asBoolean" should "give the same result as fold" in forAll { (json: Json) =>
-    assert(json.asBoolean === json.fold(None, Some(_), _ => None, _ => None, _ => None, _ => None))
+  property("asBoolean should give the same result as fold") {
+    forAll { (json: Json) =>
+      assert(json.asBoolean === json.fold(None, Some(_), _ => None, _ => None, _ => None, _ => None))
+    }
   }
 
-  "asNumber" should "give the same result as fold" in forAll { (json: Json) =>
-    assert(json.asNumber === json.fold(None, _ => None, Some(_), _ => None, _ => None, _ => None))
+  property("asNumber should give the same result as fold") {
+    forAll { (json: Json) =>
+      assert(json.asNumber === json.fold(None, _ => None, Some(_), _ => None, _ => None, _ => None))
+    }
   }
 
-  "asString" should "give the same result as fold" in forAll { (json: Json) =>
-    assert(json.asString === json.fold(None, _ => None, _ => None, Some(_), _ => None, _ => None))
+  property("asString should give the same result as fold") {
+    forAll { (json: Json) =>
+      assert(json.asString === json.fold(None, _ => None, _ => None, Some(_), _ => None, _ => None))
+    }
   }
 
-  "asArray" should "give the same result as fold" in forAll { (json: Json) =>
-    assert(json.asArray === json.fold(None, _ => None, _ => None, _ => None, Some(_), _ => None))
+  property("asArray should give the same result as fold") {
+    forAll { (json: Json) =>
+      assert(json.asArray === json.fold(None, _ => None, _ => None, _ => None, Some(_), _ => None))
+    }
   }
 
-  "asObject" should "give the same result as fold" in forAll { (json: Json) =>
-    assert(json.asObject === json.fold(None, _ => None, _ => None, _ => None, _ => None, Some(_)))
+  property("asObject should give the same result as fold") {
+    forAll { (json: Json) =>
+      assert(json.asObject === json.fold(None, _ => None, _ => None, _ => None, _ => None, Some(_)))
+    }
   }
 
-  "withNull" should "be identity with Json.Null" in forAll { (json: Json) =>
-    assert(json.withNull(Json.Null) === json)
+  property("withNull should be identity with Json.Null") {
+    forAll { (json: Json) =>
+      assert(json.withNull(Json.Null) === json)
+    }
   }
 
-  "withBoolean" should "be identity with Json.fromBoolean" in forAll { (json: Json) =>
-    assert(json.withBoolean(Json.fromBoolean) === json)
+  property("withBoolean should be identity with Json.fromBoolean") {
+    forAll { (json: Json) =>
+      assert(json.withBoolean(Json.fromBoolean) === json)
+    }
   }
 
-  "withNumber" should "be identity with Json.fromJsonNumber" in forAll { (json: Json) =>
-    assert(json.withNumber(Json.fromJsonNumber) === json)
+  property("withNumber should be identity with Json.fromJsonNumber") {
+    forAll { (json: Json) =>
+      assert(json.withNumber(Json.fromJsonNumber) === json)
+    }
   }
 
-  "withString" should "be identity with Json.fromString" in forAll { (json: Json) =>
-    assert(json.withString(Json.fromString) === json)
+  property("withString should be identity with Json.fromString") {
+    forAll { (json: Json) =>
+      assert(json.withString(Json.fromString) === json)
+    }
   }
 
-  "withArray" should "be identity with Json.fromValues" in forAll { (json: Json) =>
-    assert(json.withArray(Json.fromValues) === json)
+  property("withArray should be identity with Json.fromValues") {
+    forAll { (json: Json) =>
+      assert(json.withArray(Json.fromValues) === json)
+    }
   }
 
-  "withObject" should "be identity with Json.fromJsonObject" in forAll { (json: Json) =>
-    assert(json.withObject(Json.fromJsonObject) === json)
+  property("withObject should be identity with Json.fromJsonObject") {
+    forAll { (json: Json) =>
+      assert(json.withObject(Json.fromJsonObject) === json)
+    }
   }
 
-  "deepMerge" should "preserve argument order" in forAll { (js: List[Json]) =>
+  property("deepMerge should preserve argument order")(deepMergePreserveOrderProp)
+  lazy val deepMergePreserveOrderProp = forAll { (js: List[Json]) =>
     val fields = js.zipWithIndex.map {
       case (j, i) => i.toString -> j
     }
@@ -87,7 +117,7 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     assert(merged.asObject.map(_.toList) === Some(fields.reverse))
   }
 
-  "dropEmptyValues" should "remove empty values for JsonObject" in {
+  test("dropEmptyValues should remove empty values for JsonObject") {
     val actual = Json
       .fromFields(
         List(
@@ -111,7 +141,7 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     )
   }
 
-  "deepDropNullValues" should "remove null value for JsonObject" in {
+  test("deepDropNullValues should remove null value for JsonObject") {
     val actual = Json
       .fromFields(
         List(
@@ -134,13 +164,13 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     )
   }
 
-  "deepDropNullValues" should "remove null value for JsonArray" in {
+  test("deepDropNullValues should remove null value for JsonArray") {
     val actual = Json.fromValues(List(Json.Null, Json.fromString("a"))).deepDropNullValues
 
     assert(actual == Json.fromValues(List(Json.fromString("a"))))
   }
 
-  "deepDropNullValues" should "remove null value for nested object" in {
+  test("deepDropNullValues should remove null value for nested object") {
     val actual = Json
       .fromFields(
         List(
@@ -164,7 +194,9 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
   val value1 = "fizz"
   val value2 = "foobar"
 
-  """findAllByKey and its alias, \\""" should "return all values matching the given key with key-value pairs at heights 0 and 1." in {
+  test(
+    """findAllByKey and its alias, should return all values matching the given key with key-value pairs at heights 0 and 1."""
+  ) {
     val expected = List(Json.fromString(value1), Json.fromString(value2), Json.Null)
     val at0 = (key, Json.fromString(value1))
     val at1 = (key, Json.fromString(value2))
@@ -176,7 +208,9 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     assert(result === expected && resultAlias === expected)
   }
 
-  """findAllByKey and its alias, \\""" should "return a List of a single, empty object for a Json value with only that (key, value) matching." in {
+  test(
+    """findAllByKey and its alias, \\ should return a List of a single, empty object for a Json value with only that (key, value) matching."""
+  ) {
     val expected = List(Json.fromJsonObject(JsonObject.empty))
     val emptyJson = (key, Json.fromJsonObject(JsonObject.empty))
     val json = Json.obj(emptyJson)
@@ -186,7 +220,9 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     assert(result === expected && resultAlias === expected)
   }
 
-  """findAllByKey and its alias, \\""" should "return an empty List when used on a Json that's not an array or object" in {
+  test(
+    """findAllByKey and its alias, \\"" should return an empty List when used on a Json that's not an array or object"""
+  ) {
     val number = Json.fromLong(42L)
     val string = Json.fromString("foobar")
     val boolean = Json.fromBoolean(true)
@@ -200,7 +236,9 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
 
   val value3 = 42L
 
-  """findAllByKey and its alias, \\""" should "return all values matching the given key with key-value pairs at heights  0, 1, and 2." in {
+  test(
+    """findAllByKey and its alias, \\"" should return all values matching the given key with key-value pairs at heights  0, 1, and 2."""
+  ) {
     val expected = List(Json.arr(Json.fromString(value1)), Json.fromString(value2), Json.fromLong(value3))
     val `0` = (key, Json.arr(Json.fromString(value1)))
     val `1` = (key, Json.fromString(value2))
@@ -212,84 +250,84 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     assert(result === expected && resultAlias === expected)
   }
 
-  "fromDouble" should "fail on Double.NaN" in {
+  test("fromDouble should fail on Double.NaN") {
     assert(Json.fromDouble(Double.NaN) === None)
   }
 
-  it should "fail on Double.PositiveInfinity" in {
+  test("fromDouble should fail on Double.PositiveInfinity") {
     assert(Json.fromDouble(Double.PositiveInfinity) === None)
   }
 
-  it should "fail on Double.NegativeInfinity" in {
+  test("fromDouble should fail on Double.NegativeInfinity") {
     assert(Json.fromDouble(Double.NegativeInfinity) === None)
   }
 
-  "fromDoubleOrNull" should "return Null on Double.NaN" in {
+  test("fromDoubleOrNull should return Null on Double.NaN") {
     assert(Json.fromDoubleOrNull(Double.NaN) === Json.Null)
   }
 
-  it should "return Null on Double.PositiveInfinity" in {
+  test("fromDoubleOrNull return Null on Double.PositiveInfinity") {
     assert(Json.fromDoubleOrNull(Double.PositiveInfinity) === Json.Null)
   }
 
-  it should "return Null on Double.NegativeInfinity" in {
+  test("fromDoubleOrNull should return Null on Double.NegativeInfinity") {
     assert(Json.fromDoubleOrNull(Double.NegativeInfinity) === Json.Null)
   }
 
-  "fromDoubleOrString" should "return String on Double.NaN" in {
+  test("fromDoubleOrString should return String on Double.NaN") {
     assert(Json.fromDoubleOrString(Double.NaN) === Json.fromString("NaN"))
   }
 
-  it should "return String on Double.PositiveInfinity" in {
+  test("fromDoubleOrString return String on Double.PositiveInfinity") {
     assert(Json.fromDoubleOrString(Double.PositiveInfinity) === Json.fromString("Infinity"))
   }
 
-  it should "return String on Double.NegativeInfinity" in {
+  test("fromDoubleOrString should return String on Double.NegativeInfinity") {
     assert(Json.fromDoubleOrString(Double.NegativeInfinity) === Json.fromString("-Infinity"))
   }
 
-  it should "return JsonNumber Json values for valid Doubles" in {
+  test("fromDoubleOrString should return JsonNumber Json values for valid Doubles") {
     assert(Json.fromDoubleOrString(1.1) === Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe("1.1")))
     assert(Json.fromDoubleOrString(-1.2) === Json.fromJsonNumber(JsonNumber.fromDecimalStringUnsafe("-1.2")))
   }
 
-  "fromFloat" should "fail on Float.NaN" in {
+  test("fromFloat should fail on Float.NaN") {
     assert(Json.fromFloat(Float.NaN) === None)
   }
 
-  it should "fail on Float.PositiveInfinity" in {
+  test("fromFloat should fail on Float.PositiveInfinity") {
     assert(Json.fromFloat(Float.PositiveInfinity) === None)
   }
 
-  it should "fail on Float.NegativeInfinity" in {
+  test("fromFloat should fail on Float.NegativeInfinity") {
     assert(Json.fromFloat(Float.NegativeInfinity) === None)
   }
 
-  "fromFloatOrNull" should "return Null on Float.NaN" in {
+  test("fromFloatOrNull should return Null on Float.NaN") {
     assert(Json.fromFloatOrNull(Float.NaN) === Json.Null)
   }
 
-  it should "return Null on Float.PositiveInfinity" in {
+  test("fromFloatOrNull should return Null on Float.PositiveInfinity") {
     assert(Json.fromFloatOrNull(Float.PositiveInfinity) === Json.Null)
   }
 
-  it should "return Null on Float.NegativeInfinity" in {
+  test("fromFloatOrNull should return Null on Float.NegativeInfinity") {
     assert(Json.fromFloatOrNull(Float.NegativeInfinity) === Json.Null)
   }
 
-  "fromFloatOrString" should "return String on Float.NaN" in {
+  test("fromFloatOrString should return String on Float.NaN") {
     assert(Json.fromFloatOrString(Float.NaN) === Json.fromString("NaN"))
   }
 
-  it should "return String on Float.PositiveInfinity" in {
+  test("fromFloatOrString should return String on Float.PositiveInfinity") {
     assert(Json.fromFloatOrString(Float.PositiveInfinity) === Json.fromString("Infinity"))
   }
 
-  it should "return String on Float.NegativeInfinity" in {
+  test("fromFloatOrString should return String on Float.NegativeInfinity") {
     assert(Json.fromFloatOrString(Float.NegativeInfinity) === Json.fromString("-Infinity"))
   }
 
-  "obj" should "create object fluently" in {
+  test("obj should create object fluently") {
     val actual = Json.obj(
       "a" := 1L,
       "b" := "asdf",
@@ -305,7 +343,8 @@ class JsonSuite extends CirceSuite with FloatJsonTests {
     assert(actual === expected)
   }
 
-  "printer shortcuts" should "print the object" in forAll { (json: Json) =>
+  property("printer shortcuts should print the object")(printerShortcutsProp)
+  lazy val printerShortcutsProp = forAll { (json: Json) =>
     assert(json.noSpaces === Printer.noSpaces.print(json))
     assert(json.spaces2 === Printer.spaces2.print(json))
     assert(json.spaces4 === Printer.spaces4.print(json))

--- a/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
@@ -4,9 +4,9 @@ import java.util.UUID
 
 import cats.instances.all._
 import io.circe.testing.KeyCodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 
-class KeyCodecSuite extends CirceSuite {
+class KeyCodecSuite extends CirceMunitSuite {
 
   checkAll("KeyCodec[String]", KeyCodecTests[String].keyCodec)
   checkAll("KeyCodec[Symbol]", KeyCodecTests[Symbol].keyCodec)

--- a/modules/tests/shared/src/test/scala/io/circe/KeyDecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyDecoderSuite.scala
@@ -5,8 +5,8 @@ import cats.kernel.instances.int._
 import cats.kernel.instances.tuple._
 import cats.kernel.instances.unit._
 import cats.laws.discipline.MonadErrorTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 
-class KeyDecoderSuite extends CirceSuite {
+class KeyDecoderSuite extends CirceMunitSuite {
   checkAll("KeyDecoder[Int]", MonadErrorTests[KeyDecoder, Unit].monadError[Int, Int, Int])
 }

--- a/modules/tests/shared/src/test/scala/io/circe/KeyEncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyEncoderSuite.scala
@@ -1,8 +1,8 @@
 package io.circe
 
 import cats.laws.discipline.ContravariantTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 
-class KeyEncoderSuite extends CirceSuite {
+class KeyEncoderSuite extends CirceMunitSuite {
   checkAll("KeyEncoder[Int]", ContravariantTests[KeyEncoder].contravariant[Int, Int, Int])
 }

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -3,17 +3,20 @@ package io.circe
 import cats.kernel.instances.string._
 import cats.syntax.eq._
 import io.circe.tests.PrinterSuite
+import org.scalacheck.Prop.forAll
 
 class Spaces2PrinterSuite extends PrinterSuite(Printer.spaces2, parser.`package`) with Spaces2PrinterExample
 class Spaces4PrinterSuite extends PrinterSuite(Printer.spaces4, parser.`package`)
 class NoSpacesPrinterSuite extends PrinterSuite(Printer.noSpaces, parser.`package`) {
-  "pretty" should "match print" in forAll { (json: Json) =>
-    assert(printer.print(json) === printer.pretty(json))
+  property("pretty should match print") {
+    forAll { (json: Json) =>
+      assert(printer.print(json) === printer.pretty(json))
+    }
   }
 }
 class UnicodeEscapePrinterSuite extends PrinterSuite(Printer.noSpaces.copy(escapeNonAscii = true), parser.`package`) {
   import io.circe.syntax._
-  "Printing object" should "unicode-escape all non-ASCII chars" in {
+  test("Printing object should unicode-escape all non-ASCII chars") {
     val actual = Json.obj("0 ℃" := "32 ℉").printWith(printer)
     val expected = "{\"0 \\u2103\":\"32 \\u2109\"}"
     assert(actual === expected)

--- a/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
@@ -2,15 +2,20 @@ package io.circe
 
 import cats.laws.discipline.SerializableTests
 import cats.kernel.laws.SerializableLaws
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
+import org.scalacheck.Prop
 
-class SerializableSuite extends CirceSuite {
-  "Json" should "be serializable" in forAll { (j: Json) =>
-    SerializableLaws.serializable(j); ()
+class SerializableSuite extends CirceMunitSuite {
+  property("Json should be serializable") {
+    Prop.forAll { (j: Json) =>
+      SerializableLaws.serializable(j); ()
+    }
   }
 
-  "HCursor" should "be serializable" in forAll { (j: Json) =>
-    SerializableLaws.serializable(j.hcursor); ()
+  property("HCursor should be serializable") {
+    Prop.forAll { (j: Json) =>
+      SerializableLaws.serializable(j.hcursor); ()
+    }
   }
 
   checkAll("Decoder[Int]", SerializableTests.serializable(Decoder[Int]))

--- a/modules/tests/shared/src/test/scala/io/circe/ShowErrorSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/ShowErrorSuite.scala
@@ -4,7 +4,6 @@ import cats.kernel.instances.string._
 import cats.syntax.eq._
 import cats.syntax.show._
 import io.circe.CursorOp._
-import io.circe.tests.CirceSuite
 import munit.ScalaCheckSuite
 import org.scalacheck.{ Gen, Prop }
 

--- a/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
@@ -5,9 +5,10 @@ import cats.kernel.instances.string._
 import cats.kernel.instances.vector._
 import cats.syntax.eq._
 import io.circe.tests.PrinterSuite
+import org.scalacheck.Prop.forAll
 
 trait SortedKeysSuite { this: PrinterSuite =>
-  "Printer with sortKeys" should "sort the object keys (example)" in {
+  test("Printer with sortKeys should sort the object keys (example)") {
     val input = Json.obj(
       "one" -> Json.fromInt(1),
       "two" -> Json.fromInt(2),
@@ -21,7 +22,7 @@ trait SortedKeysSuite { this: PrinterSuite =>
     }
   }
 
-  "Printer with sortKeys" should "sort the object keys" in {
+  property("Printer with sortKeys should sort the object keys") {
     forAll { (value: Map[String, List[Int]]) =>
       val printed = printer.print(implicitly[Encoder[Map[String, List[Int]]]].apply(value))
       val parsed = parser.parse(printed).toOption.flatMap(_.asObject).get

--- a/modules/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
@@ -2,14 +2,17 @@ package io.circe.parser
 
 import io.circe.Json
 import io.circe.testing.ParserTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
+import org.scalacheck.Prop.forAll
 
-class ParserSuite extends CirceSuite {
+class ParserSuite extends CirceMunitSuite {
   checkAll("Parser", ParserTests(`package`).fromString)
 
-  "parse and decode(Accumulating)" should "fail on invalid input" in forAll { (s: String) =>
-    assert(parse(s"Not JSON $s").isLeft)
-    assert(decode[Json](s"Not JSON $s").isLeft)
-    assert(decodeAccumulating[Json](s"Not JSON $s").isInvalid)
+  property("parse and decode(Accumulating) should fail on invalid input") {
+    forAll { (s: String) =>
+      assert(parse(s"Not JSON $s").isLeft)
+      assert(decode[Json](s"Not JSON $s").isLeft)
+      assert(decodeAccumulating[Json](s"Not JSON $s").isInvalid)
+    }
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/syntax/SyntaxSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/syntax/SyntaxSuite.scala
@@ -4,18 +4,23 @@ import cats.kernel.instances.string._
 import cats.kernel.instances.tuple._
 import cats.syntax.eq._
 import io.circe.{ Encoder, Json, KeyEncoder }
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
+import org.scalacheck.Prop.forAll
 
-class SyntaxSuite extends CirceSuite {
-  "asJson" should "be available and work appropriately" in forAll { (s: String) =>
-    assert(s.asJson === Json.fromString(s))
+class SyntaxSuite extends CirceMunitSuite {
+  property("asJson should be available and work appropriately") {
+    forAll { (s: String) =>
+      assert(s.asJson === Json.fromString(s))
+    }
   }
 
-  "asJsonObject" should "be available and work appropriately" in forAll { (m: Map[String, Int]) =>
-    assert(m.asJsonObject === Encoder[Map[String, Int]].apply(m).asObject.get)
+  property("asJsonObject should be available and work appropriately") {
+    forAll { (m: Map[String, Int]) =>
+      assert(m.asJsonObject === Encoder[Map[String, Int]].apply(m).asObject.get)
+    }
   }
 
-  ":=" should "be available and work with String keys" in {
+  property(":= should be available and work with String keys") {
     forAll { (key: String, m: Map[String, Int], aNumber: Int, aString: String, aBoolean: Boolean) =>
       assert((key := m) === (key, m.asJson))
       assert((key := aNumber) === (key, aNumber.asJson))
@@ -24,7 +29,7 @@ class SyntaxSuite extends CirceSuite {
     }
   }
 
-  ":=" should "be available and work with non-String keys that have a KeyEncoder instance" in {
+  property(":= should be available and work with non-String keys that have a KeyEncoder instance") {
     case class CustomKey(componentOne: String, componentTwo: Int)
     implicit val keyEncoder: KeyEncoder[CustomKey] =
       KeyEncoder[String].contramap(k => s"${k.componentOne}_${k.componentTwo}")


### PR DESCRIPTION
Migrate several of the tests suites in `circe` from Scalatest to MUnit.  We introduce a `CirceMunitSuite` trait, similar to `CirceSuite`. We adapt most of the packages and tests suites but some are still pending to be migrated (preferably before 0.14 is released)
 
