### PR TITLE
Main is actually 0.14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,7 @@ def priorTo2_13(scalaVersion: String): Boolean =
     case _                              => false
   }
 
-val previousCirceVersion = Some("0.14.0-M3")
+val previousCirceVersion = Some("0.14.0")
 val scalaFiddleCirceVersion = "0.9.1"
 
 lazy val disableScala3 = Def.settings(

--- a/build.sbt
+++ b/build.sbt
@@ -197,7 +197,28 @@ def circeProject(path: String)(project: Project) = {
     description := s"circe $docName",
     moduleName := s"circe-$path",
     name := s"Circe $docName",
-    allSettings
+    allSettings,
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core._
+      Seq( // Methods were added... this is fine.
+        "io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryMissingField_=",
+        "io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryWrongTypeExpectation_=",
+        "io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryCustomReason_=",
+        "io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$_setter_$arbitraryReason_=",
+        "io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$$arbitraryMissingField",
+        "io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$$arbitraryWrongTypeExpectation",
+        "io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$$arbitraryCustomReason",
+        "io.circe.testing.ArbitraryInstances.arbitraryReason"
+      ).map(ProblemFilters.exclude[ReversedMissingMethodProblem](_)) ++ Seq(
+        // Pointer literals were refactored, but in a binary compatable way. These warnings are just because private stuff changed in ways that
+        // That would not be bin-compat if used from java... but this is Macro Code so it should be fine.
+        ProblemFilters.exclude[FinalClassProblem]("io.circe.pointer.literal.PointerLiteralMacros"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("io.circe.pointer.literal.PointerLiteralMacros.c"),
+        ProblemFilters
+          .exclude[DirectMissingMethodProblem]("io.circe.pointer.literal.PointerLiteralMacros.pointerStringContext"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("io.circe.pointer.literal.PointerLiteralMacros.this")
+      )
+    }
   )
 }
 

--- a/modules/core/shared/src/main/scala/io/circe/Error.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Error.scala
@@ -45,6 +45,11 @@ object ParsingFailure {
  * decoding history resulting in the failure.
  */
 sealed abstract class DecodingFailure(val reason: Reason) extends Error {
+  // Added to satisfy MiMA
+  def this(message: String) = {
+    this(CustomReason(message))
+  }
+
   def history: List[CursorOp]
 
   val message: String = reason match {

--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -74,7 +74,12 @@ final case class Printer(
     final def onNumber(value: JsonNumber): Unit = value.appendToStringBuilder(writer)
   }
 
-  private[this] final class AppendableFolder(
+  // Added to please MiMa
+  private[this] final class AppendableByteBufferFolder(
+    writer: Printer.AppendableByteBuffer
+  ) extends AppendableFolder(writer)
+
+  private[this] sealed class AppendableFolder(
     writer: Appendable
   ) extends Printer.PrintingFolder(writer, pieces, dropNullValues, escapeNonAscii, sortKeys) {
     final def onBoolean(value: Boolean): Unit = writer.append(java.lang.Boolean.toString(value))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.15.0-SNAPSHOT"
+ThisBuild / version := "0.14.2-SNAPSHOT"


### PR DESCRIPTION
It looks to me that, with a few minor changes, all the changes in `0.15.0-M1` are compatible with 0.14 series.  Someone feel free to correct me if I'm wrong.

This PR fixes 
- Fixes minor changes in core by adding the needed methods.
- Overrides Mima Warnings for new methods, because those are fine.
- Resets the version to `0.14.2-SNAPSHOT`

This PR base is set to #1905  so it runs the JS tests as well. (Will change when merging that PR).

This supersedes #1863 

## Mima Details:

Overrode these because its really just changes to private memebers.  This might be a problem if used from Java code, but its changes in Macros, so should be safe... and if someone uses it from java... thats on them I think.
```
[error] Circe pointer literal: Failed binary compatibility check against io.circe:circe-pointer-literal_2.13:0.14.0! Found 4 potential problems
[error]  * class io.circe.pointer.literal.PointerLiteralMacros is declared final in current version
[error]    filter with: ProblemFilters.exclude[FinalClassProblem]("io.circe.pointer.literal.PointerLiteralMacros")
[error]  * method c()scala.reflect.macros.blackbox.Context in class io.circe.pointer.literal.PointerLiteralMacros does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("io.circe.pointer.literal.PointerLiteralMacros.c")
[error]  * method pointerStringContext(scala.collection.immutable.Seq)scala.reflect.api.Trees#TreeApi in class io.circe.pointer.literal.PointerLiteralMacros does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("io.circe.pointer.literal.PointerLiteralMacros.pointerStringContext")
[error]  * method this(scala.reflect.macros.blackbox.Context)Unit in class io.circe.pointer.literal.PointerLiteralMacros does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("io.circe.pointer.literal.PointerLiteralMacros.this")
```

Ignored these since they are just adding methods, and we are in early semvar, so thats ok.
```
[error] Circe testing: Failed binary compatibility check against io.circe:circe-testing_2.13:0.14.0! Found 8 potential problems
[error]  * abstract synthetic method io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryMissingField_=(org.scalacheck.Gen)Unit in interface io.circe.testing.ArbitraryInstances is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryMissingField_=")
[error]  * abstract synthetic method io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryWrongTypeExpectation_=(org.scalacheck.Gen)Unit in interface io.circe.testing.ArbitraryInstances is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryWrongTypeExpectation_=")
[error]  * abstract synthetic method io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryCustomReason_=(org.scalacheck.Gen)Unit in interface io.circe.testing.ArbitraryInstances is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$_setter_$io$circe$testing$ArbitraryInstances$$arbitraryCustomReason_=")
[error]  * abstract synthetic method io$circe$testing$ArbitraryInstances$_setter_$arbitraryReason_=(org.scalacheck.Arbitrary)Unit in interface io.circe.testing.ArbitraryInstances is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$_setter_$arbitraryReason_=")
[error]  * abstract synthetic method io$circe$testing$ArbitraryInstances$$arbitraryMissingField()org.scalacheck.Gen in interface io.circe.testing.ArbitraryInstances is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$$arbitraryMissingField")
[error]  * abstract synthetic method io$circe$testing$ArbitraryInstances$$arbitraryWrongTypeExpectation()org.scalacheck.Gen in interface io.circe.testing.ArbitraryInstances is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$$arbitraryWrongTypeExpectation")
[error]  * abstract synthetic method io$circe$testing$ArbitraryInstances$$arbitraryCustomReason()org.scalacheck.Gen in interface io.circe.testing.ArbitraryInstances is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("io.circe.testing.ArbitraryInstances.io$circe$testing$ArbitraryInstances$$arbitraryCustomReason")
[error]  * abstract method arbitraryReason()org.scalacheck.Arbitrary in interface io.circe.testing.ArbitraryInstances is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("io.circe.testing.ArbitraryInstances.arbitraryReason")
```

Fixed these by adding the missing types and methods:
```
[error] Circe core: Failed binary compatibility check against io.circe:circe-core_2.13:0.14.0! Found 2 potential problems
[error]  * method this(java.lang.String)Unit in class io.circe.DecodingFailure's type is different in current version, where it is (io.circe.DecodingFailure#Reason)Unit instead of (java.lang.String)Unit
[error]    filter with: ProblemFilters.exclude[IncompatibleMethTypeProblem]("io.circe.DecodingFailure.this")
[error]  * class io.circe.Printer#AppendableByteBufferFolder does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("io.circe.Printer$AppendableByteBufferFolder")
```