### PR TITLE
Fix shapeless dependency in shapes module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -419,7 +419,7 @@ lazy val genericSimpleJS = genericSimpleBase.js
 lazy val shapesBase = circeCrossModule("shapes", mima = previousCirceVersion, CrossType.Pure)
   .settings(macroSettings)
   .settings(
-    libraryDependencies += "com.chuusai" %%% "shapeless" % shapelessVersion,
+    libraryDependencies += ("com.chuusai" %%% "shapeless" % shapelessVersion).cross(CrossVersion.for3Use2_13),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.AllLibraryJars
   )
   .jsSettings(


### PR DESCRIPTION
Running `sbt ++3.0.0 shapesJVM/update` currently fails because sbt tries
to resolve an artifact with the name `shapeless_3` but shapeless 2.3.7
does not exists for Scala 3:
```
sbt:circe> ++3.0.0 shapesJVM/update
[info] Setting Scala version to 3.0.0 on 37 projects.
[info] Excluded 2 projects, run ++ 3.0.0 -v for more details.
[info] Reapplying settings...
[info] set current project to circe (in build file:~/data/code/circe/circe/)
[info] Updating
...
[info] Resolved  dependencies
[info] Fetching artifacts of
[info] Fetched artifacts of
[info] Updating
[info] Resolved  dependencies
[warn]
[warn] 	Note: Unresolved dependencies path:
[error] stack trace is suppressed; run last shapesJVM / update for the full output
[error] (shapesJVM / update) sbt.librarymanagement.ResolveException: Error downloading com.chuusai:shapeless_3:2.3.7
[error]   Not found
[error]   Not found
[error]   not found: ~/.ivy2/local/com.chuusai/shapeless_3/2.3.7/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/com/chuusai/shapeless_3/2.3.7/shapeless_3-2.3.7.pom
[error]   not found: https://oss.sonatype.org/content/repositories/releases/com/chuusai/shapeless_3/2.3.7/shapeless_3-2.3.7.pom
[error]   not found: https://oss.sonatype.org/content/repositories/snapshots/com/chuusai/shapeless_3/2.3.7/shapeless_3-2.3.7.pom
```

Adding `.cross(CrossVersion.for3Use2_13)` to the shapeless dependency
definition in the shapes module fixes this problem:
```
sbt:circe> ++3.0.0 shapesJVM/update
[info] Setting Scala version to 3.0.0 on 37 projects.
[info] Excluded 2 projects, run ++ 3.0.0 -v for more details.
[info] Reapplying settings...
[info] set current project to circe (in build file:~/data/code/circe/circe/)
[success] Total time: 0 s, completed May 26, 2021 9:12:27 PM
```

This is most likely the reason why Scala Steward didn't update shapeless
in this repo recently.