### PR TITLE
Spelling

### DIFF
--- a/docs/src/main/tut/codecs/adt.md
+++ b/docs/src/main/tut/codecs/adt.md
@@ -65,7 +65,7 @@ This works, and if you need to be able to specify the order that the ADT constru
 As discussed [on Gitter](https://gitter.im/circe/circe?at=589dee5daa800ee52c7aac8a), we can avoid the fuss of writing out all the cases by using the `circe-shapes` module:
 
 ```scala mdoc:silent
-// To suppress previously imported inplicit codecs.
+// To suppress previously imported implicit codecs.
 import GenericDerivation.{ decodeEvent => _, encodeEvent => _ }
 
 object ShapesDerivation {

--- a/docs/src/main/tut/codecs/testing.md
+++ b/docs/src/main/tut/codecs/testing.md
@@ -19,7 +19,7 @@ object Person {
 }
 ```
 
-If you try to encode then decode a `Person`, you won't be succecssful:
+If you try to encode then decode a `Person`, you won't be successful:
 
 ```scala mdoc
 Person("James").asJson.as[Person]

--- a/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
@@ -88,7 +88,7 @@ class EncoderSuite extends CirceMunitSuite {
     assert(Encoder[Float].apply(x).toString.toFloat === x)
 
     // For floats which are NOT represented with scientific notation,
-    // the JSON representaton should match Float.toString
+    // the JSON representation should match Float.toString
     // This should catch cases where 1.2f would previously be encoded
     // as 1.2000000476837158 due to the use of .toDouble
     if (!x.toString.toLowerCase.contains('e')) {

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -77,7 +77,7 @@ object Boilerplate {
    * - The contents of the `header` val is output first
    * - Then the first block of lines beginning with '|'
    * - Then the block of lines beginning with '-' is replicated once for each arity,
-   *   with the `templateVals` already pre-populated with relevant relevant vals for that arity
+   *   with the `templateVals` already pre-populated with relevant vals for that arity
    * - Then the last block of lines prefixed with '|'
    *
    * The block otherwise behaves as a standard interpolated string with regards to variable


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/circe/commit/8456c61b5887278377550402df62dd29eabdaf37#commitcomment-75824361

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/circe/commit/0ebe0654b98cf6e5d1ae3b59fb500209933da833

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.