### PR TITLE
override Decoder instance map2Eval. prepare cats 2.7

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.{ ApplicativeError, MonadError, SemigroupK }
+import cats.{ ApplicativeError, Eval, MonadError, SemigroupK }
 import cats.data.{
   Chain,
   Kleisli,
@@ -1442,6 +1442,8 @@ object Decoder
         fa.product(fb).map {
           case (a, b) => f(a, b)
         }
+      override final def map2Eval[A, B, Z](fa: Decoder[A], fb: Eval[Decoder[B]])(f: (A, B) => Z): Eval[Decoder[Z]] =
+        fb.map(fb => map2(fa, fb)(f))
       override final def productR[A, B](fa: Decoder[A])(fb: Decoder[B]): Decoder[B] = fa.product(fb).map(_._2)
       override final def productL[A, B](fa: Decoder[A])(fb: Decoder[B]): Decoder[A] = fa.product(fb).map(_._1)
 


### PR DESCRIPTION
`Decoder` instance accumulate errors if possible.
but `cats.FlatMap` override `map2Eval` since 2.7.0

- https://github.com/typelevel/cats/pull/3951
- https://github.com/circe/circe/runs/4357465821?check_suite_focus=true#step:8:2719

```
==> X io.circe.DecoderSuite.decodeAccumulating should accumulate errors after traversal  0.027s munit.ComparisonFailException: /home/runner/work/circe/circe/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala:760
759:    assert(result.isInvalid)
760:    assertEquals(result.swap.toOption.map(_.size), Some(2))
761:  }
values are not the same
=> Obtained
Some(
  1
)
=> Diff (- obtained, + expected)
 Some(
-  1
+  2
 )
```