### PR TITLE
Replace actions/setup-ruby with ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
 
       - name: Install Jekyll
         run: |

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ githubWorkflowJavaVersions in ThisBuild := Seq("adopt@1.8")
 githubWorkflowScalaVersions in ThisBuild := crossScalaVersions.in(ThisBuild).value.tail
 githubWorkflowPublishTargetBranches in ThisBuild := Nil
 githubWorkflowBuild in ThisBuild := Seq(
-  WorkflowStep.Use("actions", "setup-ruby", "v1", name = Some("Set up Ruby")),
+  WorkflowStep.Use("ruby", "setup-ruby", "v1", params = Map("ruby-version" -> "2.7"), name = Some("Set up Ruby")),
   WorkflowStep.Run(
     List("gem install sass", "gem install jekyll -v 4.0.0"),
     name = Some("Install Jekyll")


### PR DESCRIPTION
See: https://github.com/typelevel/cats/pull/3767

`actions/setup-ruby` is being officially deprecated in favor of `ruby/setup-ruby` and building the microsite without specifying a version can possibly cause errors. This fixes both issues, to use the new action as well as set a stable version of ruby.