### PR TITLE
fix `Auto-application` warning

### DIFF
--- a/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala
@@ -12,7 +12,7 @@ trait Spaces2PrinterExample { this: Spaces2PrinterSuite =>
     case (acc, i) if i % 3 == 0 =>
       val count = rand.nextInt(10)
       val strings = List.fill(count)(Json.fromString(rand.nextString(count)))
-      val doubles = List.fill(count)(Json.fromDouble(rand.nextDouble)).flatten
+      val doubles = List.fill(count)(Json.fromDouble(rand.nextDouble())).flatten
 
       Json.obj(i.toString -> acc, "data" -> Json.fromValues(strings ++ doubles))
     case (acc, i) if i % 3 == 1 => Json.obj(i.toString -> acc, "data" -> Json.True)


### PR DESCRIPTION
```
[warn] /home/runner/work/circe/circe/modules/tests/jvm/src/test/scala/io/circe/Spaces2PrinterExample.scala:15:59: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method nextDouble,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]       val doubles = List.fill(count)(Json.fromDouble(rand.nextDouble)).flatten
[warn]                                                           ^
```