### PR TITLE
Add encoder / decoder for java.util.Locale

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -1476,9 +1476,10 @@ object Decoder
         )
     )
 
+  /** Deserializing `java.util.Locale` using a IETF BCP 47 string representation. */
   implicit final lazy val localeDecoder: Decoder[Locale] =
     new Decoder[Locale] {
-      private[this] def fail(c: HCursor): Result[Locale] = Left(DecodingFailure("Locale", c.history))
+      private[this] def fail(c: HCursor): Result[Locale] = Left(DecodingFailure("java.util.Locale", c.history))
       final def apply(c: HCursor): Result[Locale] = c.value match {
         case Json.JString(value) =>
           value match {

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -1477,26 +1477,26 @@ object Decoder
     )
 
   /** Deserializing `java.util.Locale` using a IETF BCP 47 string representation. */
-  implicit final lazy val localeDecoder: Decoder[Locale] =
-    new Decoder[Locale] {
-      private[this] def fail(c: HCursor): Result[Locale] = Left(DecodingFailure("java.util.Locale", c.history))
-      final def apply(c: HCursor): Result[Locale] = c.value match {
-        case Json.JString(value) =>
-          value match {
-            case LocaleTagConverter(locale) => Right(locale)
-            case _                          => fail(c)
-          }
-        case _ => fail(c)
-      }
-    }
-
-  object LocaleTagConverter {
+  object locale {
     final val undetermined: String = "und"
     class LocaleOpt(val locale: Locale) extends AnyVal {
       def isEmpty: Boolean = undetermined == locale.toLanguageTag
       def get: Locale = locale
     }
     def unapply(s: String): LocaleOpt = new LocaleOpt(Locale.forLanguageTag(s))
+
+    implicit final lazy val decoder: Decoder[Locale] =
+      new Decoder[Locale] {
+        private[this] def fail(c: HCursor): Result[Locale] = Left(DecodingFailure("java.util.Locale", c.history))
+        final def apply(c: HCursor): Result[Locale] = c.value match {
+          case Json.JString(value) =>
+            value match {
+              case locale(value) => Right(value)
+              case _             => fail(c)
+            }
+          case _ => fail(c)
+        }
+      }
   }
 
   /**

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -705,7 +705,7 @@ object Encoder
     Encoder[String].contramap(_.getCurrencyCode())
 
   implicit final lazy val localeEncoder: Encoder[Locale] =
-    Encoder[String].contramap(_.toString())
+    Encoder[String].contramap(_.toLanguageTag)
 
   /**
    * A subtype of `Encoder` that statically verifies that the instance encodes

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.{ Contravariant, Foldable }
 import cats.data.{ Chain, NonEmptyChain, NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector, OneAnd, Validated }
 import io.circe.`export`.Exported
+
 import java.io.Serializable
 import java.net.URI
 import java.time.{
@@ -30,8 +31,7 @@ import java.time.format.DateTimeFormatter.{
   ISO_ZONED_DATE_TIME
 }
 import java.time.temporal.TemporalAccessor
-import java.util.Currency
-import java.util.UUID
+import java.util.{ Currency, Locale, UUID }
 import scala.Predef._
 import scala.collection.Map
 import scala.collection.immutable.{ Map => ImmutableMap, Set }
@@ -703,6 +703,9 @@ object Encoder
 
   implicit final lazy val currencyEncoder: Encoder[Currency] =
     Encoder[String].contramap(_.getCurrencyCode())
+
+  implicit final lazy val localeEncoder: Encoder[Locale] =
+    Encoder[String].contramap(_.toString())
 
   /**
    * A subtype of `Encoder` that statically verifies that the instance encodes

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -705,8 +705,10 @@ object Encoder
     Encoder[String].contramap(_.getCurrencyCode())
 
   /** Serializing `java.util.Locale` using a IETF BCP 47 string representation */
-  implicit final lazy val localeEncoder: Encoder[Locale] =
-    Encoder[String].contramap(_.toLanguageTag)
+  object locale {
+    implicit final lazy val encoder: Encoder[Locale] =
+      Encoder[String].contramap(_.toLanguageTag)
+  }
 
   /**
    * A subtype of `Encoder` that statically verifies that the instance encodes

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -704,6 +704,7 @@ object Encoder
   implicit final lazy val currencyEncoder: Encoder[Currency] =
     Encoder[String].contramap(_.getCurrencyCode())
 
+  /** Serializing `java.util.Locale` using a IETF BCP 47 string representation */
   implicit final lazy val localeEncoder: Encoder[Locale] =
     Encoder[String].contramap(_.toLanguageTag)
 


### PR DESCRIPTION
As a follow up for [this](https://github.com/circe/circe/issues/1513#issue-673314224) open issue, since it's something I also need in one of our projects.
Basically, an implicit `encoder` and `decoder` for `java.util.Locale` was added to default implicit `collections`.