### PR TITLE
Make jawn a compile-time-only dependency for literal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -454,12 +454,11 @@ lazy val literalBase = circeCrossModule("literal", mima = previousCirceVersion, 
       "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test,
       "org.scalameta" %%% "munit" % munitVersion % Test,
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test
-    ) ++ (if (isScala3.value) Seq("org.typelevel" %% "jawn-parser" % jawnVersion)
+    ) ++ (if (isScala3.value) Seq("org.typelevel" %%% "jawn-parser" % jawnVersion % Provided)
           else Seq("com.chuusai" %%% "shapeless" % shapelessVersion))
   )
   .jsSettings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "jawn-parser" % jawnVersion % Test,
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
     )
   )


### PR DESCRIPTION
Closes https://github.com/circe/circe/issues/1677.

So IIUC https://github.com/circe/circe/pull/1874 does something very clever, and uses Jawn during compile-time only. So the generated code actually doesn't need Jawn at all, which is fantastic, except that it is still included as a runtime dependency, which is not ideal.

AFAICT there is no standard way to indicate that a dependency is compile-time only and not needed at runtime. The closest is `Provided`, which includes the dependency on the compile classpath but assumes it is already "provided" in the runtime classpath by the environment. (This setting is commonly used for Spark I believe.) In any case, `Provided` gives us the behavior we want, although the semantic meaning is not quite the same.

I don't think there's an easy way to test this in your build, since `Provided` dependencies are always on the build classpath 🤔 