### PR TITLE
Fix PointerInterpolatorSuite For Arbitrary Strings

### DIFF
--- a/modules/pointer-literal/src/test/scala-3/io/circe/pointer/literal/PointerInterpolatorSuite.scala
+++ b/modules/pointer-literal/src/test/scala-3/io/circe/pointer/literal/PointerInterpolatorSuite.scala
@@ -1,10 +1,11 @@
 package io.circe.pointer.literal
 
-import io.circe.pointer.Pointer
+import io.circe.pointer._
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop
 
 class PointerInterpolatorSuite extends ScalaCheckSuite {
+
   test("The pointer string interpolater should parse valid absolute JSON pointers") {
     val inputs = List("", "/foo", "/foo/0", "/", "/a~1b", "/c%d", "/e^f", "/g|h", "/i\\j", "/k\"l", "/ ", "/m~0n")
     val values = List(
@@ -46,9 +47,12 @@ class PointerInterpolatorSuite extends ScalaCheckSuite {
 
   property("The pointer string interpolater should work with arbitrary interpolated strings") {
     Prop.forAll { (v: String) =>
-      val Right(expected) = Pointer.parse(s"/foo/$v/bar")
+      val escaped: String =
+        v.replaceAll("~", "~0").replaceAll("/", "~1")
+      val expected = Pointer.parse(s"/foo/$escaped/bar")
+      val actual: Either[PointerSyntaxError, Pointer] = Right(pointer"/foo/$v/bar")
 
-      pointer"/foo/$v/bar" == expected
+      assertEquals(actual, expected)
     }
   }
 


### PR DESCRIPTION
The test for using pointer syntax with arbitrary strings did not account for the required escaping of "~" and "/" to "~0" and "~1", causing test failures.

See: https://github.com/circe/circe/runs/6885928047?check_suite_focus=true