### PR TITLE
Update shapeless to 2.3.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ val compilerOptions = Seq(
 
 val catsVersion = "2.6.1"
 val jawnVersion = "1.1.2"
-val shapelessVersion = "2.3.3"
+val shapelessVersion = "2.3.6"
 val refinedVersion = "0.9.25"
 
 val paradiseVersion = "2.1.1"


### PR DESCRIPTION
See #1750. 2.3.6 is binary compatible with 2.3.3.