### PR TITLE
replace report.error with report.errorAndAbort

### DIFF
--- a/modules/literal/src/main/scala-3/io/circe/literal/JsonLiteralMacros.scala
+++ b/modules/literal/src/main/scala-3/io/circe/literal/JsonLiteralMacros.scala
@@ -16,7 +16,7 @@ object JsonLiteralMacros {
     val replacements = args match {
       case Varargs(argExprs) =>
         argExprs.map(Replacement(stringParts, _))
-      case other => report.error("Invalid arguments for json literal."); Nil
+      case other => report.errorAndAbort("Invalid arguments for json literal.")
     }
 
     val jsonString = stringParts.zip(replacements.map(_.placeholder)).foldLeft("") {
@@ -87,8 +87,7 @@ object JsonLiteralMacros {
     Parser.parseFromString[Expr[Json]](jsonString) match {
       case Success(jsonExpr) => jsonExpr
       case Failure(e) =>
-        report.error(e.toString)
-        '{ null }
+        report.errorAndAbort(e.toString)
     }
   }
 }

--- a/modules/literal/src/main/scala-3/io/circe/literal/Replacement.scala
+++ b/modules/literal/src/main/scala-3/io/circe/literal/Replacement.scala
@@ -13,7 +13,7 @@ case class Replacement(val placeholder: String, argument: Expr[Any]) {
           case '[t] =>
             Expr.summon[Encoder[t]] match {
               case Some(encoder) => '{ $encoder.apply($arg.asInstanceOf[t]) }
-              case None          => report.error(s"could not find implicit Encoder for ${Type.show[t]}", arg); '{ null }
+              case None          => report.errorAndAbort(s"could not find implicit Encoder for ${Type.show[t]}", arg)
             }
         }
       }
@@ -28,7 +28,7 @@ case class Replacement(val placeholder: String, argument: Expr[Any]) {
           case '[t] =>
             Expr.summon[KeyEncoder[t]] match {
               case Some(encoder) => '{ $encoder.apply($arg.asInstanceOf[t]) }
-              case None => report.error(s"could not find implicit for ${Type.show[KeyEncoder[t]]}", arg); '{ null }
+              case None => report.errorAndAbort(s"could not find implicit for ${Type.show[KeyEncoder[t]]}", arg)
             }
         }
     }


### PR DESCRIPTION
With report.errorAndAbort(or report.throwError), we can remove `'{null}`
at the end of error case.