### PR TITLE
Fixup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.1.0, 2.12.15, 2.13.8]
-        java: [temurin@8, temurin@17]
+        java: [temurin@8, temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -37,6 +37,13 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
@@ -57,23 +64,143 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
+      - name: Setup NodeJS v16
+        if: matrix.ci == 'ciNodeJS'
+        uses: actions/setup-node@v2.4.0
+        with:
+          node-version: 16
+
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
-      - name: Test JVM
+      - name: Test JVM (without coverage)
         if: ${{ matrix.scala == '3.1.0' }}
-        run: sbt ++${{ matrix.scala }} clean scalafmtCheckAll scalafmtSbtCheck validateJVM
-
-      - name: Test JS
-        run: sbt ++${{ matrix.scala }} clean scalafmtCheckAll scalafmtSbtCheck validateJS
+        run: sbt ++${{ matrix.scala }} clean validateJVM
 
       - name: Test JVM
         if: ${{ matrix.scala != '3.1.0' }}
-        run: sbt ++${{ matrix.scala }} clean coverage scalastyle scalafmtCheckAll scalafmtSbtCheck validateJVM benchmark/test
+        run: sbt ++${{ matrix.scala }} clean coverage scalastyle validateJVM benchmark/test
+
+      - name: Test JS
+        run: sbt ++${{ matrix.scala }} clean validateJS
 
       - name: Coverage
         if: ${{ matrix.scala != '3.1.0' }}
         run: sbt ++${{ matrix.scala }} coverageReport
 
       - if: ${{ matrix.scala != '3.1.0' }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
+        with:
+          flags: ${{matrix.scala}},${{matrix.java}}
+
+      - name: Compress target directories
+        run: tar cf targets.tar modules/shapes/.js/target modules/numbers-testing/.jvm/target modules/testing/jvm/target modules/extras/js/target circeJVM/target modules/generic/jvm/target modules/generic-simple/.jvm/target modules/literal/.jvm/target modules/parser/jvm/target modules/literal/.js/target modules/parser/js/target modules/scalajs/target docs/target modules/shapes/.jvm/target modules/jawn/jvm/target modules/core/js/target modules/hygiene/jvm/target modules/testing/js/target circeJS/target modules/generic/js/target modules/jawn/js/target modules/hygiene/js/target modules/core/jvm/target modules/pointer-literal/.js/target modules/tests/js/target modules/numbers-testing/.js/target modules/pointer/.js/target modules/refined/js/target modules/pointer/.jvm/target modules/pointer-literal/.jvm/target target modules/scodec/jvm/target modules/scodec/js/target modules/refined/jvm/target modules/benchmark-dotty/target modules/scalajs-java-time-test/target modules/numbers/js/target modules/tests/jvm/target modules/extras/jvm/target modules/generic-simple/.js/target modules/numbers/jvm/target modules/benchmark/target project/target
+
+      - name: Upload target directories
+        uses: actions/upload-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.scala }}-${{ matrix.java }}
+          path: targets.tar
+
+  scalafmt:
+    name: Scalafmt
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [3.1.0, 2.12.15, 2.13.8]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Scalafmt tests
+        run: sbt ++${{ matrix.scala }} scalafmtCheckAll scalafmtSbtCheck
+
+  mima:
+    name: Mima
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [3.1.0, 2.12.15, 2.13.8]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Mima Check Java
+        run: sbt ++${{ matrix.scala }} mimaReportBinaryIssuesJVM
+
+      - name: Mima Check NodeJS
+        run: sbt ++${{ matrix.scala }} mimaReportBinaryIssuesJS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,14 +75,14 @@ jobs:
 
       - name: Test JVM (without coverage)
         if: ${{ matrix.scala == '3.1.0' }}
-        run: sbt ++${{ matrix.scala }} clean validateJVM
+        run: sbt ++${{ matrix.scala }} clean circeJVM/compile circeJVM/test
 
-      - name: Test JVM
+      - name: Test JVM (with coverage)
         if: ${{ matrix.scala != '3.1.0' }}
-        run: sbt ++${{ matrix.scala }} clean coverage scalastyle validateJVM benchmark/test
+        run: sbt ++${{ matrix.scala }} clean coverage scalastyle circeJVM/compile circeJVM/test benchmark/test
 
       - name: Test JS
-        run: sbt ++${{ matrix.scala }} clean validateJS
+        run: sbt ++${{ matrix.scala }} circeJS/compile circeJS/test
 
       - name: Coverage
         if: ${{ matrix.scala != '3.1.0' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,15 +93,6 @@ jobs:
         with:
           flags: ${{matrix.scala}},${{matrix.java}}
 
-      - name: Compress target directories
-        run: tar cf targets.tar modules/shapes/.js/target modules/numbers-testing/.jvm/target modules/testing/jvm/target modules/extras/js/target circeJVM/target modules/generic/jvm/target modules/generic-simple/.jvm/target modules/literal/.jvm/target modules/parser/jvm/target modules/literal/.js/target modules/parser/js/target modules/scalajs/target docs/target modules/shapes/.jvm/target modules/jawn/jvm/target modules/core/js/target modules/hygiene/jvm/target modules/testing/js/target circeJS/target modules/generic/js/target modules/jawn/js/target modules/hygiene/js/target modules/core/jvm/target modules/pointer-literal/.js/target modules/tests/js/target modules/numbers-testing/.js/target modules/pointer/.js/target modules/refined/js/target modules/pointer/.jvm/target modules/pointer-literal/.jvm/target target modules/scodec/jvm/target modules/scodec/js/target modules/refined/jvm/target modules/benchmark-dotty/target modules/scalajs-java-time-test/target modules/numbers/js/target modules/tests/jvm/target modules/extras/jvm/target modules/generic-simple/.js/target modules/numbers/jvm/target modules/benchmark/target project/target
-
-      - name: Upload target directories
-        uses: actions/upload-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.scala }}-${{ matrix.java }}
-          path: targets.tar
-
   scalafmt:
     name: Scalafmt
     strategy:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
 version = 3.5.0
+project.git = true
 runner.dialect = scala213
 project.layout = StandardConvention
 continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ ThisBuild / scalaVersion := crossScalaVersions.value.last
 
 ThisBuild / githubWorkflowJavaVersions := Seq("8", "11", "17").map(JavaSpec.temurin)
 ThisBuild / githubWorkflowPublishTargetBranches := Nil
+ThisBuild / githubWorkflowArtifactUpload := false // TODO: Maybe enable this later for efficiency.
 ThisBuild / githubWorkflowBuildPreamble +=
   WorkflowStep.Use(
     UseRef.Public("actions", "setup-node", "v2.4.0"),

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(
     List(
       "clean",
-      "validateJVM"
+      "circeJVM/compile",
+      "circeJVM/test"
     ),
     id = None,
     name = Some("Test JVM (without coverage)"),
@@ -36,17 +37,18 @@ ThisBuild / githubWorkflowBuild := Seq(
       "clean",
       "coverage",
       "scalastyle",
-      "validateJVM",
+      "circeJVM/compile",
+      "circeJVM/test",
       "benchmark/test"
     ),
     id = None,
-    name = Some("Test JVM"),
+    name = Some("Test JVM (with coverage)"),
     cond = Some("${{ matrix.scala != '" + Scala3 + "' }}")
   ),
   WorkflowStep.Sbt(
     List(
-      "clean",
-      "validateJS"
+      "circeJS/compile",
+      "circeJS/test"
     ),
     id = None,
     name = Some("Test JS")


### PR DESCRIPTION
- Added Java 11 to build matrix. (Http4s builds on this, we should too)
- Moved Scalafmt Checks to their own actions.
- Set scalafmt `project.git = true` so scalafmt only checks tracked files (no more checking metals.sbt)
- Added Mima Check Actions
- Fixed Mima Checks:
  - They now work on JS
  - We aren't trying to check non-published projects.
- Added `circeJS` and `circeJVM` aggregation projects to help run commands on all JS or all JVM projects separately.

FYI: Mima Checks will fail, that is expected.