### PR TITLE
Update shapeless to 2.3.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ val compilerOptions = Seq(
 
 val catsVersion = "2.6.1"
 val jawnVersion = "1.1.2"
-val shapelessVersion = "2.3.3"
+val shapelessVersion = "2.3.6"
 val refinedVersion = "0.9.25"
 
 val paradiseVersion = "2.1.1"


### PR DESCRIPTION
Before:
```
andriy@notebook:~/Projects/com/github/plokhotnyuk/circe$ sbt dependencyTree | grep shapeless
[info]   +-com.chuusai:shapeless_sjs1_2.13:2.3.3 [S]
[info]   +-com.chuusai:shapeless_2.13:2.3.3 [S]
[info]   | +-com.chuusai:shapeless_sjs1_2.13:2.3.6 [S]
[info]   +-com.chuusai:shapeless_sjs1_2.13:2.3.3 [S]
[info]   +-com.chuusai:shapeless_sjs1_2.13:2.3.3 [S]
[info]   +-com.chuusai:shapeless_2.13:2.3.3 [S]
[info]   | +-com.chuusai:shapeless_2.13:2.3.6 [S]
[info]   | +-com.chuusai:shapeless_2.13:2.3.3 [S]
[info]   | +-com.chuusai:shapeless_sjs1_2.13:2.3.3 [S]
[info]   +-com.chuusai:shapeless_2.13:2.3.3 [S]
[info]   | +-com.chuusai:shapeless_2.13:2.3.3 [S]
[info]   | +-com.chuusai:shapeless_2.13:2.3.3 [S]
```
After:
```
andriy@notebook:~/Projects/com/github/plokhotnyuk/circe$ sbt dependencyTree | grep shapeless
[info]   +-com.chuusai:shapeless_2.13:2.3.6 [S]
[info]   +-com.chuusai:shapeless_2.13:2.3.6 [S]
[info]   | +-com.chuusai:shapeless_2.13:2.3.6 [S]
[info]   +-com.chuusai:shapeless_sjs1_2.13:2.3.6 [S]
[info]   +-com.chuusai:shapeless_2.13:2.3.6 [S]
[info]   | +-com.chuusai:shapeless_sjs1_2.13:2.3.6 [S]
[info]   +-com.chuusai:shapeless_sjs1_2.13:2.3.6 [S]
[info]   | +-com.chuusai:shapeless_2.13:2.3.6 [S]
[info]   +-com.chuusai:shapeless_sjs1_2.13:2.3.6 [S]
[info]   | +-com.chuusai:shapeless_2.13:2.3.6 [S]
[info]   | +-com.chuusai:shapeless_2.13:2.3.6 [S]
[info]   | +-com.chuusai:shapeless_sjs1_2.13:2.3.6 [S]
```
Also, it solves [compilation errors due to binary incompatibilities](https://github.com/plokhotnyuk/jsoniter-scala/runs/2625742357#step:7:3284) when other dependencies have 2.3.6 version