### PR TITLE
Add Encoder and Decoder for java.net.URI

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -19,6 +19,7 @@ import cats.instances.either.{ catsStdInstancesForEither, catsStdSemigroupKForEi
 import cats.kernel.Order
 import io.circe.`export`.Exported
 import java.io.Serializable
+import java.net.URI
 import java.time.{
   DateTimeException,
   Duration,
@@ -923,6 +924,22 @@ object Decoder
         catch {
           case _: IllegalArgumentException =>
             Left(DecodingFailure("Couldn't decode a valid UUID", c.history))
+        }
+      case json => Left(DecodingFailure(WrongTypeExpectation("string", json), c.history))
+    }
+  }
+
+  /**
+   * @group Decoding
+   */
+  implicit final lazy val decodeURI: Decoder[URI] = new Decoder[URI] {
+
+    final def apply(c: HCursor): Result[URI] = c.value match {
+      case Json.JString(string) =>
+        try Right(URI.create(string))
+        catch {
+          case _: IllegalArgumentException =>
+            Left(DecodingFailure("Couldn't decode a valid URI", c.history))
         }
       case json => Left(DecodingFailure(WrongTypeExpectation("string", json), c.history))
     }

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -19,7 +19,7 @@ import cats.instances.either.{ catsStdInstancesForEither, catsStdSemigroupKForEi
 import cats.kernel.Order
 import io.circe.`export`.Exported
 import java.io.Serializable
-import java.net.URI
+import java.net.{ URI, URISyntaxException }
 import java.time.{
   DateTimeException,
   Duration,
@@ -936,10 +936,12 @@ object Decoder
 
     final def apply(c: HCursor): Result[URI] = c.value match {
       case Json.JString(string) =>
-        try Right(URI.create(string))
+        try Right(new URI(string))
         catch {
-          case _: IllegalArgumentException =>
-            Left(DecodingFailure("Couldn't decode a valid URI", c.history))
+          case _: URISyntaxException =>
+            Left(DecodingFailure("String could not be parsed as a URI reference, it violates RFC 2396.", c.history))
+          case _: NullPointerException =>
+            Left(DecodingFailure("String is null.", c.history))
         }
       case json => Left(DecodingFailure(WrongTypeExpectation("string", json), c.history))
     }

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -4,6 +4,7 @@ import cats.{ Contravariant, Foldable }
 import cats.data.{ Chain, NonEmptyChain, NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector, OneAnd, Validated }
 import io.circe.`export`.Exported
 import java.io.Serializable
+import java.net.URI
 import java.time.{
   Duration,
   Instant,
@@ -304,6 +305,13 @@ object Encoder
    */
   implicit final lazy val encodeUUID: Encoder[UUID] = new Encoder[UUID] {
     final def apply(a: UUID): Json = Json.fromString(a.toString)
+  }
+
+  /**
+   * @group Encoding
+   */
+  implicit final lazy val encodeURI: Encoder[URI] = new Encoder[URI] {
+    final def apply(a: URI): Json = Json.fromString(a.toString)
   }
 
   /**

--- a/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.MonadError
 import java.io.Serializable
+import java.net.URI
 import java.util.UUID
 import scala.annotation.tailrec
 
@@ -70,6 +71,14 @@ object KeyDecoder {
         case _: IllegalArgumentException => None
       }
     } else None
+  }
+
+  implicit val decodeKeyURI: KeyDecoder[URI] = new KeyDecoder[URI] {
+    final def apply(key: String): Option[URI] =
+      try Some(URI.create(key))
+      catch {
+        case _: IllegalArgumentException => None
+      }
   }
 
   implicit val decodeKeyByte: KeyDecoder[Byte] = numberInstance(java.lang.Byte.parseByte)

--- a/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
@@ -5,6 +5,7 @@ import java.io.Serializable
 import java.net.URI
 import java.util.UUID
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 
 /**
  * A type class that provides a conversion from a string used as a JSON key to a
@@ -75,9 +76,9 @@ object KeyDecoder {
 
   implicit val decodeKeyURI: KeyDecoder[URI] = new KeyDecoder[URI] {
     final def apply(key: String): Option[URI] =
-      try Some(URI.create(key))
+      try Some(new URI(key))
       catch {
-        case _: IllegalArgumentException => None
+        case NonFatal(_) => None
       }
   }
 

--- a/modules/core/shared/src/main/scala/io/circe/KeyEncoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyEncoder.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import cats.Contravariant
 import java.io.Serializable
+import java.net.URI
 import java.util.UUID
 
 /**
@@ -45,6 +46,10 @@ object KeyEncoder {
 
   implicit val encodeKeyUUID: KeyEncoder[UUID] = new KeyEncoder[UUID] {
     final def apply(key: UUID): String = key.toString
+  }
+
+  implicit val encodeKeyURI: KeyEncoder[URI] = new KeyEncoder[URI] {
+    final def apply(key: URI): String = key.toString
   }
 
   implicit val encodeKeyByte: KeyEncoder[Byte] = new KeyEncoder[Byte] {

--- a/modules/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
@@ -1,6 +1,7 @@
 package io.circe.tests
 
 import cats.kernel.Eq
+import java.net.URI
 import java.util.UUID
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.util.Buildable
@@ -12,6 +13,7 @@ trait MissingInstances {
   implicit lazy val eqThrowable: Eq[Throwable] = Eq.fromUniversalEquals
   implicit lazy val eqBigDecimal: Eq[BigDecimal] = Eq.fromUniversalEquals
   implicit lazy val eqUUID: Eq[UUID] = Eq.fromUniversalEquals
+  implicit lazy val eqURI: Eq[URI] = Eq.fromUniversalEquals
   implicit def eqRefArray[A <: AnyRef: Eq]: Eq[Array[A]] =
     Eq.by((value: Array[A]) => Predef.wrapRefArray(value).toVector)(
       cats.kernel.instances.vector.catsKernelStdEqForVector[A]
@@ -93,4 +95,12 @@ trait MissingInstances {
     Arbitrary(
       Gen.containerOfN[C, A](toInt(), A.arbitrary).filter(ca => ev(ca).size == toInt()).map(Sized.wrap[C[A], L])
     )
+
+  implicit final lazy val arbitraryURI: Arbitrary[URI] = Arbitrary {
+    for {
+      url <- Gen.oneOf(List("gov.taipei", "searchmgr.com", "699pic.com", "kinogo.movie", "connexus.com"))
+      protocol <- Gen.oneOf(List("http://", "https://", "ftp://", "file://"))
+      www <- Gen.oneOf("www.", "")
+    } yield URI.create(s"$protocol$www$url")
+  }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -19,6 +19,7 @@ import cats.syntax.eq._
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceMunitSuite
 import io.circe.tests.examples.{ Foo, Wub }
+import java.net.URI
 import java.util.UUID
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Prop.forAll
@@ -93,6 +94,7 @@ class StdLibCodecSuite extends CirceMunitSuite with ArrayFactoryInstance {
   checkAll("Codec[BigInt]", CodecTests[BigInt].codec)
   checkAll("Codec[BigDecimal]", CodecTests[BigDecimal].codec)
   checkAll("Codec[UUID]", CodecTests[UUID].codec)
+  checkAll("Codec[URI]", CodecTests[URI].codec)
   checkAll("Codec[Option[Int]]", CodecTests[Option[Int]].codec)
   checkAll("Codec[Some[Int]]", CodecTests[Some[Int]].codec)
   checkAll("Codec[None.type]", CodecTests[None.type].codec)
@@ -101,6 +103,7 @@ class StdLibCodecSuite extends CirceMunitSuite with ArrayFactoryInstance {
   checkAll("Codec[Map[String, Int]]", CodecTests[Map[String, Int]].codec)
   checkAll("Codec[Map[Symbol, Int]]", CodecTests[Map[Symbol, Int]].codec)
   checkAll("Codec[Map[UUID, Int]]", CodecTests[Map[UUID, Int]].codec)
+  checkAll("Codec[Map[URI, Int]]", CodecTests[Map[URI, Int]].codec)
   checkAll("Codec[Map[Byte, Int]]", CodecTests[Map[Byte, Int]].codec)
   checkAll("Codec[Map[Short, Int]]", CodecTests[Map[Short, Int]].codec)
   checkAll("Codec[Map[Int, Int]]", CodecTests[Map[Int, Int]].codec)

--- a/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
@@ -1,7 +1,7 @@
 package io.circe
 
+import java.net.URI
 import java.util.UUID
-
 import cats.instances.all._
 import io.circe.testing.KeyCodecTests
 import io.circe.tests.CirceMunitSuite
@@ -11,6 +11,7 @@ class KeyCodecSuite extends CirceMunitSuite {
   checkAll("KeyCodec[String]", KeyCodecTests[String].keyCodec)
   checkAll("KeyCodec[Symbol]", KeyCodecTests[Symbol].keyCodec)
   checkAll("KeyCodec[UUID]", KeyCodecTests[UUID].keyCodec)
+  checkAll("KeyCodec[URI]", KeyCodecTests[URI].keyCodec)
   checkAll("KeyCodec[Byte]", KeyCodecTests[Byte].keyCodec)
   checkAll("KeyCodec[Short]", KeyCodecTests[Short].keyCodec)
   checkAll("KeyCodec[Int]", KeyCodecTests[Int].keyCodec)

--- a/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
@@ -2,6 +2,7 @@ package io.circe
 
 import java.net.URI
 import java.util.UUID
+
 import cats.instances.all._
 import io.circe.testing.KeyCodecTests
 import io.circe.tests.CirceMunitSuite


### PR DESCRIPTION
Also `KeyDecoder` and `KeyEncoder`.
A trivial `Arbitrary[URI]` is used, inspired by
https://github.com/yannick-cw/sane-gen/blob/master/src/main/scala/io/github/yannick_cw/urls/UrlGen.scala#L9
https://github.com/yannick-cw/sane-gen/blob/master/src/main/resources/urls/top_urls