### PR TITLE
Docs - Update note about @JsonCodec use

### DIFF
--- a/docs/src/main/tut/codecs/semiauto-derivation.md
+++ b/docs/src/main/tut/codecs/semiauto-derivation.md
@@ -42,7 +42,7 @@ Bar(13, "Qux").asJson
 
 This works with both case classes and sealed trait hierarchies.
 
-NOTE: You will need the [Macro Paradise](https://docs.scala-lang.org/overviews/macros/paradise.html) plugin to use annotation macros like `@JsonCodec`
+NOTE: You will need to use the `-Ymacro-annotations` flag to use [annotation macros](https://docs.scala-lang.org/overviews/macros/annotations.html) like `@JsonCodec`. (If you're using Scala 2.10.x to Scala 2.12.x you will need the [Macro Paradise](https://docs.scala-lang.org/overviews/macros/paradise.html) plugin instead).
 
 ### forProductN helper methods
 


### PR DESCRIPTION
In the [documentation](https://circe.github.io/circe/codecs/semiauto-derivation.html#jsoncodec) it is written that, to use  `@JsonCodec` you need the Macro Paradise plugin.

But as of Scala 2.13.x, [the plugin has been included in the compiler](https://github.com/scalamacros/paradise#macro-paradise-plugin) and what you need is the `"-Ymacro-annotations"` flag.