### PR TITLE
Use human-readable cursor history for DecodingFailure getMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ target/
 .classpath
 .bsp/
 tmp/
+.metals/
+.vscode/
+.bloop/
+*metals.sbt

--- a/modules/core/shared/src/main/scala/io/circe/Error.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Error.scala
@@ -58,8 +58,7 @@ sealed abstract class DecodingFailure(val reason: Reason) extends Error {
     case CustomReason(message)              => message
   }
 
-  final override def getMessage: String =
-    if (history.isEmpty) message else s"$message: ${history.mkString(",")}"
+  final override def getMessage: String = DecodingFailure.showDecodingFailure.show(this)
 
   final def copy(message: String = message, history: => List[CursorOp] = history): DecodingFailure = {
     def newHistory = history


### PR DESCRIPTION
This would turn the message
```
String: DownField(foo),MoveRight,MoveRight,MoveRight,MoveRight,MoveRight,DownArray,DownField(items)
```
Into
```
DecodingFailure at .items[5].foo: String
```
Not sure if there are any situations where this wouldn't be easier to read?