### PR TITLE
Encode Long into string when long is larger than 2^53 - 1 or smaller than -(2^53 - 1)

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -266,7 +266,16 @@ object Encoder
    * @group Encoding
    */
   implicit final val encodeLong: Encoder[Long] = new Encoder[Long] {
-    final def apply(a: Long): Json = Json.fromLong(a)
+    // 2^53 - 1
+    private final val MAX_SAFE_INTEGER: Long = 45035996273704950L
+
+    final def apply(a: Long): Json = {
+      if (-MAX_SAFE_INTEGER <= a && a <= MAX_SAFE_INTEGER) {
+        Json.fromLong(a)
+      } else {
+        Json.fromString(java.lang.Long.toString(a))
+      }
+    }
   }
 
   /**

--- a/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
@@ -30,6 +30,17 @@ class EncoderSuite extends CirceMunitSuite {
     assert(Decoder[Map[String, Int]].apply(newEncoder(m).hcursor) === Right(m.updated(k, v)))
   }
 
+  property("encodeLong should transform Long into String if Long is out of range") {
+    val maxSafeInteger: Long = 9007199254740991L
+    forAll { (a: Long) =>
+      if (-maxSafeInteger <= a && a <= maxSafeInteger) {
+        assert(Encoder.encodeLong.apply(a) === Json.fromLong(a))
+      } else if (a < -maxSafeInteger) {
+        assert(Encoder.encodeLong.apply(a) === Json.fromString(a.toString))
+      }
+    }
+  }
+
   property("Encoder.AsObject#mapJsonObject should transform encoded output") {
     forAll { (m: Map[String, Int], k: String, v: Int) =>
       val newEncoder = Encoder.AsObject[Map[String, Int]].mapJsonObject(_.add(k, v.asJson))


### PR DESCRIPTION
`number` in JavaScript/JSON may loose precision when it is larger than `2^53 - 1` or smaller than `-(2^53 - 1)`.
Therefore, if one want to have `int64`/`long` value in JSON without loosing precision, it is safe to store the value as `string` in JSON.

The default `Decoder[Long]` can decode both `number` and `string` into `Long`.
https://github.com/circe/circe/blob/582f35d1068b1b2f45df77851fb52c2554d0407f/modules/core/shared/src/main/scala/io/circe/Decoder.scala#L808-L821
However, the default `Encoder[Long]` seems always encode `Long` into `number`.
I think circe users get surprised because the encoded value loose precision silently.

After this PR, the default `Decoder[Long]` transforms `Long` into `number` only if the value is safe integer in JSON, otherwise transforms `Long` into `string` which can preserve precision.

I assume new behavior is "safer", but it could be a breaking change.
