### PR TITLE
add iemapTry to Codec

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Codec.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Codec.scala
@@ -3,6 +3,8 @@ package io.circe
 import cats.Invariant
 import cats.data.Validated
 
+import scala.util.Try
+
 /**
  * A type class that provides back and forth conversion between values of type `A`
  * and the [[Json]] format.
@@ -15,13 +17,22 @@ import cats.data.Validated
 trait Codec[A] extends Decoder[A] with Encoder[A] {
 
   /**
-   * Variant of `imap` which allows the [[Decoder]] to fail.
-   * @param f decode value
+   * Variant of `imap` which allows the [[Decoder]] to fail with message string.
+   * @param f decode value or fail
    * @param g encode value
    * @tparam B the type of the new [[Codec]]
    * @return a codec for [[B]]
    */
   def iemap[B](f: A => Either[String, B])(g: B => A): Codec[B] = Codec.from(emap(f), contramap(g))
+
+  /**
+   * Variant of `imap` which allows the [[Decoder]] to fail with Throwable.
+   * @param f decode value or fail
+   * @param g encode value
+   * @tparam B the type of the new [[Codec]]
+   * @return a codec for [[B]]
+   */
+  def iemapTry[B](f: A => Try[B])(g: B => A): Codec[B] = Codec.from(emapTry(f), contramap(g))
 
 }
 

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -25,6 +25,7 @@ import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Prop.forAll
 import scala.collection.immutable.SortedMap
 import scala.collection.mutable.HashMap
+import scala.util.Success
 
 trait SpecialEqForFloatAndDouble {
 
@@ -192,9 +193,11 @@ class CirceCodecSuite extends CirceMunitSuite {
 class InvariantCodecSuite extends CirceMunitSuite {
   val wubCodec = Codec.from(Decoder[Long], Encoder[Long]).imap(Wub(_))(_.x)
   val wubCodecE = Codec.from(Decoder[Long], Encoder[Long]).iemap(l => Right(Wub(l)))(_.x)
+  val wubCodecT = Codec.from(Decoder[Long], Encoder[Long]).iemapTry(l => Success(Wub(l)))(_.x)
 
   checkAll("Codec[Wub] via imap", CodecTests[Wub](wubCodec, wubCodec).codec)
   checkAll("Codec[Wub] via iemap", CodecTests[Wub](wubCodecE, wubCodecE).codec)
+  checkAll("Codec[Wub] via iemapTry", CodecTests[Wub](wubCodecT, wubCodecT).codec)
 }
 
 class EitherCodecSuite extends CirceMunitSuite {


### PR DESCRIPTION
Adding `iemapTry` to trait `Codec` which allows `f` to fail with exceptions.