### PR TITLE
Add JSON Pointer module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -588,11 +588,12 @@ lazy val benchmark = circeModule("benchmark", mima = None)
       _.filterNot(Set("-Yno-predef"))
     },
     libraryDependencies ++= Seq(
+      "io.circe" %% "circe-optics" % "0.13.0",
       "org.scalameta" %% "munit" % munitVersion % Test
     )
   )
   .enablePlugins(JmhPlugin)
-  .dependsOn(core, generic, jawn)
+  .dependsOn(core, generic, jawn, pointer)
 
 lazy val benchmarkDotty = circeModule("benchmark-dotty", mima = None)
   .settings(noPublishSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -231,6 +231,7 @@ lazy val circeCrossModules = Seq[(Project, Project)](
   (numbersTesting, numbersTestingJS),
   (numbers, numbersJS),
   (core, coreJS),
+  (pointer, pointerJS),
   (extras, extrasJS),
   (generic, genericJS),
   (shapes, shapesJS),
@@ -568,6 +569,12 @@ lazy val jawn = circeModule("jawn", mima = previousCirceVersion)
     )
   )
   .dependsOn(core)
+
+lazy val pointerBase =
+  circeCrossModule("pointer", mima = previousCirceVersion, CrossType.Pure).dependsOn(coreBase, testsBase % Test)
+
+lazy val pointer = pointerBase.jvm
+lazy val pointerJS = pointerBase.js
 
 lazy val extrasBase = circeCrossModule("extras", mima = previousCirceVersion).dependsOn(coreBase, testsBase % Test)
 

--- a/build.sbt
+++ b/build.sbt
@@ -232,6 +232,7 @@ lazy val circeCrossModules = Seq[(Project, Project)](
   (numbers, numbersJS),
   (core, coreJS),
   (pointer, pointerJS),
+  (pointerLiteral, pointerLiteralJS),
   (extras, extrasJS),
   (generic, genericJS),
   (shapes, shapesJS),
@@ -575,6 +576,19 @@ lazy val pointerBase =
 
 lazy val pointer = pointerBase.jvm
 lazy val pointerJS = pointerBase.js
+
+lazy val pointerLiteralBase = circeCrossModule("pointer-literal", mima = previousCirceVersion, CrossType.Pure)
+  .settings(macroSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.scalameta" %%% "munit" % munitVersion % Test,
+      "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test
+    )
+  )
+  .dependsOn(coreBase, pointerBase)
+
+lazy val pointerLiteral = pointerLiteralBase.jvm
+lazy val pointerLiteralJS = pointerLiteralBase.js
 
 lazy val extrasBase = circeCrossModule("extras", mima = previousCirceVersion).dependsOn(coreBase, testsBase % Test)
 

--- a/modules/benchmark/src/main/scala/io/circe/benchmark/PointerBenchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/PointerBenchmark.scala
@@ -1,0 +1,42 @@
+package io.circe.benchmark
+
+import io.circe.Json
+import io.circe.optics.JsonPath
+import io.circe.pointer.Pointer
+import io.circe.syntax._
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+/**
+ * Compare the performance of various ways of folding JSON values.
+ *
+ * The following command will run the benchmarks with reasonable settings:
+ *
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.PointerBenchmark"
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class PointerBenchmark {
+  val good: Json = Json.obj(
+    "foo" := List("foo".asJson, true.asJson, Json.obj("bar" := Json.obj("baz" := Json.obj("qux" := 123.asJson))))
+  )
+  val bad: Json = Json.obj(
+    "foo" := List("foo".asJson, true.asJson, Json.obj("bar" := Json.obj("baz" := Json.obj("quux" := 123.asJson))))
+  )
+
+  val path = JsonPath.root.foo(2).bar.baz.qux.json
+  val Right(pointer) = Pointer.parse("/foo/2/bar/baz/qux")
+
+  @Benchmark
+  def goodOptics: Option[Json] = path.getOption(good)
+
+  @Benchmark
+  def goodPointer: Option[Json] = pointer.getOption(good)
+
+  @Benchmark
+  def badOptics: Option[Json] = path.getOption(bad)
+
+  @Benchmark
+  def badPointer: Option[Json] = pointer.getOption(bad)
+}

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/PointerBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/PointerBenchmarkSpec.scala
@@ -1,0 +1,24 @@
+package io.circe.benchmark
+
+import io.circe.Json
+import munit.FunSuite
+
+class PointerBenchmarkSpec extends FunSuite {
+  val benchmark: PointerBenchmark = new PointerBenchmark
+
+  test("goodOptics should succeed correctly") {
+    assertEquals(benchmark.goodOptics, Some(Json.fromInt(123)))
+  }
+
+  test("goodPointer should succeed correctly") {
+    assertEquals(benchmark.goodPointer, Some(Json.fromInt(123)))
+  }
+
+  test("badOptics should fail") {
+    assertEquals(benchmark.badOptics, None)
+  }
+
+  test("badPointer should fail") {
+    assertEquals(benchmark.badPointer, None)
+  }
+}

--- a/modules/pointer-literal/src/main/scala/io/circe/pointer/literal/PointerLiteralMacro.scala
+++ b/modules/pointer-literal/src/main/scala/io/circe/pointer/literal/PointerLiteralMacro.scala
@@ -1,0 +1,35 @@
+package io.circe.pointer.literal
+
+import io.circe.pointer.Pointer
+import scala.reflect.macros.blackbox
+
+private class PointerLiteralMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  final def pointerStringContext(args: c.Expr[Any]*): Tree = c.prefix.tree match {
+    case Apply(_, Apply(_, parts) :: Nil) =>
+      val stringParts: List[String] = parts.map {
+        case Literal(Constant(part: String)) => part
+        case _ =>
+          c.abort(
+            c.enclosingPosition,
+            "A StringContext part for the pointer interpolator is not a string"
+          )
+      }
+
+      if (Pointer.parse(stringParts.mkString("X")).isRight) {
+        val input = args.zip(stringParts.tail).foldLeft(q"${stringParts.head}") {
+          case (acc, (a, p)) => q"""$acc + $a.toString.replaceAll("~", "~0").replaceAll("/", "~1") + $p"""
+        }
+
+        val t = q"""_root_.io.circe.pointer.Pointer.parse($input)
+          .asInstanceOf[_root_.scala.Right[_root_.scala.Nothing, _root_.io.circe.pointer.Pointer]].value
+        """
+
+        t
+      } else {
+        c.abort(c.enclosingPosition, "Invalid JSON Pointer in interpolated string")
+      }
+    case _ => c.abort(c.enclosingPosition, "Invalid use of the pointer interpolator")
+  }
+}

--- a/modules/pointer-literal/src/main/scala/io/circe/pointer/literal/package.scala
+++ b/modules/pointer-literal/src/main/scala/io/circe/pointer/literal/package.scala
@@ -1,0 +1,9 @@
+package io.circe.pointer
+
+import scala.language.experimental.macros
+
+package object literal {
+  implicit final class PointerStringContext(sc: StringContext) {
+    final def pointer(args: Any*): Pointer = macro PointerLiteralMacros.pointerStringContext
+  }
+}

--- a/modules/pointer-literal/src/test/scala/io/circe/pointer/literal/PointerInterpolatorSuite.scala
+++ b/modules/pointer-literal/src/test/scala/io/circe/pointer/literal/PointerInterpolatorSuite.scala
@@ -1,0 +1,92 @@
+package io.circe.pointer.literal
+
+import io.circe.pointer.Pointer
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop
+
+class PointerInterpolatorSuite extends ScalaCheckSuite {
+  test("The pointer string interpolater should parse valid absolute JSON pointers") {
+    val inputs = List("", "/foo", "/foo/0", "/", "/a~1b", "/c%d", "/e^f", "/g|h", "/i\\j", "/k\"l", "/ ", "/m~0n")
+    val values = List(
+      pointer"",
+      pointer"/foo",
+      pointer"/foo/0",
+      pointer"/",
+      pointer"/a~1b",
+      pointer"/c%d",
+      pointer"/e^f",
+      pointer"/g|h",
+      pointer"""/i\j""",
+      pointer"""/k"l""",
+      pointer"/ ",
+      pointer"/m~0n"
+    )
+
+    values.zip(inputs).foreach {
+      case (value, input) =>
+        assertEquals(Pointer.parse(input), Right(value))
+    }
+  }
+
+  test("The pointer string interpolater should parse valid relative JSON pointers") {
+    val inputs = List("0", "1/0", "2/highly/nested/objects", "0#", "1#")
+    val values = List(pointer"0", pointer"1/0", pointer"2/highly/nested/objects", pointer"0#", pointer"1#")
+
+    values.zip(inputs).foreach {
+      case (value, input) =>
+        assertEquals(Pointer.parse(input), Right(value))
+    }
+  }
+
+  property("The pointer string interpolater should work with interpolated values that need escaping") {
+    val s = "foo~bar/baz/~"
+    val Right(expected) = Pointer.parse("/base/foo~0bar~1baz~1~0/leaf")
+    assertEquals(pointer"/base/$s/leaf", expected)
+  }
+
+  property("The pointer string interpolater should work with arbitrary interpolated strings") {
+    Prop.forAll { (v: String) =>
+      val Right(expected) = Pointer.parse(s"/foo/$v/bar")
+
+      pointer"/foo/$v/bar" == expected
+    }
+  }
+
+  property("The pointer string interpolater should work with arbitrary interpolated integers") {
+    Prop.forAll { (v: Long) =>
+      val Right(expected) = Pointer.parse(s"/foo/$v/bar")
+
+      pointer"/foo/$v/bar" == expected
+    }
+  }
+
+  test("The pointer string interpolater should fail to compile on invalid literals") {
+    assertNoDiff(
+      compileErrors("pointer\"foo\""),
+      """|error: Invalid JSON Pointer in interpolated string
+         |pointer"foo"
+         |^
+         |""".stripMargin
+    )
+  }
+
+  test("The pointer string interpolater should fail with an interpolated relative distance") {
+    assertNoDiff(
+      compileErrors("""{val x = 1; pointer"$x/"}"""),
+      """|error: Invalid JSON Pointer in interpolated string
+         |{val x = 1; pointer"$x/"}
+         |            ^
+         |""".stripMargin
+    )
+  }
+
+  test("The pointer string interpolater should fail with an empty interpolated relative distance") {
+    assertNoDiff(
+      compileErrors("""{val x = ""; pointer"$x/"}"""),
+      """|error: Invalid JSON Pointer in interpolated string
+         |{val x = ""; pointer"$x/"}
+         |             ^
+         |""".stripMargin
+    )
+  }
+}

--- a/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
+++ b/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
@@ -1,0 +1,247 @@
+package io.circe.pointer
+
+import io.circe.{ ACursor, Json }
+
+sealed abstract class Pointer extends (ACursor => ACursor) {
+  final def get(input: Json): Either[PointerFailure, Json] = {
+    val navigated = apply(input.hcursor)
+
+    navigated.focus match {
+      case Some(value) => Right(value)
+      case None        => Left(PointerFailure(navigated.history))
+    }
+  }
+}
+
+object Pointer {
+  def parse(input: String, supportRelative: Boolean = true): Either[PointerSyntaxError, Pointer] = {
+    if (input.length == 0) {
+      Right(empty)
+    } else {
+      if (supportRelative && isAsciiDigit(input.charAt(0))) {
+        Relative.parse(input)
+      } else if (input.charAt(0) == '/') {
+        var parts = input.split("/")
+        if (parts.length == 0) {
+          parts = Array("/", "")
+        }
+        var pos = 1
+        var i = 1
+        val tokens = Vector.newBuilder[(String, Int)]
+
+        while (i < parts.length) {
+          val part = parts(i)
+          if (part == "-") {
+            tokens += hyphenToken
+          } else {
+            val digits = digitPrefixLength(parts(i))
+
+            if (digits == part.length && !part.isEmpty) {
+              tokens += ((part, Integer.parseInt(part)))
+            } else {
+              var previousEscapeEnd = 0
+              var currentTildeIndex = part.indexOf('~')
+
+              if (currentTildeIndex == -1) {
+                tokens += ((part, -1))
+              } else {
+                val builder = new StringBuilder()
+
+                while (currentTildeIndex != -1) {
+                  if (part.length > currentTildeIndex + 1) {
+                    builder.append(part.substring(previousEscapeEnd, currentTildeIndex))
+                    val next = part.charAt(currentTildeIndex + 1)
+
+                    if (next == '0') {
+                      builder.append('~')
+                    } else if (next == '1') {
+                      builder.append('/')
+                    } else {
+                      return Left(PointerSyntaxError(pos + currentTildeIndex + 1, "0 or 1"))
+                    }
+                  } else {
+                    return Left(PointerSyntaxError(pos + currentTildeIndex, "token character"))
+                  }
+
+                  previousEscapeEnd = currentTildeIndex + 2
+                  currentTildeIndex = part.indexOf('~', previousEscapeEnd)
+                }
+
+                builder.append(part.substring(previousEscapeEnd))
+
+                tokens += ((builder.toString, -1))
+              }
+            }
+          }
+
+          pos += part.length + 1
+          i += 1
+        }
+
+        Right(TokensPointer(tokens.result()))
+      } else {
+        val message = if (supportRelative) "/ or digit" else "/"
+
+        Left(PointerSyntaxError(0, message))
+      }
+    }
+  }
+
+  private[this] val hyphenToken: (String, Int) = ("-", Int.MaxValue)
+
+  val empty: Pointer = Empty
+
+  private[this] case object Empty extends Pointer {
+    def apply(c: ACursor): ACursor = c
+    override def toString(): String = ""
+  }
+
+  private[this] case class TokensPointer(tokens: Vector[(String, Int)]) extends Pointer {
+    def apply(c: ACursor): ACursor = {
+      var current = c
+
+      tokens.foreach {
+        case (key, asIndex) =>
+          if (asIndex != -1) {
+            current.values match {
+              case Some(values) =>
+                if (key == "-") {
+                  current = current.downN(values.size)
+                } else {
+                  current = current.downN(asIndex)
+                }
+              case None =>
+                current = current.downField(key)
+            }
+          } else {
+            current = current.downField(key)
+          }
+      }
+
+      current
+    }
+    override def toString(): String =
+      tokens.map(_._1.replaceAll("~", "~0").replaceAll("/", "~1")).mkString("/", "/", "")
+  }
+
+  sealed abstract class Relative extends Pointer {
+    def evaluate(c: ACursor): Either[PointerFailure, Relative.Result]
+    def distance: Int
+    def path: Option[Pointer]
+
+    protected[this] def navigateUp(c: ACursor, distance: Int): ACursor = {
+      var current: ACursor = c
+      var i = 0
+
+      while (i < distance) {
+        current = current.up
+        i += 1
+      }
+
+      current
+    }
+  }
+
+  object Relative {
+    sealed abstract class Result
+
+    object Result {
+      case class Json(value: io.circe.Json) extends Result
+      case class Key(value: String) extends Result
+      case class Index(value: Int) extends Result
+    }
+
+    def parse(input: String): Either[PointerSyntaxError, Relative] = {
+      val digits = digitPrefixLength(input)
+
+      if (digits == -1) {
+        // There was a leading zero.
+        Left(PointerSyntaxError(1, "JSON Pointer or #"))
+      } else if (digits == 0) {
+        Left(PointerSyntaxError(0, "digit"))
+      } else if (digits > 9) {
+        Left(PointerSyntaxError(9, "JSON Pointer or #"))
+      } else {
+        val distance = java.lang.Integer.parseInt(input.substring(0, digits))
+
+        if (input.length == digits) {
+          Right(PointerRelative(distance, Pointer.empty))
+        } else {
+          val c = input.charAt(digits)
+
+          if (c == '/') {
+            Pointer.parse(input.substring(digits), false).map(PointerRelative(distance, _))
+          } else if (c == '#') {
+            if (input.length == digits + 1) {
+              Right(LocationLookupRelative(distance))
+            } else {
+              Left(PointerSyntaxError(digits + 1, "end of input"))
+            }
+          } else {
+            Left(PointerSyntaxError(digits, "JSON Pointer or #"))
+          }
+        }
+      }
+    }
+
+    private[this] case class LocationLookupRelative(distance: Int) extends Relative {
+      final def apply(c: ACursor): ACursor = navigateUp(c, distance)
+      final def path: Option[Pointer] = None
+
+      final def evaluate(c: ACursor): Either[PointerFailure, Result] = {
+        val navigated = apply(c)
+
+        navigated.index match {
+          case Some(index) => Right(Result.Index(index))
+          case None =>
+            navigated.key match {
+              case Some(key) => Right(Result.Key(key))
+              case None      => Left(PointerFailure(navigated.history))
+            }
+        }
+      }
+      final override def toString(): String = s"$distance#"
+    }
+
+    private[this] case class PointerRelative(distance: Int, pointer: Pointer) extends Relative {
+      final def apply(c: ACursor): ACursor = pointer(navigateUp(c, distance))
+      final def path: Option[Pointer] = Some(pointer)
+
+      final def evaluate(c: ACursor): Either[PointerFailure, Result] = {
+        val navigated = apply(c)
+
+        navigated.focus match {
+          case Some(value) => Right(Result.Json(value))
+          case None        => Left(PointerFailure(navigated.history))
+        }
+      }
+      final override def toString(): String = s"$distance$pointer"
+    }
+  }
+
+  private[this] def isAsciiDigit(c: Char): Boolean = c >= '0' && c <= '9'
+
+  // Returns -1 to indicate a leading zero.
+  private[this] def digitPrefixLength(input: String): Int = {
+    var i = 0
+    val length = input.length
+
+    if (length > 0) {
+      if (input.charAt(i) == '0') {
+        if (length == 1 || !isAsciiDigit(input.charAt(i + 1))) {
+          1
+        } else {
+          -1
+        }
+      } else {
+        while ((i < input.length) && isAsciiDigit(input.charAt(i))) {
+          i += 1
+        }
+
+        i
+      }
+    } else {
+      0
+    }
+  }
+}

--- a/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
+++ b/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
@@ -216,7 +216,7 @@ object Pointer {
       if (current.ne(null)) Some(current) else None
     }
 
-    def tokens: Vector[String] = new scala.collection.mutable.ArraySeq.ofRef(tokenArray).toVector
+    def tokens: Vector[String] = new scala.collection.mutable.WrappedArray.ofRef(tokenArray).toVector
 
     override def toString(): String = if (tokenArray.length == 0) {
       ""

--- a/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
+++ b/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
@@ -140,11 +140,11 @@ object Pointer {
 
       if (digits == -1) {
         // There was a leading zero.
-        Left(PointerSyntaxError(1, "JSON Pointer or #"))
+        leadingZeroError
       } else if (digits == 0) {
-        Left(PointerSyntaxError(0, "digit"))
+        notDigitError
       } else if (digits > 9) {
-        Left(PointerSyntaxError(9, "JSON Pointer or #"))
+        tooManyDigitsError
       } else {
         val distance = Integer.parseInt(input.substring(0, digits))
 
@@ -167,6 +167,14 @@ object Pointer {
         }
       }
     }
+
+    private[this] val leadingZeroError: Either[PointerSyntaxError, Relative] = Left(
+      PointerSyntaxError(1, "JSON Pointer or #")
+    )
+    private[this] val notDigitError: Either[PointerSyntaxError, Relative] = Left(PointerSyntaxError(0, "digit"))
+    private[this] val tooManyDigitsError: Either[PointerSyntaxError, Relative] = Left(
+      PointerSyntaxError(9, "JSON Pointer or #")
+    )
 
     private[this] case class LocationLookupRelative(distance: Int) extends Relative {
       final def apply(c: ACursor): ACursor = navigateUp(c, distance)

--- a/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
+++ b/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
@@ -8,7 +8,7 @@ import io.circe.{ ACursor, Json }
 sealed abstract class Pointer extends (ACursor => ACursor) {
 
   /**
-   * Attempt to get the value at the location pointed to.
+   * Attempt to get the value at the location pointed to, returning the history if it doesn't exist.
    */
   final def get(input: Json): Either[PointerFailure, Json] = {
     val navigated = apply(input.hcursor)
@@ -18,6 +18,11 @@ sealed abstract class Pointer extends (ACursor => ACursor) {
       case None        => Left(PointerFailure(navigated.history))
     }
   }
+
+  /**
+   * Attempt to get the value at the location pointed to.
+   */
+  final def getOption(input: Json): Option[Json] = apply(input.hcursor).focus
 
   /**
    * Safely downcast this value.

--- a/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
+++ b/modules/pointer/src/main/scala/io/circe/pointer/Pointer.scala
@@ -78,7 +78,7 @@ object Pointer {
       leadingZeroError
     } else if (digits == 0) {
       notDigitError
-    } else if (digits > 9) {
+    } else if (digits > maxIntegerDigits) {
       tooManyDigitsError
     } else {
       val distance = Integer.parseInt(input.substring(0, digits))
@@ -290,6 +290,8 @@ object Pointer {
       }
   }
 
+  private[this] val maxIntegerDigits: Int = 9
+
   private[this] val notRootError: Either[PointerSyntaxError, Absolute] =
     Left(PointerSyntaxError(0, "/"))
   private[this] val notDigitError: Either[PointerSyntaxError, Relative] =
@@ -299,7 +301,7 @@ object Pointer {
   private[this] val leadingZeroError: Either[PointerSyntaxError, Relative] =
     Left(PointerSyntaxError(1, "JSON Pointer or #"))
   private[this] val tooManyDigitsError: Either[PointerSyntaxError, Relative] =
-    Left(PointerSyntaxError(9, "JSON Pointer or #"))
+    Left(PointerSyntaxError(maxIntegerDigits, "JSON Pointer or #"))
 
   private[this] def isAsciiDigit(c: Char): Boolean = c >= '0' && c <= '9'
 
@@ -342,7 +344,7 @@ object Pointer {
       val part = parts(i)
       val digits = digitPrefixLength(parts(i))
 
-      if (digits == part.length && !part.isEmpty) {
+      if (digits == part.length && digits <= maxIntegerDigits && !part.isEmpty) {
         tokenArray(i - 1) = part
         asIndexArray(i - 1) = Integer.parseInt(part)
       } else {

--- a/modules/pointer/src/main/scala/io/circe/pointer/PointerFailure.scala
+++ b/modules/pointer/src/main/scala/io/circe/pointer/PointerFailure.scala
@@ -1,0 +1,7 @@
+package io.circe.pointer
+
+import io.circe.CursorOp
+
+case class PointerFailure(history: List[CursorOp]) extends Exception {
+  final override def fillInStackTrace(): Throwable = this
+}

--- a/modules/pointer/src/main/scala/io/circe/pointer/PointerSyntaxError.scala
+++ b/modules/pointer/src/main/scala/io/circe/pointer/PointerSyntaxError.scala
@@ -1,0 +1,6 @@
+package io.circe.pointer
+
+case class PointerSyntaxError(position: Int, expected: String) extends Exception {
+  final override def fillInStackTrace(): Throwable = this
+  final override def getMessage(): String = s"Syntax error at ${position}; expected: $expected"
+}

--- a/modules/pointer/src/test/scala/io/circe/pointer/PointerSuite.scala
+++ b/modules/pointer/src/test/scala/io/circe/pointer/PointerSuite.scala
@@ -48,6 +48,19 @@ class PointerSuite extends DisciplineSuite {
     assertEquals(p10(example.hcursor).focus, Some(Json.fromInt(7)))
     assertEquals(p11(example.hcursor).focus, Some(Json.fromInt(8)))
 
+    assertEquals(p0.getOption(example), Some(example))
+    assertEquals(p1.getOption(example), Some(Json.arr(Json.fromString("bar"), Json.fromString("baz"))))
+    assertEquals(p2.getOption(example), Some(Json.fromString("bar")))
+    assertEquals(p3.getOption(example), Some(Json.fromInt(0)))
+    assertEquals(p4.getOption(example), Some(Json.fromInt(1)))
+    assertEquals(p5.getOption(example), Some(Json.fromInt(2)))
+    assertEquals(p6.getOption(example), Some(Json.fromInt(3)))
+    assertEquals(p7.getOption(example), Some(Json.fromInt(4)))
+    assertEquals(p8.getOption(example), Some(Json.fromInt(5)))
+    assertEquals(p9.getOption(example), Some(Json.fromInt(6)))
+    assertEquals(p10.getOption(example), Some(Json.fromInt(7)))
+    assertEquals(p11.getOption(example), Some(Json.fromInt(8)))
+
     List(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11).foreach { p =>
       assertEquals(Option(p), p.asAbsolute)
     }
@@ -78,6 +91,12 @@ class PointerSuite extends DisciplineSuite {
     val Right(r2) = Pointer.parseRelative("2/highly/nested/objects")
     val Right(r3) = Pointer.parseRelative("0#")
     val Right(r4) = Pointer.parseRelative("1#")
+
+    assertEquals(p0(original).focus, Some(Json.fromString("baz")))
+    assertEquals(p1(original).focus, Some(Json.fromString("bar")))
+    assertEquals(p2(original).focus, Some(Json.fromBoolean(true)))
+    assertEquals(p3(original).focus, Some(Json.fromString("baz")))
+    assertEquals(p4(original).focus, Some(Json.arr(Json.fromString("bar"), Json.fromString("baz"))))
 
     assertEquals(p0(original).focus, Some(Json.fromString("baz")))
     assertEquals(p1(original).focus, Some(Json.fromString("bar")))

--- a/modules/pointer/src/test/scala/io/circe/pointer/PointerSuite.scala
+++ b/modules/pointer/src/test/scala/io/circe/pointer/PointerSuite.scala
@@ -1,0 +1,171 @@
+package io.circe.pointer
+
+import io.circe.{ CursorOp, Json }
+import io.circe.parser
+import munit.DisciplineSuite
+import org.scalacheck.Prop
+
+class PointerSuite extends DisciplineSuite {
+  test("The absolute pointer examples from RFC 6901 should evaluate correctly") {
+    val Right(example: Json) = parser.parse(
+      """{
+        "foo": ["bar", "baz"],
+        "": 0,
+        "a/b": 1,
+        "c%d": 2,
+        "e^f": 3,
+        "g|h": 4,
+        "i\\j": 5,
+        "k\"l": 6,
+        " ": 7,
+        "m~n": 8
+      }"""
+    )
+
+    val Right(p0) = Pointer.parse("")
+    val Right(p1) = Pointer.parse("/foo")
+    val Right(p2) = Pointer.parse("/foo/0")
+    val Right(p3) = Pointer.parse("/")
+    val Right(p4) = Pointer.parse("/a~1b")
+    val Right(p5) = Pointer.parse("/c%d")
+    val Right(p6) = Pointer.parse("/e^f")
+    val Right(p7) = Pointer.parse("/g|h")
+    val Right(p8) = Pointer.parse("/i\\j")
+    val Right(p9) = Pointer.parse("/k\"l")
+    val Right(p10) = Pointer.parse("/ ")
+    val Right(p11) = Pointer.parse("/m~0n")
+
+    assertEquals(p0(example.hcursor).focus, Some(example))
+    assertEquals(p1(example.hcursor).focus, Some(Json.arr(Json.fromString("bar"), Json.fromString("baz"))))
+    assertEquals(p2(example.hcursor).focus, Some(Json.fromString("bar")))
+    assertEquals(p3(example.hcursor).focus, Some(Json.fromInt(0)))
+    assertEquals(p4(example.hcursor).focus, Some(Json.fromInt(1)))
+    assertEquals(p5(example.hcursor).focus, Some(Json.fromInt(2)))
+    assertEquals(p6(example.hcursor).focus, Some(Json.fromInt(3)))
+    assertEquals(p7(example.hcursor).focus, Some(Json.fromInt(4)))
+    assertEquals(p8(example.hcursor).focus, Some(Json.fromInt(5)))
+    assertEquals(p9(example.hcursor).focus, Some(Json.fromInt(6)))
+    assertEquals(p10(example.hcursor).focus, Some(Json.fromInt(7)))
+    assertEquals(p11(example.hcursor).focus, Some(Json.fromInt(8)))
+  }
+
+  test("The relative pointer examples from the Relative JSON Pointers memo should evaluate correctly") {
+    val Right(example: Json) = parser.parse(
+      """{
+        "foo": ["bar", "baz"],
+        "highly": {
+          "nested": {
+            "objects": true
+          }
+        }
+      }"""
+    )
+
+    val original = example.hcursor.downField("foo").downN(1)
+
+    val Right(p0) = Pointer.parse("0")
+    val Right(p1) = Pointer.parse("1/0")
+    val Right(p2) = Pointer.parse("2/highly/nested/objects")
+    val Right(p3) = Pointer.parse("0#")
+    val Right(p4) = Pointer.parse("1#")
+
+    val Right(r0) = Pointer.Relative.parse("0")
+    val Right(r1) = Pointer.Relative.parse("1/0")
+    val Right(r2) = Pointer.Relative.parse("2/highly/nested/objects")
+    val Right(r3) = Pointer.Relative.parse("0#")
+    val Right(r4) = Pointer.Relative.parse("1#")
+
+    assertEquals(p0(original).focus, Some(Json.fromString("baz")))
+    assertEquals(p1(original).focus, Some(Json.fromString("bar")))
+    assertEquals(p2(original).focus, Some(Json.fromBoolean(true)))
+    assertEquals(p3(original).focus, Some(Json.fromString("baz")))
+    assertEquals(p4(original).focus, Some(Json.arr(Json.fromString("bar"), Json.fromString("baz"))))
+
+    assertEquals(r0(original).focus, Some(Json.fromString("baz")))
+    assertEquals(r1(original).focus, Some(Json.fromString("bar")))
+    assertEquals(r2(original).focus, Some(Json.fromBoolean(true)))
+    assertEquals(r3(original).focus, Some(Json.fromString("baz")))
+    assertEquals(r4(original).focus, Some(Json.arr(Json.fromString("bar"), Json.fromString("baz"))))
+
+    assertEquals(r0.evaluate(original), Right(Pointer.Relative.Result.Json(Json.fromString("baz"))))
+    assertEquals(r1.evaluate(original), Right(Pointer.Relative.Result.Json(Json.fromString("bar"))))
+    assertEquals(r2.evaluate(original), Right(Pointer.Relative.Result.Json(Json.fromBoolean(true))))
+    assertEquals(r3.evaluate(original), Right(Pointer.Relative.Result.Index(1)))
+    assertEquals(r4.evaluate(original), Right(Pointer.Relative.Result.Key("foo")))
+  }
+
+  test("Tokens with leading zeros should work as object keys") {
+    val Right(p) = Pointer.parse("/foo/01/bar")
+    val Right(doc) = parser.parse("""{"foo": {"01": {"bar": true}}}""")
+
+    assertEquals(p(doc.hcursor).focus, Some(Json.fromBoolean(true)))
+  }
+
+  test("Tokens with leading zeros should not work as array indices") {
+    val Right(good) = Pointer.parse("/foo/1/bar")
+    val Right(bad) = Pointer.parse("/foo/01/bar")
+    val Right(doc) = parser.parse("""{"foo": [{}, {"bar": true}]}""")
+
+    assertEquals(good(doc.hcursor).focus, Some(Json.fromBoolean(true)))
+    assertEquals(bad(doc.hcursor).focus, None)
+  }
+
+  property("Pointer.parse should never throw exceptions") {
+    Prop.forAll { (input: String) =>
+      Pointer.parse(input)
+      Pointer.parse(input, supportRelative = false)
+      true
+    }
+  }
+
+  test("Pointer parsing should fail with invalid escape sequences") {
+    assertEquals(Pointer.parse("/foo/~0/~2/~1"), Left(PointerSyntaxError(9, "0 or 1")))
+  }
+
+  test("Pointer parsing should fail with trailing tilde") {
+    assertEquals(Pointer.parse("/foo/~0/bar/~"), Left(PointerSyntaxError(12, "token character")))
+  }
+
+  test("Pointer parsing should fail on missing root") {
+    assertEquals(Pointer.parse("foo/~0/bar"), Left(PointerSyntaxError(0, "/ or digit")))
+  }
+
+  test("Pointer parsing should fail on missing root if relative pointers aren't supported") {
+    assertEquals(Pointer.parse("foo/~0/bar", supportRelative = false), Left(PointerSyntaxError(0, "/")))
+  }
+
+  test("Pointer parsing should fail on relative pointer if relative pointers aren't supported") {
+    assertEquals(Pointer.parse("0", supportRelative = false), Left(PointerSyntaxError(0, "/")))
+  }
+
+  test("Relative pointer parsing should fail on leading zeros") {
+    assertEquals(Pointer.parse("01/foo"), Left(PointerSyntaxError(1, "JSON Pointer or #")))
+  }
+
+  test("Relative pointer parsing should fail on extra input") {
+    assertEquals(Pointer.parse("1foo"), Left(PointerSyntaxError(1, "JSON Pointer or #")))
+  }
+
+  test("Relative pointer parsing should fail on extra input after #") {
+    assertEquals(Pointer.parse("0#/foo"), Left(PointerSyntaxError(2, "end of input")))
+  }
+
+  test("Relative pointer parsing should fail with an excessively large leading number") {
+    assertEquals(Pointer.parse("1234567890/foo"), Left(PointerSyntaxError(9, "JSON Pointer or #")))
+  }
+
+  test("Relative pointer parsing should fail without a leading number") {
+    assertEquals(Pointer.Relative.parse("/foo"), Left(PointerSyntaxError(0, "digit")))
+  }
+
+  test("Pointer navigation should fail as expected") {
+    val Right(example) = parser.parse("""{"foo": [1, 2, 3], "bar": null, "baz": false}""")
+    val Right(p0) = Pointer.parse("/foo/3")
+    val Right(p1) = Pointer.parse("/qux/3")
+    val Right(p2) = Pointer.parse("/foo/bar")
+
+    assertEquals(p0.get(example), Left(PointerFailure(List(CursorOp.DownN(3), CursorOp.DownField("foo")))))
+    assertEquals(p1.get(example), Left(PointerFailure(List(CursorOp.DownField("qux")))))
+    assertEquals(p2.get(example), Left(PointerFailure(List(CursorOp.DownField("bar"), CursorOp.DownField("foo")))))
+  }
+}


### PR DESCRIPTION
This PR includes two new modules that introduce [JSON Pointer](https://tools.ietf.org/html/rfc6901) functionality. They are intended to be fully compliant with [RFC 6901](https://tools.ietf.org/html/rfc6901) and the [Relative JSON Pointers](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02) memo from the IETF, with a minimal API and reasonable performance.

Usage looks like this:

```scala
scala> import io.circe.Decoder, io.circe.pointer.literal._
import io.circe.Decoder
import io.circe.pointer.literal._

scala> case class Foo(x: Int)
class Foo

scala> implicit val decodeFoo: Decoder[Foo] = Decoder[Int].map(Foo(_)).prepare(pointer"/a/b/c")
val decodeFoo: io.circe.Decoder[Foo] = io.circe.Decoder$$anon$11@7a4dad50

scala> io.circe.jawn.decode[Foo]("""{"a": {"b": {"c": 123}}}""")
val res0: Either[io.circe.Error,Foo] = Right(Foo(123))
```

The `pointer` string interpolator returns a `Pointer`, which is a new type that implements `ACursor => ACursor`, allowing it to be used conveniently in contexts like `prepare`.

The `Pointer.Relative` subtype additionally supports position evaluation with `#`:

```scala
scala> import io.circe.literal._, io.circe.pointer.Pointer
import io.circe.literal._
import io.circe.pointer.Pointer

scala> val Right(position) = Pointer.parseRelative("0#")
val position: io.circe.pointer.Pointer.Relative = 0#

scala> val Right(parentPosition) = Pointer.parseRelative("1#")
val parentPosition: io.circe.pointer.Pointer.Relative = 1#

scala> val atFalse = json"""{"foo": [true, false, true]}""".hcursor.downField("foo").downN(1)
val atFalse: io.circe.ACursor = io.circe.cursor.ArrayCursor@30936ff6

scala> position.evaluate(atFalse)
val res0: Either[io.circe.pointer.PointerFailure,io.circe.pointer.Pointer.Relative.Result] = Right(Index(1))

scala> parentPosition.evaluate(atFalse)
val res1: Either[io.circe.pointer.PointerFailure,io.circe.pointer.Pointer.Relative.Result] = Right(Key(foo))
```

There are currently some limitations to the interpolation macro (e.g. the initial depth for relative pointers can't be interpolated, and parsing happens at both compile-time and runtime), and while the code is fairly well tested, it's also approximately never been used.
