### PR TITLE
fix Scala 3 semiauto

### DIFF
--- a/modules/generic/shared/src/main/scala-3/io/circe/generic/auto.scala
+++ b/modules/generic/shared/src/main/scala-3/io/circe/generic/auto.scala
@@ -1,6 +1,6 @@
 package io.circe.generic
 
-import io.circe.{ Decoder, Encoder }
+import io.circe.{ Decoder, DerivationType, Encoder }
 import io.circe.`export`.Exported
 import scala.deriving.Mirror
 
@@ -13,9 +13,9 @@ import scala.deriving.Mirror
  */
 trait AutoDerivation {
   implicit inline final def deriveDecoder[A](using inline A: Mirror.Of[A]): Exported[Decoder[A]] =
-    Exported(Decoder.derived[A])
+    Exported(Decoder.derived[A](DerivationType.Auto))
   implicit inline final def deriveEncoder[A](using inline A: Mirror.Of[A]): Exported[Encoder.AsObject[A]] =
-    Exported(Encoder.AsObject.derived[A])
+    Exported(Encoder.AsObject.derived[A](DerivationType.Auto))
 }
 
 object auto extends AutoDerivation

--- a/modules/generic/shared/src/main/scala-3/io/circe/generic/semiauto.scala
+++ b/modules/generic/shared/src/main/scala-3/io/circe/generic/semiauto.scala
@@ -1,6 +1,6 @@
 package io.circe.generic
 
-import io.circe.{ Codec, Decoder, Encoder }
+import io.circe.{ Codec, Decoder, DerivationType, Encoder }
 import scala.deriving.Mirror
 
 /**
@@ -23,7 +23,10 @@ import scala.deriving.Mirror
  * }}}
  */
 object semiauto {
-  inline final def deriveDecoder[A](using inline A: Mirror.Of[A]): Decoder[A] = Decoder.derived[A]
-  inline final def deriveEncoder[A](using inline A: Mirror.Of[A]): Encoder.AsObject[A] = Encoder.AsObject.derived[A]
-  inline final def deriveCodec[A](using inline A: Mirror.Of[A]): Codec.AsObject[A] = Codec.AsObject.derived[A]
+  inline final def deriveDecoder[A](using inline A: Mirror.Of[A]): Decoder[A] =
+    Decoder.derived[A](DerivationType.SemiAuto)
+  inline final def deriveEncoder[A](using inline A: Mirror.Of[A]): Encoder.AsObject[A] =
+    Encoder.AsObject.derived[A](DerivationType.SemiAuto)
+  inline final def deriveCodec[A](using inline A: Mirror.Of[A]): Codec.AsObject[A] =
+    Codec.AsObject.derived[A](DerivationType.SemiAuto)
 }


### PR DESCRIPTION
### before

```
Welcome to Scala 3.1.1 (1.8.0_322, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> case class A(x: Int); case class B(y: A)
// defined case class A
// defined case class B

scala> io.circe.generic.semiauto.deriveEncoder[B] // don't derive nested classes if semiauto!?
val res0: io.circe.Encoder.AsObject[B] = anon$1@1ea5f0e7
```

### after

```
Welcome to Scala 3.1.1 (1.8.0_322, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> case class A(x: Int); case class B(y: A)
// defined case class A
// defined case class B

scala> io.circe.generic.semiauto.deriveEncoder[B]
-- Error: ----------------------------------------------------------------------
1 |io.circe.generic.semiauto.deriveEncoder[B]
  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |cannot reduce summonFrom with
  | patterns :  case given encodeA @ _:io.circe.Encoder[A]
  | This location contains code that was inlined from Derivation.scala:53
  | This location contains code that was inlined from Derivation.scala:70
  | This location contains code that was inlined from Derivation.scala:51
  | This location contains code that was inlined from Derivation.scala:86
  | This location contains code that was inlined from semiauto.scala:27
1 error found
```

### Scala 2.x

```
Welcome to Scala 2.13.8 (OpenJDK 64-Bit Server VM, Java 1.8.0_322).
Type in expressions for evaluation. Or try :help.

scala> case class A(x: Int); case class B(y: A)
class A
class B

scala> io.circe.generic.semiauto.deriveEncoder[B]
                                              ^
       error: could not find Lazy implicit value of type io.circe.generic.encoding.DerivedAsObjectEncoder[B]
```