### PR TITLE
remove redundant `final` modifiers

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/CursorOp.scala
+++ b/modules/core/shared/src/main/scala/io/circe/CursorOp.scala
@@ -33,14 +33,14 @@ object CursorOp {
     final def requiresArray: Boolean = false
   }
 
-  final case object MoveLeft extends UnconstrainedOp
-  final case object MoveRight extends UnconstrainedOp
-  final case object MoveUp extends UnconstrainedOp
+  case object MoveLeft extends UnconstrainedOp
+  case object MoveRight extends UnconstrainedOp
+  case object MoveUp extends UnconstrainedOp
   final case class Field(k: String) extends UnconstrainedOp
   final case class DownField(k: String) extends ObjectOp
-  final case object DownArray extends ArrayOp
+  case object DownArray extends ArrayOp
   final case class DownN(n: Int) extends ArrayOp
-  final case object DeleteGoParent extends UnconstrainedOp
+  case object DeleteGoParent extends UnconstrainedOp
 
   implicit final val showCursorOp: Show[CursorOp] = Show.show {
     case MoveLeft       => "<-"

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -267,7 +267,7 @@ object Json {
     def onObject(value: JsonObject): X
   }
 
-  private[circe] final case object JNull extends Json {
+  private[circe] case object JNull extends Json {
     final def foldWith[X](folder: Folder[X]): X = folder.onNull
 
     final def isNull: Boolean = true


### PR DESCRIPTION
```
Welcome to Scala 3.1.0 (1.8.0_312, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> final case object Foo
-- Warning:
1 |final case object Foo
  |^^^^^
  |Modifier final is redundant for this definition
```