### PR TITLE
Add `printToAppendable`

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -74,8 +74,8 @@ final case class Printer(
     final def onNumber(value: JsonNumber): Unit = value.appendToStringBuilder(writer)
   }
 
-  private[this] final class AppendableByteBufferFolder(
-    writer: Printer.AppendableByteBuffer
+  private[this] final class AppendableFolder(
+    writer: Appendable
   ) extends Printer.PrintingFolder(writer, pieces, dropNullValues, escapeNonAscii, sortKeys) {
     final def onBoolean(value: Boolean): Unit = writer.append(java.lang.Boolean.toString(value))
     final def onNumber(value: JsonNumber): Unit = writer.append(value.toString)
@@ -189,9 +189,7 @@ final case class Printer(
       w
     } else new StringBuilder()
 
-    val folder = new StringBuilderFolder(writer)
-
-    json.foldWith(folder)
+    printToAppendable(json, writer)
 
     writer.toString
   }
@@ -209,15 +207,18 @@ final case class Printer(
       else Printer.NoSizePredictor
 
     val writer = new Printer.AppendableByteBuffer(cs, predictor)
-    val folder = new AppendableByteBufferFolder(writer)
-
-    json.foldWith(folder)
+    printToAppendable(json, writer)
 
     writer.toByteBuffer
   }
 
   final def printToByteBuffer(json: Json): ByteBuffer =
     printToByteBuffer(json, StandardCharsets.UTF_8)
+
+  final def printToAppendable(json: Json, out: Appendable): Unit = {
+    val folder = new AppendableFolder(out)
+    json.foldWith(folder)
+  }
 
   /**
    * The same pretty-printer configuration that outputs fields in sorted order.

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -189,7 +189,7 @@ final case class Printer(
       w
     } else new StringBuilder()
 
-    printToAppendable(json, writer)
+    unsafePrintToAppendable(json, writer)
 
     writer.toString
   }
@@ -207,7 +207,7 @@ final case class Printer(
       else Printer.NoSizePredictor
 
     val writer = new Printer.AppendableByteBuffer(cs, predictor)
-    printToAppendable(json, writer)
+    unsafePrintToAppendable(json, writer)
 
     writer.toByteBuffer
   }
@@ -215,7 +215,11 @@ final case class Printer(
   final def printToByteBuffer(json: Json): ByteBuffer =
     printToByteBuffer(json, StandardCharsets.UTF_8)
 
-  final def printToAppendable(json: Json, out: Appendable): Unit = {
+  /**
+   * Prints the JSON value by appending directly to the provided `Appendable`.
+   * This method is UNSAFE and SIDE-EFFECTING!
+   */
+  final def unsafePrintToAppendable(json: Json, out: Appendable): Unit = {
     val folder = new AppendableFolder(out)
     json.foldWith(folder)
   }


### PR DESCRIPTION
Not sure if the precedent here is to avoid side-effecting APIs at all costs (if so, apologies), but personally I would find this useful. I started this PR to add an API for writing to an `OutputStream` but realized it could be more general.