### PR TITLE
remove sbt-dotty from build

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.4")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "1.3.3")
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.10.1")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")


### PR DESCRIPTION
its functionality is built in to sbt 1.5. but some details are a little different