### PR TITLE
Migrate tests from ScalaTest to Munit: DecoderSuite

### DIFF
--- a/modules/tests/js/src/test/scala/io/circe/LargeNumberDecoderTests.scala
+++ b/modules/tests/js/src/test/scala/io/circe/LargeNumberDecoderTests.scala
@@ -1,9 +1,10 @@
 package io.circe
 
-import io.circe.tests.CirceSuite
+import io.circe.tests.{ CirceMunitSuite, CirceSuite }
 
 /**
  * On the JVM this trait contains tests that fail because of bugs (or at least
  * limitations) on Scala.js.
  */
 trait LargeNumberDecoderTests { this: CirceSuite => }
+trait LargeNumberDecoderTestsMunit { this: CirceMunitSuite => }

--- a/modules/tests/jvm/src/test/scala/io/circe/LargeNumberDecoderTests.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/LargeNumberDecoderTests.scala
@@ -2,7 +2,8 @@ package io.circe
 
 import cats.instances.all._
 import io.circe.parser.parse
-import io.circe.tests.CirceSuite
+import io.circe.tests.{ CirceMunitSuite, CirceSuite }
+import org.scalacheck.Prop.forAll
 
 /**
  * Tests that fail because of bugs (or at least limitations) on Scala.js.
@@ -20,5 +21,23 @@ trait LargeNumberDecoderTests { this: CirceSuite =>
     val Right(json) = parse(s"$v.$zeros")
 
     assert(Decoder[BigInt].apply(json.hcursor) === Right(v))
+  }
+}
+
+trait LargeNumberDecoderTestsMunit { this: CirceMunitSuite =>
+  property("Decoder[Long] should succeed on whole decimal values (#83)") {
+    forAll { (v: Long, n: Byte) =>
+      val zeros = "0" * (math.abs(n.toInt) + 1)
+      val Right(json) = parse(s"$v.$zeros")
+      assertEquals(Decoder[Long].apply(json.hcursor), Right(v))
+    }
+  }
+
+  property("Decoder[BigInt] should succeed on whole decimal values (#83)") {
+    forAll { (v: BigInt, n: Byte) =>
+      val zeros = "0" * (math.abs(n.toInt) + 1)
+      val Right(json) = parse(s"$v.$zeros")
+      assertEquals(Decoder[BigInt].apply(json.hcursor), Right(v))
+    }
   }
 }

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CirceMunitSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CirceMunitSuite.scala
@@ -6,4 +6,16 @@ import munit.DisciplineSuite
 /**
  * An opinionated stack of traits to improve consistency and reduce boilerplate in circe tests.
  */
-trait CirceMunitSuite extends DisciplineSuite with ArbitraryInstances with EqInstances with MissingInstances
+trait CirceMunitSuite extends DisciplineSuite with ArbitraryInstances with EqInstances with MissingInstances {
+
+  protected def group(name: String)(thunk: => Unit): Unit = {
+    val countBefore = munitTestsBuffer.size
+    val _ = thunk
+    val countAfter = munitTestsBuffer.size
+    val countRegistered = countAfter - countBefore
+    val registered = munitTestsBuffer.toList.drop(countBefore)
+    (0 until countRegistered).foreach(_ => munitTestsBuffer.remove(countBefore))
+    registered.foreach(t => munitTestsBuffer += t.withName(s"$name - ${t.name}"))
+  }
+
+}

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -2,60 +2,60 @@ package io.circe
 
 import cats.data.Validated.Invalid
 import cats.data.{ Chain, NonEmptyList, Validated }
-import cats.instances.all._
+import cats.implicits._
 import cats.kernel.Eq
 import cats.laws.discipline.{ MonadErrorTests, SemigroupKTests }
-import cats.syntax.eq._
-import cats.syntax.foldable._
 import io.circe.CursorOp.{ DownArray, DownN }
 import io.circe.parser.parse
 import io.circe.syntax._
 import io.circe.testing.CodecTests
-import io.circe.tests.CirceSuite
+import io.circe.tests.CirceMunitSuite
 import io.circe.tests.examples.WrappedOptionalField
-import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalacheck.Prop.forAll
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NoStackTrace
 
-class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDrivenPropertyChecks {
+class DecoderSuite extends CirceMunitSuite with LargeNumberDecoderTestsMunit {
   checkAll("Decoder[Int]", MonadErrorTests[Decoder, DecodingFailure].monadError[Int, Int, Int])
   checkAll("Decoder[Int]", SemigroupKTests[Decoder].semigroupK[Int])
 
-  private[this] def transformations[T] = Table[Decoder[T] => Decoder[T]](
-    "transformation",
+  private[this] def transformations[T]: List[Decoder[T] => Decoder[T]] = List(
     _.prepare(identity),
     _.map(identity),
     _.emap(Right(_)),
     _.emapTry(Success(_))
   )
 
-  private[this] def containerDecoders[T: Decoder] = Table[Decoder[_]](
-    "decoder",
+  private[this] def containerDecoders[T: Decoder]: List[Decoder[_]] = List(
     Decoder[Set[T]],
     Decoder[List[T]],
     Decoder[Vector[T]],
     Decoder[Chain[T]]
   )
 
-  "transformations" should "do nothing when used with identity" in forAll(transformations[Int]) { transformation =>
-    val decoder = transformation(Decoder[Int])
-    forAll { (i: Int) =>
-      assert(decoder.decodeJson(i.asJson) === Right(i))
-      assert(decoder.decodeAccumulating(i.asJson.hcursor) === Validated.valid(i))
+  property("transformations should do nothing when used with identity") {
+    transformations[Int].foreach { transformation =>
+      val decoder = transformation(Decoder[Int])
+      forAll { (i: Int) =>
+        assertEquals(decoder.decodeJson(i.asJson), Right(i))
+        assertEquals(decoder.decodeAccumulating(i.asJson.hcursor), Validated.valid(i))
+      }
     }
   }
 
-  "transformations" should "fail when called on failed decoder" in forAll(transformations[Int]) { transformation =>
-    val decoder = transformation(Decoder.failedWithMessage("Some message"))
-    val failure = DecodingFailure("Some message", Nil)
-    forAll { (i: Int) =>
-      assert(decoder.decodeJson(i.asJson) === Left(failure))
-      assert(decoder.decodeAccumulating(i.asJson.hcursor) === Validated.invalidNel(failure))
+  property("transformations should fail when called on failed decoder") {
+    transformations[Int].foreach { transformation =>
+      val decoder = transformation(Decoder.failedWithMessage("Some message"))
+      val failure = DecodingFailure("Some message", Nil)
+      forAll { (i: Int) =>
+        assertEquals(decoder.decodeJson(i.asJson), Left(failure))
+        assertEquals(decoder.decodeAccumulating(i.asJson.hcursor), Validated.invalidNel(failure))
+      }
     }
   }
 
-  "transformations" should "not break derived decoders when called on Decoder[Option[T]]" in
-    forAll(transformations[Option[String]]) { transformation =>
+  property("transformations should not break derived decoders when called on Decoder[Option[T]]") {
+    transformations[Option[String]].foreach { transformation =>
       implicit val decodeOptionString: Decoder[Option[String]] =
         transformation(Decoder.decodeOption(Decoder.decodeString))
 
@@ -66,66 +66,83 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
 
       case class Test(a: Option[String])
       // Dotty crashes here with `CyclicReference` on `assert`.
-      assertResult(Decoder[Test].decodeJson(Json.obj()))(Right(Test(None)))
-      assertResult(Decoder[Test].decodeAccumulating(Json.obj().hcursor))(Validated.valid(Test(None)))
+      assertEquals(Decoder[Test].decodeJson(Json.obj()), Right(Test(None)))
+      assertEquals(Decoder[Test].decodeAccumulating(Json.obj().hcursor), Validated.valid(Test(None)))
     }
-
-  "prepare" should "move appropriately with downField" in forAll { (i: Int, k: String, m: Map[String, Int]) =>
-    assert(Decoder[Int].prepare(_.downField(k)).decodeJson(m.updated(k, i).asJson) === Right(i))
   }
 
-  "at" should "move appropriately" in forAll { (i: Int, k: String, m: Map[String, Int]) =>
-    assert(Decoder[Int].at(k).decodeJson(m.updated(k, i).asJson) === Right(i))
+  property("prepare should move appropriately with downField") {
+    forAll { (i: Int, k: String, m: Map[String, Int]) =>
+      assertEquals(Decoder[Int].prepare(_.downField(k)).decodeJson(m.updated(k, i).asJson), Right(i))
+    }
   }
 
-  it should "accumulate errors" in forAll { (k: String, x: Boolean, xs: List[Boolean], m: Map[String, Int]) =>
-    val json = m.mapValues(_.asJson).toMap.updated(k, (x :: xs).asJson).asJson
-
-    assert(Decoder[List[Int]].at(k).decodeAccumulating(json.hcursor).leftMap(_.size) === Validated.invalid(xs.size + 1))
+  property("at should move appropriately") {
+    forAll { (i: Int, k: String, m: Map[String, Int]) =>
+      assertEquals(Decoder[Int].at(k).decodeJson(m.updated(k, i).asJson), Right(i))
+    }
   }
 
-  "emap" should "appropriately transform the result with an operation that can't fail" in forAll { (i: Int) =>
-    assert(Decoder[Int].emap(v => Right(v + 1)).decodeJson(i.asJson) === Right(i + 1))
+  property("at should accumulate errors") {
+    forAll { (k: String, x: Boolean, xs: List[Boolean], m: Map[String, Int]) =>
+      val json = m.mapValues(_.asJson).toMap.updated(k, (x :: xs).asJson).asJson
+      val actual = Decoder[List[Int]].at(k).decodeAccumulating(json.hcursor).leftMap(_.size)
+      assertEquals(actual, Validated.invalid(xs.size + 1))
+    }
   }
 
-  it should "appropriately transform the result with an operation that may fail" in forAll { (i: Int) =>
-    val decoder = Decoder[Int].emap(v => if (v % 2 == 0) Right(v) else Left("Odd"))
-    val expected = if (i % 2 == 0) Right(i) else Left(DecodingFailure("Odd", Nil))
-
-    assert(decoder.decodeJson(i.asJson) === expected)
+  property("emap should appropriately transform the result with an operation that can't fail") {
+    forAll { (i: Int) =>
+      assertEquals(Decoder[Int].emap(v => Right(v + 1)).decodeJson(i.asJson), Right(i + 1))
+    }
   }
 
-  "emapTry" should "appropriately transform the result with an operation that can't fail" in forAll { (i: Int) =>
-    assert(Decoder[Int].emapTry(v => Success(v + 1)).decodeJson(i.asJson) === Right(i + 1))
+  property("emap should appropriately transform the result with an operation that may fail") {
+    forAll { (i: Int) =>
+      val decoder = Decoder[Int].emap(v => if (v % 2 == 0) Right(v) else Left("Odd"))
+      val expected = if (i % 2 == 0) Right(i) else Left(DecodingFailure("Odd", Nil))
+
+      assertEquals(decoder.decodeJson(i.asJson), expected)
+    }
   }
 
-  it should "appropriately transform the result with an operation that may fail" in forAll { (i: Int) =>
-    val exception = new Exception("Odd") with NoStackTrace
-    val decoder = Decoder[Int].emapTry(v => if (v % 2 == 0) Success(v) else Failure(exception))
-
-    assert(decoder.decodeJson(i.asJson).isRight == (i % 2 == 0))
+  property("emapTry should appropriately transform the result with an operation that can't fail") {
+    forAll { (i: Int) =>
+      assertEquals(Decoder[Int].emapTry(v => Success(v + 1)).decodeJson(i.asJson), Right(i + 1))
+    }
   }
 
-  "handleErrorWith" should "respect the underlying decoder's tryDecode (#1271)" in {
+  property("emapTry should appropriately transform the result with an operation that may fail") {
+    forAll { (i: Int) =>
+      val exception = new Exception("Odd") with NoStackTrace
+      val decoder = Decoder[Int].emapTry(v => if (v % 2 == 0) Success(v) else Failure(exception))
+
+      assertEquals(decoder.decodeJson(i.asJson).isRight, i % 2 == 0)
+    }
+  }
+
+  test("handleErrorWith should respect the underlying decoder's tryDecode (#1271)") {
     val decoder: Decoder[Option[String]] =
       Decoder.decodeOption[String].handleErrorWith(_ => Decoder.const(None)).at("a")
 
-    assert(decoder.decodeJson(Json.obj("a" := 1)) === Right(None))
-    assert(decoder.decodeJson(Json.obj("a" := Json.Null)) === Right(None))
-    assert(decoder.decodeJson(Json.obj("b" := "abc")) === Right(None))
-    assert(decoder.decodeJson(Json.obj("a" := "abc")) === Right(Some("abc")))
+    assertEquals(decoder.decodeJson(Json.obj("a" := 1)), Right(None))
+    assertEquals(decoder.decodeJson(Json.obj("a" := Json.Null)), Right(None))
+    assertEquals(decoder.decodeJson(Json.obj("b" := "abc")), Right(None))
+    assertEquals(decoder.decodeJson(Json.obj("a" := "abc")), Right(Some("abc")))
 
-    assert(decoder.decodeAccumulating(Json.obj("a" := 1).hcursor) === Validated.valid(None))
-    assert(decoder.decodeAccumulating(Json.obj("a" := Json.Null).hcursor) === Validated.valid(None))
-    assert(decoder.decodeAccumulating(Json.obj("b" := "abc").hcursor) === Validated.valid(None))
-    assert(decoder.decodeAccumulating(Json.obj("a" := "abc").hcursor) === Validated.valid(Some("abc")))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := 1).hcursor), Validated.valid(None))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := Json.Null).hcursor), Validated.valid(None))
+    assertEquals(decoder.decodeAccumulating(Json.obj("b" := "abc").hcursor), Validated.valid(None))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := "abc").hcursor), Validated.valid(Some("abc")))
   }
 
-  "failedWithMessage" should "replace the message" in forAll { (json: Json) =>
-    assert(Decoder.failedWithMessage[Int]("Bad").decodeJson(json) === Left(DecodingFailure("Bad", Nil)))
+  property("failedWithMessage should replace the message") {
+    forAll { (json: Json) =>
+      assertEquals(Decoder.failedWithMessage[Int]("Bad").decodeJson(json), Left(DecodingFailure("Bad", Nil)))
+    }
   }
 
-  "An optional object field decoder" should "fail appropriately" in {
+  property("An optional object field decoder should fail appropriately") {
     val decoder: Decoder[Option[String]] = Decoder.instance(
       _.downField("").downField("").as[Option[String]]
     )
@@ -133,40 +150,38 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     forAll { (json: Json) =>
       val result = decoder.apply(json.hcursor)
 
-      assert(
-        json.asObject match {
-          // The top-level value isn't an object, so we should fail.
-          case None => result.isLeft
-          case Some(o1) =>
-            o1("") match {
-              // The top-level object doesn't contain a "" key, so we should succeed emptily.
-              case None => result === Right(None)
-              case Some(j2) =>
-                j2.asObject match {
-                  // The second-level value isn't an object, so we should fail.
-                  case None => result.isLeft
-                  case Some(o2) =>
-                    o2("") match {
-                      // The second-level object doesn't contain a "" key, so we should succeed emptily.
-                      case None => result === Right(None)
-                      // The third-level value is null, so we succeed emptily.
-                      case Some(j3) if j3.isNull => result === Right(None)
-                      case Some(j3) =>
-                        j3.asString match {
-                          // The third-level value isn't a string, so we should fail.
-                          case None => result.isLeft
-                          // The third-level value is a string, so we should have decoded it.
-                          case Some(s3) => result === Right(Some(s3))
-                        }
-                    }
-                }
-            }
-        }
-      )
+      json.asObject match {
+        // The top-level value isn't an object, so we should fail.
+        case None => assert(result.isLeft)
+        case Some(o1) =>
+          o1("") match {
+            // The top-level object doesn't contain a "" key, so we should succeed emptily.
+            case None => assertEquals(result, Right(None))
+            case Some(j2) =>
+              j2.asObject match {
+                // The second-level value isn't an object, so we should fail.
+                case None => assert(result.isLeft)
+                case Some(o2) =>
+                  o2("") match {
+                    // The second-level object doesn't contain a "" key, so we should succeed emptily.
+                    case None => assertEquals(result, Right(None))
+                    // The third-level value is null, so we succeed emptily.
+                    case Some(j3) if j3.isNull => assertEquals(result, Right(None))
+                    case Some(j3) =>
+                      j3.asString match {
+                        // The third-level value isn't a string, so we should fail.
+                        case None => assert(result.isLeft)
+                        // The third-level value is a string, so we should have decoded it.
+                        case Some(s3) => assertEquals(result, Right(Some(s3)))
+                      }
+                  }
+              }
+          }
+      }
     }
   }
 
-  "An optional array position decoder" should "fail appropriately" in {
+  property("An optional array position decoder should fail appropriately") {
     val decoder: Decoder[Option[String]] = Decoder.instance(
       _.downN(0).downN(1).as[Option[String]]
     )
@@ -174,183 +189,216 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     forAll { (json: Json) =>
       val result = decoder.apply(json.hcursor)
 
-      assert(
-        json.asArray match {
-          // The top-level value isn't an array, so we should fail.
-          case None => result.isLeft
-          case Some(a1) =>
-            a1.lift(0) match {
-              // The top-level array is empty, so we should succeed emptily.
-              case None => result === Right(None)
-              case Some(j2) =>
-                j2.asArray match {
-                  // The second-level value isn't an array, so we should fail.
-                  case None => result.isLeft
-                  case Some(a2) =>
-                    a2.lift(1) match {
-                      // The second-level array doesn't have a second element, so we should succeed emptily.
-                      case None => result === Right(None)
-                      // The third-level value is null, so we succeed emptily.
-                      case Some(j3) if j3.isNull => result === Right(None)
-                      case Some(j3) =>
-                        j3.asString match {
-                          // The third-level value isn't a string, so we should fail.
-                          case None => result.isLeft
-                          // The third-level value is a string, so we should have decoded it.
-                          case Some(s3) => result === Right(Some(s3))
-                        }
-                    }
-                }
-            }
-        }
-      )
+      json.asArray match {
+        // The top-level value isn't an array, so we should fail.
+        case None => assert(result.isLeft)
+        case Some(a1) =>
+          a1.lift(0) match {
+            // The top-level array is empty, so we should succeed emptily.
+            case None => assertEquals(result, Right(None))
+            case Some(j2) =>
+              j2.asArray match {
+                // The second-level value isn't an array, so we should fail.
+                case None => assert(result.isLeft)
+                case Some(a2) =>
+                  a2.lift(1) match {
+                    // The second-level array doesn't have a second element, so we should succeed emptily.
+                    case None => assertEquals(result, Right(None))
+                    // The third-level value is null, so we succeed emptily.
+                    case Some(j3) if j3.isNull => assertEquals(result, Right(None))
+                    case Some(j3) =>
+                      j3.asString match {
+                        // The third-level value isn't a string, so we should fail.
+                        case None => assert(result.isLeft)
+                        // The third-level value is a string, so we should have decoded it.
+                        case Some(s3) => assertEquals(result, Right(Some(s3)))
+                      }
+                  }
+              }
+          }
+      }
     }
   }
 
-  "An optional top-level decoder" should "fail appropriately" in {
+  property("An optional top-level decoder should fail appropriately") {
     val decoder: Decoder[Option[String]] = Decoder.instance(_.as[Option[String]])
 
     forAll { (json: Json) =>
       val result = decoder.apply(json.hcursor)
-
-      assert(
-        if (json.isNull) {
-          result === Right(None)
-        } else
-          json.asString match {
-            case Some(str) => result === Right(Some(str))
-            case None      => result.isLeft
-          }
-      )
+      if (json.isNull)
+        assertEquals(result, Right(None))
+      else
+        json.asString match {
+          case Some(str) => assertEquals(result, Right(Some(str)))
+          case None      => assert(result.isLeft)
+        }
     }
   }
 
-  "A nested optional decoder" should "accumulate failures" in {
+  test("A nested optional decoder should accumulate failures") {
     val pair = Json.arr(Json.fromInt(1), Json.fromInt(2))
 
     val result = Decoder[Option[(String, String)]].decodeAccumulating(pair.hcursor)
     val expected = Validated.invalid(
       NonEmptyList.of(DecodingFailure("String", List(DownN(0))), DecodingFailure("String", List(DownN(1))))
     )
-
-    assert(result === expected)
+    assertEquals(result, expected)
   }
 
-  "instanceTry" should "provide instances that succeed or fail appropriately" in forAll { (json: Json) =>
-    val exception = new Exception("Not an Int")
-    val expected = json.hcursor.as[Int].leftMap(_ => DecodingFailure.fromThrowable(exception, Nil))
-    val instance = Decoder.instanceTry(c => Try(c.as[Int].getOrElse(throw exception)))
+  property("instanceTry should provide instances that succeed or fail appropriately") {
+    forAll { (json: Json) =>
+      val exception = new Exception("Not an Int")
+      val expected = json.hcursor.as[Int].leftMap(_ => DecodingFailure.fromThrowable(exception, Nil))
+      val instance = Decoder.instanceTry(c => Try(c.as[Int].getOrElse(throw exception)))
 
-    assert(instance.decodeJson(json) === expected)
+      assertEquals(instance.decodeJson(json), expected)
+    }
   }
 
-  "Decoder[Byte]" should "fail on out-of-range values (#83)" in forAll { (l: Long) =>
-    val json = Json.fromLong(l)
-    val result = Decoder[Byte].apply(json.hcursor)
+  group("Decoder[Byte] should") {
+    property("fail on out-of-range values (#83)") {
+      forAll { (l: Long) =>
+        val json = Json.fromLong(l)
+        val result = Decoder[Byte].apply(json.hcursor)
 
-    assert(if (l.toByte.toLong == l) result === Right(l.toByte) else result.isLeft)
+        assert(if (l.toByte.toLong == l) result === Right(l.toByte) else result.isLeft)
+      }
+    }
+
+    property("fail on non-whole values (#83)") {
+      forAll { (d: Double) =>
+        val json = Json.fromDoubleOrNull(d)
+        val result = Decoder[Byte].apply(json.hcursor)
+
+        assert(d.isWhole || result.isLeft)
+      }
+    }
+
+    property("succeed on whole decimal values (#83)") {
+      forAll { (v: Byte, n: Byte) =>
+        val zeros = "0" * (math.abs(n.toInt) + 1)
+        val Right(json) = parse(s"$v.$zeros")
+
+        assertEquals(Decoder[Byte].apply(json.hcursor), Right(v))
+      }
+    }
   }
 
-  it should "fail on non-whole values (#83)" in forAll { (d: Double) =>
-    val json = Json.fromDoubleOrNull(d)
-    val result = Decoder[Byte].apply(json.hcursor)
+  group("Decoder[Short] should") {
+    property("fail on out-of-range values (#83)") {
+      forAll { (l: Long) =>
+        val json = Json.fromLong(l)
+        val result = Decoder[Short].apply(json.hcursor)
 
-    assert(d.isWhole || result.isLeft)
+        assert(if (l.toShort.toLong == l) result === Right(l.toShort) else result.isLeft)
+      }
+    }
+
+    property("fail on non-whole values (#83)") {
+      forAll { (d: Double) =>
+        val json = Json.fromDoubleOrNull(d)
+        val result = Decoder[Short].apply(json.hcursor)
+
+        assert(d.isWhole || result.isLeft)
+      }
+    }
+
+    property("succeed on whole decimal values (#83)") {
+      forAll { (v: Short, n: Byte) =>
+        val zeros = "0" * (math.abs(n.toInt) + 1)
+        val Right(json) = parse(s"$v.$zeros")
+
+        assertEquals(Decoder[Short].apply(json.hcursor), Right(v))
+      }
+    }
   }
 
-  it should "succeed on whole decimal values (#83)" in forAll { (v: Byte, n: Byte) =>
-    val zeros = "0" * (math.abs(n.toInt) + 1)
-    val Right(json) = parse(s"$v.$zeros")
+  group("Decoder[Int] should") {
+    property("fail on out-of-range values (#83)") {
+      forAll { (l: Long) =>
+        val json = Json.fromLong(l)
+        val result = Decoder[Int].apply(json.hcursor)
 
-    assert(Decoder[Byte].apply(json.hcursor) === Right(v))
+        assert(if (l.toInt.toLong == l) result === Right(l.toInt) else result.isLeft)
+      }
+    }
+
+    property("fail on non-whole values (#83)") {
+      forAll { (d: Double) =>
+        val json = Json.fromDoubleOrNull(d)
+        val result = Decoder[Int].apply(json.hcursor)
+
+        assert(d.isWhole || result.isLeft)
+      }
+    }
+
+    property("succeed on whole decimal values (#83)") {
+      forAll { (v: Int, n: Byte) =>
+        val zeros = "0" * (math.abs(n.toInt) + 1)
+        val Right(json) = parse(s"$v.$zeros")
+
+        assertEquals(Decoder[Int].apply(json.hcursor), Right(v))
+      }
+    }
+
   }
 
-  "Decoder[Short]" should "fail on out-of-range values (#83)" in forAll { (l: Long) =>
-    val json = Json.fromLong(l)
-    val result = Decoder[Short].apply(json.hcursor)
+  property("Decoder[Long] should fail on out-of-range values (#83)") {
+    forAll { (i: BigInt) =>
+      val json = Json.fromBigDecimal(BigDecimal(i))
+      val result = Decoder[Long].apply(json.hcursor)
 
-    assert(if (l.toShort.toLong == l) result === Right(l.toShort) else result.isLeft)
+      if (BigInt(i.toLong) == i) assertEquals(result, Right(i.toLong)) else assert(result.isLeft)
+    }
   }
 
-  it should "fail on non-whole values (#83)" in forAll { (d: Double) =>
-    val json = Json.fromDoubleOrNull(d)
-    val result = Decoder[Short].apply(json.hcursor)
+  property("Decoder[Long] should fail on non-whole values (#83)") {
+    forAll { (d: Double) =>
+      val json = Json.fromDoubleOrNull(d)
+      val result = Decoder[Long].apply(json.hcursor)
 
-    assert(d.isWhole || result.isLeft)
+      assert(d.isWhole || result.isLeft)
+    }
   }
 
-  it should "succeed on whole decimal values (#83)" in forAll { (v: Short, n: Byte) =>
-    val zeros = "0" * (math.abs(n.toInt) + 1)
-    val Right(json) = parse(s"$v.$zeros")
+  group("Decoder[Float]") {
+    property("should attempt to parse string values as doubles (#173)") {
+      forAll { (d: Float) =>
+        val Right(json) = parse("\"" + d.toString + "\"")
 
-    assert(Decoder[Short].apply(json.hcursor) === Right(v))
+        assertEquals(Decoder[Float].apply(json.hcursor), Right(d))
+      }
+    }
+
+    property("match the rounding of Float.parseFloat (#1063)") {
+      forAll { (d: Double) =>
+        val Right(json) = parse(d.toString)
+
+        assertEquals(Decoder[Float].apply(json.hcursor), Right(java.lang.Float.parseFloat(d.toString)))
+      }
+    }
+
+    test(" should match the rounding of Float.parseFloat for known problematic inputs (#1063)") {
+      val bad1 = "1.199999988079071"
+      val bad2 = "7.038531E-26"
+
+      val Right(json1) = parse(bad1)
+      val Right(json2) = parse(bad2)
+
+      assertEquals(Decoder[Float].apply(json1.hcursor), Right(java.lang.Float.parseFloat(bad1)))
+      assertEquals(Decoder[Float].apply(json2.hcursor), Right(java.lang.Float.parseFloat(bad2)))
+    }
   }
 
-  "Decoder[Int]" should "fail on out-of-range values (#83)" in forAll { (l: Long) =>
-    val json = Json.fromLong(l)
-    val result = Decoder[Int].apply(json.hcursor)
+  property("Decoder[Double] should attempt to parse string values as doubles (#173)") {
+    forAll { (d: Double) =>
+      val Right(json) = parse("\"" + d.toString + "\"")
 
-    assert(if (l.toInt.toLong == l) result === Right(l.toInt) else result.isLeft)
+      assertEquals(Decoder[Double].apply(json.hcursor), Right(d))
+    }
   }
 
-  it should "fail on non-whole values (#83)" in forAll { (d: Double) =>
-    val json = Json.fromDoubleOrNull(d)
-    val result = Decoder[Int].apply(json.hcursor)
-
-    assert(d.isWhole || result.isLeft)
-  }
-
-  it should "succeed on whole decimal values (#83)" in forAll { (v: Int, n: Byte) =>
-    val zeros = "0" * (math.abs(n.toInt) + 1)
-    val Right(json) = parse(s"$v.$zeros")
-
-    assert(Decoder[Int].apply(json.hcursor) === Right(v))
-  }
-
-  "Decoder[Long]" should "fail on out-of-range values (#83)" in forAll { (i: BigInt) =>
-    val json = Json.fromBigDecimal(BigDecimal(i))
-    val result = Decoder[Long].apply(json.hcursor)
-
-    assert(if (BigInt(i.toLong) == i) result === Right(i.toLong) else result.isLeft)
-  }
-
-  it should "fail on non-whole values (#83)" in forAll { (d: Double) =>
-    val json = Json.fromDoubleOrNull(d)
-    val result = Decoder[Long].apply(json.hcursor)
-
-    assert(d.isWhole || result.isLeft)
-  }
-
-  "Decoder[Float]" should "attempt to parse string values as doubles (#173)" in forAll { (d: Float) =>
-    val Right(json) = parse("\"" + d.toString + "\"")
-
-    assert(Decoder[Float].apply(json.hcursor) === Right(d))
-  }
-
-  it should "match the rounding of Float.parseFloat (#1063)" in forAll { (d: Double) =>
-    val Right(json) = parse(d.toString)
-
-    assert(Decoder[Float].apply(json.hcursor) === Right(java.lang.Float.parseFloat(d.toString)))
-  }
-
-  it should "match the rounding of Float.parseFloat for known problematic inputs (#1063)" in {
-    val bad1 = "1.199999988079071"
-    val bad2 = "7.038531E-26"
-
-    val Right(json1) = parse(bad1)
-    val Right(json2) = parse(bad2)
-
-    assert(Decoder[Float].apply(json1.hcursor) === Right(java.lang.Float.parseFloat(bad1)))
-    assert(Decoder[Float].apply(json2.hcursor) === Right(java.lang.Float.parseFloat(bad2)))
-  }
-
-  "Decoder[Double]" should "attempt to parse string values as doubles (#173)" in forAll { (d: Double) =>
-    val Right(json) = parse("\"" + d.toString + "\"")
-
-    assert(Decoder[Double].apply(json.hcursor) === Right(d))
-  }
-
-  "Decoder[BigInt]" should "fail when producing a value would be intractable" in {
+  test("Decoder[BigInt] should fail when producing a value would be intractable") {
     val Right(bigNumber) = parse("1e2147483647")
 
     assert(Decoder[BigInt].apply(bigNumber.hcursor).isLeft)
@@ -359,290 +407,321 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
   val isPositive: Int => Boolean = _ > 0
   val isOdd: Int => Boolean = _ % 2 != 0
 
-  "ensure" should "fail appropriately on an invalid result" in forAll { (i: Int) =>
-    val message = "Not positive!"
+  group("ensure should") {
 
-    val decodePositiveInt: Decoder[Int] = Decoder[Int].ensure(_ > 0, message)
-    val expected = if (i > 0) Right(i) else Left(DecodingFailure(message, Nil))
+    property("fail appropriately on an invalid result") {
+      forAll { (i: Int) =>
+        val message = "Not positive!"
 
-    assert(decodePositiveInt.decodeJson(Json.fromInt(i)) === expected)
-  }
+        val decodePositiveInt: Decoder[Int] = Decoder[Int].ensure(_ > 0, message)
+        val expected = if (i > 0) Right(i) else Left(DecodingFailure(message, Nil))
 
-  it should "only include the first failure when chained, even in error-accumulation mode" in forAll { (i: Int) =>
-    val positiveMessage = "Not positive!"
-    val oddMessage = "Not odd!"
-
-    val badDecodePositiveOddInt: Decoder[Int] =
-      Decoder[Int].ensure(isPositive, positiveMessage).ensure(isOdd, oddMessage)
-
-    val expected = if (isPositive(i)) {
-      if (isOdd(i)) {
-        Validated.valid(i)
-      } else {
-        Validated.invalidNel(DecodingFailure(oddMessage, Nil))
-      }
-    } else {
-      Validated.invalidNel(DecodingFailure(positiveMessage, Nil))
-    }
-
-    assert(badDecodePositiveOddInt.decodeAccumulating(Json.fromInt(i).hcursor) === expected)
-  }
-
-  it should "not include failures it hasn't checked for" in {
-    val decodePositiveInt: Decoder[Int] =
-      Decoder[Int].ensure(isPositive, "Not positive!")
-
-    val expected = Validated.invalidNel(DecodingFailure("Int", Nil))
-
-    assert(decodePositiveInt.decodeAccumulating(Json.Null.hcursor) === expected)
-  }
-
-  it should "include all given failures in error-accumulation mode" in forAll { (i: Int) =>
-    val positiveMessage = "Not positive!"
-    val oddMessage = "Not odd!"
-
-    val decodePositiveOddInt: Decoder[Int] =
-      Decoder[Int].ensure(i =>
-        (if (isPositive(i)) Nil else List(positiveMessage)) ++
-          (if (isOdd(i)) Nil else List(oddMessage))
-      )
-
-    val expected = if (isPositive(i)) {
-      if (isOdd(i)) {
-        Validated.valid(i)
-      } else {
-        Validated.invalidNel(DecodingFailure(oddMessage, Nil))
-      }
-    } else {
-      if (isOdd(i)) {
-        Validated.invalidNel(DecodingFailure(positiveMessage, Nil))
-      } else {
-        Validated.invalid(NonEmptyList.of(DecodingFailure(positiveMessage, Nil), DecodingFailure(oddMessage, Nil)))
+        assertEquals(decodePositiveInt.decodeJson(Json.fromInt(i)), expected)
       }
     }
 
-    assert(decodePositiveOddInt.decodeAccumulating(Json.fromInt(i).hcursor) === expected)
-  }
+    property("only include the first failure when chained, even in error-accumulation mode") {
+      forAll { (i: Int) =>
+        val positiveMessage = "Not positive!"
+        val oddMessage = "Not odd!"
 
-  "validate" should "fail appropriately on invalid input in fail-fast mode" in forAll { (i: Int) =>
-    val message = "Not positive!"
+        val badDecodePositiveOddInt: Decoder[Int] =
+          Decoder[Int].ensure(isPositive, positiveMessage).ensure(isOdd, oddMessage)
 
-    val decodePositiveInt: Decoder[Int] =
-      Decoder[Int].validate(_.as[Int].exists(_ > 0), message)
+        val expected = if (isPositive(i)) {
+          if (isOdd(i)) {
+            Validated.valid(i)
+          } else {
+            Validated.invalidNel(DecodingFailure(oddMessage, Nil))
+          }
+        } else {
+          Validated.invalidNel(DecodingFailure(positiveMessage, Nil))
+        }
 
-    val expected = if (i > 0) Right(i) else Left(DecodingFailure(message, Nil))
-
-    assert(decodePositiveInt.decodeJson(Json.fromInt(i)) === expected)
-  }
-
-  it should "fail appropriately on invalid input in error-accumulation mode (#865)" in forAll { (i: Int) =>
-    val message = "Not positive!"
-
-    val decodePositiveInt: Decoder[Int] =
-      Decoder[Int].validate(_.as[Int].exists(_ > 0), message)
-
-    val expected = if (i > 0) Validated.valid(i) else Validated.invalidNel(DecodingFailure(message, Nil))
-
-    assert(decodePositiveInt.decodeAccumulating(Json.fromInt(i).hcursor) === expected)
-  }
-
-  it should "not infinitely recurse (#396)" in forAll { (i: Int) =>
-    assert(Decoder[Int].validate(_ => true, "whatever").apply(Json.fromInt(i).hcursor) === Right(i))
-  }
-
-  it should "preserve error accumulation when validation succeeds" in {
-    val message = "This shouldn't work"
-
-    trait Foo
-
-    val decoder: Decoder[Foo] = new Decoder[Foo] {
-      override def apply(c: HCursor): Decoder.Result[Foo] = Right(new Foo {})
-
-      override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[Foo] = Invalid(
-        NonEmptyList.one(DecodingFailure(message, c.history))
-      )
+        assertEquals(badDecodePositiveOddInt.decodeAccumulating(Json.fromInt(i).hcursor), expected)
+      }
     }
 
-    val validatingDecoder = decoder.validate(c => true, "Foobar")
+    test("not include failures it hasn't checked for") {
+      val decodePositiveInt: Decoder[Int] = Decoder[Int].ensure(isPositive, "Not positive!")
 
-    assert(validatingDecoder.decodeAccumulating(Json.True.hcursor).isInvalid)
-  }
+      val expected = Validated.invalidNel(DecodingFailure("Int", Nil))
 
-  it should "provide the generated error messages from HCursor when a function is passed" in {
-    case class Foo(x: Int, y: String)
-
-    val decoder: Decoder[Foo] = Decoder.const(Foo(42, "meaning")).validate { c =>
-      val maybeFieldsStr = for {
-        json <- c.focus
-        jsonKeys <- json.hcursor.keys
-      } yield jsonKeys.mkString(",")
-      maybeFieldsStr.getOrElse("") :: Nil
+      assertEquals(decodePositiveInt.decodeAccumulating(Json.Null.hcursor), expected)
     }
 
-    val Right(fooJson) = parse("""{"x":42, "y": "meaning"}""")
+    property("include all given failures in error-accumulation mode") {
+      forAll { (i: Int) =>
+        val positiveMessage = "Not positive!"
+        val oddMessage = "Not odd!"
 
-    assert(decoder.decodeJson(fooJson).swap.exists(_.message === "x,y"))
+        val decodePositiveOddInt: Decoder[Int] =
+          Decoder[Int].ensure(i =>
+            (if (isPositive(i)) Nil else List(positiveMessage)) ++
+              (if (isOdd(i)) Nil else List(oddMessage))
+          )
+
+        val expected = if (isPositive(i)) {
+          if (isOdd(i)) {
+            Validated.valid(i)
+          } else {
+            Validated.invalidNel(DecodingFailure(oddMessage, Nil))
+          }
+        } else {
+          if (isOdd(i)) {
+            Validated.invalidNel(DecodingFailure(positiveMessage, Nil))
+          } else {
+            Validated.invalid(NonEmptyList.of(DecodingFailure(positiveMessage, Nil), DecodingFailure(oddMessage, Nil)))
+          }
+        }
+
+        assertEquals(decodePositiveOddInt.decodeAccumulating(Json.fromInt(i).hcursor), expected)
+      }
+    }
   }
 
-  it should "not fail when the passed errors function returns an empty list" in {
-    val testValue = 42
-    val decoder = Decoder[Int].validate(_ => Nil)
+  group("validate should") {
+    property("validate should fail appropriately on invalid input in fail-fast mode") {
+      forAll { (i: Int) =>
+        val message = "Not positive!"
+        val decodePositiveInt: Decoder[Int] = Decoder[Int].validate(_.as[Int].exists(_ > 0), message)
+        val expected = if (i > 0) Right(i) else Left(DecodingFailure(message, Nil))
 
-    val Right(intJson) = parse(testValue.toString)
-
-    assert(decoder.decodeJson(intJson) === Right(testValue))
-  }
-
-  "either" should "return the correct disjunct" in forAll { (value: Either[String, Boolean]) =>
-    val json = value match {
-      case Left(s)  => Json.fromString(s)
-      case Right(b) => Json.fromBoolean(b)
+        assertEquals(decodePositiveInt.decodeJson(Json.fromInt(i)), expected)
+      }
     }
 
-    assert(Decoder[String].either(Decoder[Boolean]).decodeJson(json) === Right(value))
+    property("fail appropriately on invalid input in error-accumulation mode (#865)") {
+      forAll { (i: Int) =>
+        val message = "Not positive!"
+
+        val decodePositiveInt: Decoder[Int] = Decoder[Int].validate(_.as[Int].exists(_ > 0), message)
+
+        val expected = if (i > 0) Validated.valid(i) else Validated.invalidNel(DecodingFailure(message, Nil))
+
+        assertEquals(decodePositiveInt.decodeAccumulating(Json.fromInt(i).hcursor), expected)
+      }
+    }
+
+    property("not infinitely recurse (#396)") {
+      forAll { (i: Int) =>
+        assertEquals(Decoder[Int].validate(_ => true, "whatever").apply(Json.fromInt(i).hcursor), Right(i))
+      }
+    }
+
+    test("preserve error accumulation when validation succeeds") {
+      val message = "This shouldn't work"
+
+      trait Foo
+
+      val decoder: Decoder[Foo] = new Decoder[Foo] {
+        override def apply(c: HCursor): Decoder.Result[Foo] = Right(new Foo {})
+
+        override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[Foo] = Invalid(
+          NonEmptyList.one(DecodingFailure(message, c.history))
+        )
+      }
+
+      val validatingDecoder = decoder.validate(c => true, "Foobar")
+
+      assert(validatingDecoder.decodeAccumulating(Json.True.hcursor).isInvalid)
+    }
+
+    test("provide the generated error messages from HCursor when a function is passed") {
+      case class Foo(x: Int, y: String)
+
+      val decoder: Decoder[Foo] = Decoder.const(Foo(42, "meaning")).validate { c =>
+        val maybeFieldsStr = for {
+          json <- c.focus
+          jsonKeys <- json.hcursor.keys
+        } yield jsonKeys.mkString(",")
+        maybeFieldsStr.getOrElse("") :: Nil
+      }
+
+      val Right(fooJson) = parse("""{"x":42, "y": "meaning"}""")
+
+      assert(decoder.decodeJson(fooJson).swap.exists(_.message === "x,y"))
+    }
+
+    test("not fail when the passed errors function returns an empty list") {
+      val testValue = 42
+      val decoder = Decoder[Int].validate(_ => Nil)
+
+      val Right(intJson) = parse(testValue.toString)
+
+      assertEquals(decoder.decodeJson(intJson), Right(testValue))
+    }
+
   }
 
-  it should "respect the underlying decoder's tryDecode (#1271)" in {
+  property("either should return the correct disjunct") {
+    forAll { (value: Either[String, Boolean]) =>
+      val json = value match {
+        case Left(s)  => Json.fromString(s)
+        case Right(b) => Json.fromBoolean(b)
+      }
+
+      assertEquals(Decoder[String].either(Decoder[Boolean]).decodeJson(json), Right(value))
+    }
+  }
+
+  test("either should respect the underlying decoder's tryDecode (#1271)") {
     val decoder: Decoder[Either[Option[String], Boolean]] =
       Decoder.decodeOption[String].either(Decoder.const(true)).at("a")
 
-    assert(decoder.decodeJson(Json.obj("a" := 1)) === Right(Right(true)))
-    assert(decoder.decodeJson(Json.obj("a" := Json.Null)) === Right(Left(None)))
-    assert(decoder.decodeJson(Json.obj("b" := "abc")) === Right(Left(None)))
-    assert(decoder.decodeJson(Json.obj("a" := "abc")) === Right(Left(Some("abc"))))
+    assertEquals(decoder.decodeJson(Json.obj("a" := 1)), Right(Right(true)))
+    assertEquals(decoder.decodeJson(Json.obj("a" := Json.Null)), Right(Left(None)))
+    assertEquals(decoder.decodeJson(Json.obj("b" := "abc")), Right(Left(None)))
+    assertEquals(decoder.decodeJson(Json.obj("a" := "abc")), Right(Left(Some("abc"))))
 
-    assert(decoder.decodeAccumulating(Json.obj("a" := 1).hcursor) === Validated.valid(Right(true)))
-    assert(decoder.decodeAccumulating(Json.obj("a" := Json.Null).hcursor) === Validated.valid(Left(None)))
-    assert(decoder.decodeAccumulating(Json.obj("b" := "abc").hcursor) === Validated.valid(Left(None)))
-    assert(decoder.decodeAccumulating(Json.obj("a" := "abc").hcursor) === Validated.valid(Left(Some("abc"))))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := 1).hcursor), Validated.valid(Right(true)))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := Json.Null).hcursor), Validated.valid(Left(None)))
+    assertEquals(decoder.decodeAccumulating(Json.obj("b" := "abc").hcursor), Validated.valid(Left(None)))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := "abc").hcursor), Validated.valid(Left(Some("abc"))))
   }
 
-  "or" should "respect the underlying decoder's tryDecode (#1271)" in {
+  test("or should respect the underlying decoder's tryDecode (#1271)") {
     val decoder: Decoder[Option[String]] =
       Decoder.decodeOption[String].or(Decoder.const(Option.empty[String])).at("a")
 
-    assert(decoder.decodeJson(Json.obj("a" := 1)) === Right(None))
-    assert(decoder.decodeJson(Json.obj("a" := Json.Null)) === Right(None))
-    assert(decoder.decodeJson(Json.obj("b" := "abc")) === Right(None))
-    assert(decoder.decodeJson(Json.obj("a" := "abc")) === Right(Some("abc")))
+    assertEquals(decoder.decodeJson(Json.obj("a" := 1)), Right(None))
+    assertEquals(decoder.decodeJson(Json.obj("a" := Json.Null)), Right(None))
+    assertEquals(decoder.decodeJson(Json.obj("b" := "abc")), Right(None))
+    assertEquals(decoder.decodeJson(Json.obj("a" := "abc")), Right(Some("abc")))
 
-    assert(decoder.decodeAccumulating(Json.obj("a" := 1).hcursor) === Validated.valid(None))
-    assert(decoder.decodeAccumulating(Json.obj("a" := Json.Null).hcursor) === Validated.valid(None))
-    assert(decoder.decodeAccumulating(Json.obj("b" := "abc").hcursor) === Validated.valid(None))
-    assert(decoder.decodeAccumulating(Json.obj("a" := "abc").hcursor) === Validated.valid(Some("abc")))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := 1).hcursor), Validated.valid(None))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := Json.Null).hcursor), Validated.valid(None))
+    assertEquals(decoder.decodeAccumulating(Json.obj("b" := "abc").hcursor), Validated.valid(None))
+    assertEquals(decoder.decodeAccumulating(Json.obj("a" := "abc").hcursor), Validated.valid(Some("abc")))
   }
 
-  private[this] val stateful = {
-    import Decoder.state._
-    Decoder.fromState(for {
-      a <- decodeField[String]("a")
-      b <- decodeField[String]("b")
-      _ <- requireEmpty
-    } yield a ++ b)
-  }
-
-  "a stateful Decoder with requireEmpty" should "succeed when there are no leftover fields" in {
-    val json = Json.obj("a" -> "1".asJson, "b" -> "2".asJson)
-
-    assert(stateful.decodeJson(json) === Right("12"))
-  }
-
-  it should "fail when there are leftover fields" in {
-    val json = Json.obj("a" -> "1".asJson, "b" -> "2".asJson, "c" -> "3".asJson, "d" -> "4".asJson)
-
-    assert(stateful.decodeJson(json).swap.exists(_.message === "Leftover keys: c, d"))
-  }
-
-  it should "fail normally when a field is missing" in {
-    val json = Json.obj("a" -> "1".asJson)
-
-    assert(stateful.decodeJson(json).swap.exists(_.message === "Attempt to decode value on failed cursor"))
-  }
-
-  private[this] val statefulOpt = {
-    import Decoder.state._
-    Decoder.fromState(for {
-      a <- decodeField[Option[String]]("a")
-      b <- decodeField[String]("b")
-      _ <- requireEmpty
-    } yield a.foldMap(identity) ++ b)
-  }
-
-  "a stateful Decoder with requireEmpty and an optional value" should
-    "succeed when there are no leftover fields and an optional field is missing" in {
-      val json = Json.obj("b" -> "2".asJson)
-
-      assert(statefulOpt.decodeJson(json) === Right("2"))
+  group("a stateful Decoder with requireEmpty should ") {
+    val stateful = {
+      import Decoder.state._
+      Decoder.fromState(for {
+        a <- decodeField[String]("a")
+        b <- decodeField[String]("b")
+        _ <- requireEmpty
+      } yield a ++ b)
     }
 
-  it should "succeed when there are no leftover fields and an optional field is present" in {
-    val json = Json.obj("a" -> "1".asJson, "b" -> "2".asJson)
+    test("succeed when there are no leftover fields") {
+      val json = Json.obj("a" -> "1".asJson, "b" -> "2".asJson)
 
-    assert(statefulOpt.decodeJson(json) === Right("12"))
+      assertEquals(stateful.decodeJson(json), Right("12"))
+    }
+
+    test("fail when there are leftover fields") {
+      val json = Json.obj("a" -> "1".asJson, "b" -> "2".asJson, "c" -> "3".asJson, "d" -> "4".asJson)
+
+      assert(stateful.decodeJson(json).swap.exists(_.message === "Leftover keys: c, d"))
+    }
+
+    test("fail normally when a field is missing") {
+      val json = Json.obj("a" -> "1".asJson)
+
+      assert(stateful.decodeJson(json).swap.exists(_.message === "Attempt to decode value on failed cursor"))
+    }
   }
 
-  it should "fail when there are leftover fields and an optional field is missing" in {
-    val json = Json.obj("b" -> "2".asJson, "c" -> "3".asJson, "d" -> "4".asJson)
+  group("a stateful Decoder with requireEmpty and an optional value should") {
 
-    assert(statefulOpt.decodeJson(json).swap.exists(_.message === "Leftover keys: c, d"))
-  }
+    val statefulOpt = {
+      import Decoder.state._
+      Decoder.fromState(for {
+        a <- decodeField[Option[String]]("a")
+        b <- decodeField[String]("b")
+        _ <- requireEmpty
+      } yield a.foldMap(identity) ++ b)
+    }
 
-  it should "fail when there are leftover fields and an optional field is present" in {
-    val json = Json.obj("a" -> "1".asJson, "b" -> "2".asJson, "c" -> "3".asJson, "d" -> "4".asJson)
+    test("succeed when there are no leftover fields and an optional field is missing") {
+      val json = Json.obj("b" -> "2".asJson)
 
-    assert(statefulOpt.decodeJson(json).swap.exists(_.message === "Leftover keys: c, d"))
-  }
+      assertEquals(statefulOpt.decodeJson(json), Right("2"))
+    }
 
-  it should "fail normally when a field is missing and an optional field is present" in {
-    val json = Json.obj("a" -> "1".asJson)
+    test("succeed when there are no leftover fields and an optional field is present") {
+      val json = Json.obj("a" -> "1".asJson, "b" -> "2".asJson)
+      assertEquals(statefulOpt.decodeJson(json), Right("12"))
+    }
 
-    assert(statefulOpt.decodeJson(json).swap.exists(_.message === "Attempt to decode value on failed cursor"))
-  }
+    test("fail when there are leftover fields and an optional field is missing") {
+      val json = Json.obj("b" -> "2".asJson, "c" -> "3".asJson, "d" -> "4".asJson)
 
-  it should "fail normally when a field is missing and an optional field is missing" in {
-    val json = Json.obj()
+      assert(statefulOpt.decodeJson(json).swap.exists(_.message === "Leftover keys: c, d"))
+    }
 
-    assert(statefulOpt.decodeJson(json).swap.exists(_.message === "Attempt to decode value on failed cursor"))
+    test("fail when there are leftover fields and an optional field is present") {
+      val json = Json.obj("a" -> "1".asJson, "b" -> "2".asJson, "c" -> "3".asJson, "d" -> "4".asJson)
+
+      assert(statefulOpt.decodeJson(json).swap.exists(_.message === "Leftover keys: c, d"))
+    }
+
+    test("fail normally when a field is missing and an optional field is present") {
+      val json = Json.obj("a" -> "1".asJson)
+
+      assert(statefulOpt.decodeJson(json).swap.exists(_.message === "Attempt to decode value on failed cursor"))
+    }
+
+    test("fail normally when a field is missing and an optional field is missing") {
+      val json = Json.obj()
+
+      assert(statefulOpt.decodeJson(json).swap.exists(_.message === "Attempt to decode value on failed cursor"))
+    }
   }
 
   checkAll("Codec[WrappedOptionalField]", CodecTests[WrappedOptionalField].codec)
 
-  "decodeSet" should "match sequence decoders" in forAll { (xs: List[Int]) =>
-    assert(Decoder.decodeSet[Int].decodeJson(xs.asJson) === Decoder[Seq[Int]].map(_.toSet).decodeJson(xs.asJson))
+  property("decodeSet should match sequence decoders") {
+    forAll { (xs: List[Int]) =>
+      val sequence = Decoder[Seq[Int]].map(_.toSet).decodeJson(xs.asJson)
+      assertEquals(Decoder.decodeSet[Int].decodeJson(xs.asJson), sequence)
+    }
   }
 
-  "decodeList" should "match sequence decoders" in forAll { (xs: List[Int]) =>
-    assert(Decoder.decodeList[Int].decodeJson(xs.asJson) === Decoder[Seq[Int]].map(_.toList).decodeJson(xs.asJson))
+  property("decodeList should match sequence decoders") {
+    forAll { (xs: List[Int]) =>
+      val sequence = Decoder[Seq[Int]].map(_.toList).decodeJson(xs.asJson)
+      assertEquals(Decoder.decodeList[Int].decodeJson(xs.asJson), sequence)
+    }
   }
 
-  "decodeVector" should "match sequence decoders" in forAll { (xs: List[Int]) =>
-    assert(Decoder.decodeVector[Int].decodeJson(xs.asJson) === Decoder[Seq[Int]].map(_.toVector).decodeJson(xs.asJson))
+  property("decodeVector should match sequence decoders") {
+    forAll { (xs: List[Int]) =>
+      val sequence = Decoder[Seq[Int]].map(_.toVector).decodeJson(xs.asJson)
+      assertEquals(Decoder.decodeVector[Int].decodeJson(xs.asJson), sequence)
+    }
   }
 
-  "decodeChain" should "match sequence decoders" in forAll { (xs: List[Int]) =>
-    assert(
-      Decoder.decodeChain[Int].decodeJson(xs.asJson) === Decoder[Seq[Int]].map(Chain.fromSeq(_)).decodeJson(xs.asJson)
-    )
+  property("decodeChain should match sequence decoders") {
+    forAll { (xs: List[Int]) =>
+      val sequence = Decoder[Seq[Int]].map(Chain.fromSeq(_)).decodeJson(xs.asJson)
+      val chainDec = Decoder.decodeChain[Int].decodeJson(xs.asJson)
+      assertEquals(sequence, chainDec)
+    }
   }
 
-  "HCursor#history" should "be stack safe" in {
+  test("HCursor#history should be stack safe") {
     val size = 10000
     val json = List.fill(size)(1).asJson.mapArray(_ :+ true.asJson)
     val Left(DecodingFailure(_, history)) = Decoder[List[Int]].decodeJson(json)
 
-    assert(history.size === size + 1)
+    assertEquals(history.size, size + 1)
   }
 
   case class NotDecodable(a: Int)
   implicit val decodeNotDecodable: Decoder[NotDecodable] = Decoder.failedWithMessage("Some message")
 
-  "container decoder" should "pass through error message from item" in forAll(containerDecoders[NotDecodable]) {
-    decoder =>
+  property("container decoder should pass through error message from item") {
+    containerDecoders[NotDecodable].foreach { decoder =>
       val json = Json.arr(Json.obj("a" -> 1.asJson))
-      assert(decoder.decodeJson(json) == Left(DecodingFailure("Some message", List(DownArray))))
+      val failure = DecodingFailure("Some message", List(DownArray))
+      assertEquals(decoder.decodeJson(json), Left(failure))
+    }
   }
 
-  "decodeAccumulating" should "accumulate errors after traversal" in {
+  test("decodeAccumulating should accumulate errors after traversal") {
     import cats.syntax.functor._
     import cats.syntax.traverse._
 
@@ -654,6 +733,6 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests with TableDri
     val result = decoder.decodeAccumulating(Json.fromInt(-2).hcursor)
 
     assert(result.isInvalid)
-    assert(result.swap.toOption.map(_.size) === Some(2))
+    assertEquals(result.swap.toOption.map(_.size), Some(2))
   }
 }


### PR DESCRIPTION
Add duplicated traits for `LargeNumberDecoderTests`, temporary
while we migrate the rest of existing tests until a next PR.