### PR TITLE
Use GitHub URLs instead of local paths in SJSIR files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,7 +149,18 @@ def circeCrossModule(path: String, mima: Option[String], crossType: CrossType = 
     .jvmSettings(
       mimaPreviousArtifacts := mima.map("io.circe" %% moduleName.value % _).toSet
     )
-    .jsSettings(coverageEnabled := false)
+    .jsSettings(
+      coverageEnabled := false,
+      scalacOptions += {
+        val tagOrHash =
+          if (!isSnapshot.value) s"v${version.value}"
+          else git.gitHeadCommit.value.getOrElse("master")
+        val local = (baseDirectory in LocalRootProject).value.toURI.toString
+        val remote = s"https://raw.githubusercontent.com/circe/circe/$tagOrHash/"
+        val opt = if (isDotty.value) "-scalajs-mapSourceURI" else "-P:scalajs:mapSourceURI"
+        s"$opt:$local->$remote"
+      }
+    )
 }
 
 /**


### PR DESCRIPTION
This replaces local file paths in Scala.js SJSIR files with GitHub URLs.

It enables to see circe sources in the browser in Scala.js projects and gets rid of warnings like these in projects that use scalajs-bundler and webpack:
```
[warn] Module Warning (from ./node_modules/source-map-loader/index.js):
[warn] (Emitted value instead of an instance of Error) Cannot find source file
  '../../../../../../../../../../../../home/travis/code/projects/circe/modules/core/js/target/scala-2.13/src_managed/main/io/circe/TupleDecoders.scala'
```

Note that the same is done in [Cats](https://github.com/typelevel/cats/blob/7931fe217cd00feefbadb8078596679b42d1bfa0/build.sbt#L189-L198).