### PR TITLE
Decreased Build Warnings

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Error.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Error.scala
@@ -84,8 +84,8 @@ object DecodingFailure {
       DecodingFailure(sw.toString, ops)
   }
 
-  implicit final val eqDecodingFailure: Eq[DecodingFailure] = Eq.instance {
-    case (DecodingFailure(m1, h1), DecodingFailure(m2, h2)) => m1 == m2 && CursorOp.eqCursorOpList.eqv(h1, h2)
+  implicit final val eqDecodingFailure: Eq[DecodingFailure] = Eq.instance { (a, b) =>
+    a.message == b.message && CursorOp.eqCursorOpList.eqv(a.history, b.history)
   }
 
   /**

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -589,7 +589,7 @@ object Json {
     val it0 = x.iterator
     val it1 = y.iterator
     while (it0.hasNext && it1.hasNext) {
-      if (Json.eqJson.neqv(it0.next, it1.next)) return false
+      if (Json.eqJson.neqv(it0.next(), it1.next())) return false
     }
     it0.hasNext == it1.hasNext
   }

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -230,7 +230,7 @@ object JsonObject {
     val iterator = fields.iterator
 
     while (iterator.hasNext) {
-      val (key, value) = iterator.next
+      val (key, value) = iterator.next()
 
       map.put(key, value)
     }

--- a/modules/core/shared/src/main/scala/io/circe/MapDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/MapDecoder.scala
@@ -36,7 +36,7 @@ private[circe] abstract class MapDecoder[K, V, M[K, V] <: Map[K, V]](
     var failed: DecodingFailure = null
 
     while (failed.eq(null) && it.hasNext) {
-      val key = it.next
+      val key = it.next()
       val atH = createObjectCursor(c, obj, key)
 
       failed = if (alwaysDecodeK.ne(null)) {
@@ -49,7 +49,7 @@ private[circe] abstract class MapDecoder[K, V, M[K, V] <: Map[K, V]](
       }
     }
 
-    if (failed.eq(null)) Right(builder.result) else Left(failed)
+    if (failed.eq(null)) Right(builder.result()) else Left(failed)
   }
 
   final override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[M[K, V]] = c.value match {
@@ -60,7 +60,7 @@ private[circe] abstract class MapDecoder[K, V, M[K, V] <: Map[K, V]](
       val failures = List.newBuilder[DecodingFailure]
 
       while (it.hasNext) {
-        val key = it.next
+        val key = it.next()
         val atH = createObjectCursor(c, obj, key)
 
         if (alwaysDecodeK.ne(null)) {
@@ -88,11 +88,11 @@ private[circe] abstract class MapDecoder[K, V, M[K, V] <: Map[K, V]](
         }
       }
 
-      if (!failed) Validated.valid(builder.result)
+      if (!failed) Validated.valid(builder.result())
       else {
-        failures.result match {
+        failures.result() match {
           case h :: t => Validated.invalid(NonEmptyList(h, t))
-          case Nil    => Validated.valid(builder.result)
+          case Nil    => Validated.valid(builder.result())
         }
       }
     case _ => MapDecoder.failureAccumulatingResult[M[K, V]](c)

--- a/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
@@ -22,9 +22,9 @@ private[circe] abstract class SeqDecoder[A, C[_]](decodeA: Decoder[A]) extends D
         }
       }
 
-      if (failed.eq(null)) Right(builder.result) else Left(failed)
+      if (failed.eq(null)) Right(builder.result()) else Left(failed)
     } else {
-      if (c.value.isArray) Right(createBuilder().result)
+      if (c.value.isArray) Right(createBuilder().result())
       else {
         Left(DecodingFailure("C[A]", c.history))
       }
@@ -51,15 +51,15 @@ private[circe] abstract class SeqDecoder[A, C[_]](decodeA: Decoder[A]) extends D
         current = current.right
       }
 
-      if (!failed) Validated.valid(builder.result)
+      if (!failed) Validated.valid(builder.result())
       else {
-        failures.result match {
+        failures.result() match {
           case h :: t => Validated.invalid(NonEmptyList(h, t))
-          case Nil    => Validated.valid(builder.result)
+          case Nil    => Validated.valid(builder.result())
         }
       }
     } else {
-      if (c.value.isArray) Validated.valid(createBuilder().result)
+      if (c.value.isArray) Validated.valid(createBuilder().result())
       else {
         Validated.invalidNel(DecodingFailure("C[A]", c.history))
       }

--- a/modules/literal/src/main/scala/io/circe/literal/JsonLiteralMacros.scala
+++ b/modules/literal/src/main/scala/io/circe/literal/JsonLiteralMacros.scala
@@ -29,7 +29,7 @@ class JsonLiteralMacros(val c: blackbox.Context) {
        * Generate a unique string that doesn't appear in the JSON literal.
        */
       val placeholder =
-        Stream.continually(generatePlaceholder()).distinct.dropWhile(s => stringParts.exists(_.contains(s))).head
+        LazyList.continually(generatePlaceholder()).distinct.dropWhile(s => stringParts.exists(_.contains(s))).head
 
       new Replacement(placeholder, argument)
     }

--- a/modules/literal/src/main/scala/io/circe/literal/JsonLiteralMacros.scala
+++ b/modules/literal/src/main/scala/io/circe/literal/JsonLiteralMacros.scala
@@ -29,7 +29,7 @@ class JsonLiteralMacros(val c: blackbox.Context) {
        * Generate a unique string that doesn't appear in the JSON literal.
        */
       val placeholder =
-        LazyList.continually(generatePlaceholder()).distinct.dropWhile(s => stringParts.exists(_.contains(s))).head
+        Stream.continually(generatePlaceholder()).distinct.dropWhile(s => stringParts.exists(_.contains(s))).head
 
       new Replacement(placeholder, argument)
     }

--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -18,7 +18,7 @@ package object scalajs {
     case a: js.Array[_] => Json.fromValues(a.map(convertAnyToJsonUnsafe(_: Any)))
     case o: js.Object =>
       Json.fromFields(
-        o.asInstanceOf[js.Dictionary[_]].mapValues(convertAnyToJsonUnsafe).toSeq
+        o.asInstanceOf[js.Dictionary[_]].view.mapValues(convertAnyToJsonUnsafe).toSeq
       )
     case other if js.isUndefined(other) => Json.Null
   }
@@ -49,7 +49,7 @@ package object scalajs {
     def onNumber(value: JsonNumber): js.Any = value.toDouble
     def onString(value: String): js.Any = value
     def onArray(value: Vector[Json]): js.Any = value.map(this).toJSArray
-    def onObject(value: JsonObject): js.Any = value.toMap.mapValues(this).toMap.toJSDictionary
+    def onObject(value: JsonObject): js.Any = value.toMap.view.mapValues(this).toMap.toJSDictionary
   }
 
   /**

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
@@ -1,8 +1,7 @@
 package io.circe.tests
 
-import cats.instances._
 import cats.syntax._
-import io.circe.testing.{ ArbitraryInstances, EqInstances }
+import io.circe.testing.{ArbitraryInstances, EqInstances}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.typelevel.discipline.scalatest.FlatSpecDiscipline

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
@@ -1,7 +1,7 @@
 package io.circe.tests
 
 import cats.syntax._
-import io.circe.testing.{ArbitraryInstances, EqInstances}
+import io.circe.testing.{ ArbitraryInstances, EqInstances }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.typelevel.discipline.scalatest.FlatSpecDiscipline


### PR DESCRIPTION
Picked some low hanging fruits from #1680 

Removed most to all of the following warnings when using `sbt compile`:
- Auto-application to () is depricated
- Unused Imports
- non exhaustive pattern matches
- changed Streams to LazyLists where used internally
- changed Map.mapValues to Map.view.mapValues(.map where needed)

based on local testing this should decrease the number of build output lines with `[warn]` in them by around 40%

There are still a lot of build warnings coming the usage of streams in the api, these could not really be adjusted