### PR TITLE
Add the circe booster

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The following open source projects are either built on circe or provide circe su
 * [IdeaLingua][izumi-r2]: Staged Interface Definition and Data Modeling Language & RPC system currently targeting Scala, Go, C# and TypeScript. Scala codegen generates models and JSON codecs using circe.
 * [Iglu Schema Repository][iglu]: A [JSON Schema][json-schema] repository with circe support.
 * [jsactor][jsactor]: An actor library for Scala.js with circe support.
+* [jsoniter-scala-circe][jsoniter-scala-circe]: A booster for faster parsing/printing to/from circe AST and decoding/encoding of `java.time._` and `BigInt` types.
 * [jwt-circe][jwt-circe]: A [JSON Web Token][jwt] implementation with circe support.
 * [kadai-log][kadai-log]: A logging library with circe support.
 * [msgpack4z-circe][msgpack4z-circe]: A [MessagePack][msgpack] implementation with circe support.
@@ -245,6 +246,7 @@ limitations under the License.
 [jsactor]: https://github.com/codemettle/jsactor
 [json-schema]: http://json-schema.org/
 [json-rpc]: http://www.jsonrpc.org
+[jsoniter-scala-circe]: https://github.com/plokhotnyuk/jsoniter-scala/tree/master/jsoniter-scala-circe
 [jwt]: https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32
 [jwt-circe]: http://pauldijou.fr/jwt-scala/samples/jwt-circe/
 [kadai-log]: https://bitbucket.org/atlassian/kadai-log


### PR DESCRIPTION
Results of benchmarks comparing it with circe and other JSON parsers for Scala: 
- on [JVMs](https://plokhotnyuk.github.io/jsoniter-scala/) 
- on [browsers](https://plokhotnyuk.github.io/jsoniter-scala/index-scalajs.html)