### PR TITLE
`mimaReportBinaryIssuesJS` should run `circeJS/mimaReportBinaryIssues`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -878,7 +878,7 @@ addCommandAlias(
   ";buildJVM;circeJVM/test" + formatCommands
 )
 addCommandAlias("buildJS", "circeJS/compile")
-addCommandAlias("mimaReportBinaryIssuesJS", "circeJVM/mimaReportBinaryIssues")
+addCommandAlias("mimaReportBinaryIssuesJS", "circeJS/mimaReportBinaryIssues")
 addCommandAlias(
   "validateJS",
   ";buildJS;circeJS/test" + formatCommands


### PR DESCRIPTION
Noticed this while working on your build. Probably better to start running this sooner than later, hopefully nothing is broken ...