### PR TITLE
avoid `scala.App`

### DIFF
--- a/examples/todo-spray/src/main/scala/todo/TodoService.scala
+++ b/examples/todo-spray/src/main/scala/todo/TodoService.scala
@@ -23,13 +23,15 @@ import spray.routing.{ HttpService, MalformedRequestContentRejection, RejectionH
 
 case class Todo(id: UUID, title: String, completed: Boolean, order: Int, dueDate: LocalDateTime)
 
-object Boot extends App {
-  implicit val system: ActorSystem = ActorSystem("todo-service")
-  implicit val timeout: Timeout = Timeout(1.second)
-  val service: ActorRef = system.actorOf(Props[TodoService], "todo-service")
+object Boot {
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem("todo-service")
+    implicit val timeout: Timeout = Timeout(1.second)
+    val service: ActorRef = system.actorOf(Props[TodoService], "todo-service")
 
-  IO(Http).ask(Http.Bind(service, interface = "localhost", port = 8080)).mapTo[Http.Event].map {
-    case Http.CommandFailed(_) => system.shutdown()
+    IO(Http).ask(Http.Bind(service, interface = "localhost", port = 8080)).mapTo[Http.Event].map {
+      case Http.CommandFailed(_) => system.shutdown()
+    }
   }
 }
 


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/book/methods-main-methods.html

> The previous functionality of App, which relied on the “magic” DelayedInit trait, is no longer available. App still exists in limited form for now, but it doesn’t support command line arguments and will be deprecated in the future.
> 
> If programs need to cross-build between Scala 2 and Scala 3, it’s recommended to use an explicit main method with an Array[String] argument instead:
