### PR TITLE
Use The Jawn Parser For Parsing Sorted Output In Tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -400,7 +400,7 @@ lazy val tests = circeCrossModule("tests")
       ("com.chuusai" %%% "shapeless" % shapelessVersion).cross(CrossVersion.for3Use2_13),
       "org.scalameta" %%% "munit" % munitVersion,
       "org.typelevel" %%% "discipline-scalatest" % disciplineScalaTestVersion,
-      "org.typelevel" %%% "discipline-munit" % disciplineMunitVersion,
+      "org.typelevel" %%% "discipline-munit" % disciplineMunitVersion
     ),
     Test / sourceGenerators += (Test / sourceManaged).map(Boilerplate.genTests).taskValue
   )

--- a/build.sbt
+++ b/build.sbt
@@ -400,7 +400,7 @@ lazy val tests = circeCrossModule("tests")
       ("com.chuusai" %%% "shapeless" % shapelessVersion).cross(CrossVersion.for3Use2_13),
       "org.scalameta" %%% "munit" % munitVersion,
       "org.typelevel" %%% "discipline-scalatest" % disciplineScalaTestVersion,
-      "org.typelevel" %%% "discipline-munit" % disciplineMunitVersion
+      "org.typelevel" %%% "discipline-munit" % disciplineMunitVersion,
     ),
     Test / sourceGenerators += (Test / sourceManaged).map(Boilerplate.genTests).taskValue
   )
@@ -413,7 +413,7 @@ lazy val tests = circeCrossModule("tests")
   .jsSettings(
     libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test
   )
-  .dependsOn(core, parser, testing)
+  .dependsOn(core, parser, testing, jawn)
 
 lazy val hygiene = circeCrossModule("hygiene")
   .enablePlugins(NoPublishPlugin)

--- a/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
@@ -30,7 +30,7 @@ trait SortedKeysSuite { this: PrinterSuite =>
     }
   }
 
-  test("Sorting keys should be handle newlines consistently") {
+  test("Sorting keys should be handle \"\" consistently") {
     // From https://github.com/circe/circe/issues/1911
     val testMap: Map[String, List[Int]] = Map("4" -> Nil, "" -> Nil)
 

--- a/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
@@ -30,7 +30,7 @@ trait SortedKeysSuite { this: PrinterSuite =>
     }
   }
 
-  test("Sorting keys should be handle \"\" consistently") {
+  test("Sorting keys should handle \"\" consistently") {
     // From https://github.com/circe/circe/issues/1911
     val testMap: Map[String, List[Int]] = Map("4" -> Nil, "" -> Nil)
 

--- a/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
@@ -2,10 +2,9 @@ package io.circe
 
 import cats.kernel.instances.list._
 import cats.kernel.instances.string._
-import cats.kernel.instances.vector._
 import cats.syntax.eq._
 import io.circe.tests.PrinterSuite
-import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop._
 
 trait SortedKeysSuite { this: PrinterSuite =>
   test("Printer with sortKeys should sort the object keys (example)") {
@@ -25,9 +24,25 @@ trait SortedKeysSuite { this: PrinterSuite =>
   property("Printer with sortKeys should sort the object keys") {
     forAll { (value: Map[String, List[Int]]) =>
       val printed = printer.print(implicitly[Encoder[Map[String, List[Int]]]].apply(value))
-      val parsed = parser.parse(printed).toOption.flatMap(_.asObject).get
+      val parsed = TestParser.parser.parse(printed).toOption.flatMap(_.asObject).get
       val keys = parsed.keys.toVector
-      assert(keys.sorted === keys)
+      keys.sorted =? keys
+    }
+  }
+
+  test("Sorting keys should be handle newlines consistently") {
+    // From https://github.com/circe/circe/issues/1911
+    val testMap: Map[String, List[Int]] = Map("4" -> Nil, "" -> Nil)
+
+    val printed: String = printer.print(Encoder[Map[String, List[Int]]].apply(testMap))
+
+    TestParser.parser.parse(printed) match {
+      case Left(e) => fail(e.getLocalizedMessage, e)
+      case Right(value) =>
+        value.asObject.fold(fail(s"Expected object, but got ${value}.")) { value =>
+          val keys: Vector[String] = value.keys.toVector
+          assertEquals(keys.sorted, keys)
+        }
     }
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/TestParser.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/TestParser.scala
@@ -2,21 +2,22 @@ package io.circe
 
 import io.circe.jawn._
 
-/** Provides Jawn parser on both the JVM and JS. Technically we already have
-  * one on the JVM, but since this is test only code doing the platforming
-  * work seems like bloat here.
-  *
-  * The reason this is needed is for testing the printing of Json values
-  * complying to some order. The default JS parser will apply an order out of
-  * the box that deviates slightly from `Order[String]` and thus causes tests
-  * to fail. Note, the issue is not and has never been with the printer. The
-  * printer has been emitting values in the correct order, it is the parser
-  * that has been re-ordering values.
-  *
-  * @note If it is decided that circe should use Jawn on JS in the future
-  *       (https://github.com/circe/circe/issues/1941), then this can and
-  *       should be removed.
-  */
+/**
+ * Provides Jawn parser on both the JVM and JS. Technically we already have
+ * one on the JVM, but since this is test only code doing the platforming
+ * work seems like bloat here.
+ *
+ * The reason this is needed is for testing the printing of Json values
+ * complying to some order. The default JS parser will apply an order out of
+ * the box that deviates slightly from `Order[String]` and thus causes tests
+ * to fail. Note, the issue is not and has never been with the printer. The
+ * printer has been emitting values in the correct order, it is the parser
+ * that has been re-ordering values.
+ *
+ * @note If it is decided that circe should use Jawn on JS in the future
+ *       (https://github.com/circe/circe/issues/1941), then this can and
+ *       should be removed.
+ */
 private[circe] object TestParser {
   val parser: JawnParser =
     new JawnParser

--- a/modules/tests/shared/src/test/scala/io/circe/TestParser.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/TestParser.scala
@@ -1,0 +1,23 @@
+package io.circe
+
+import io.circe.jawn._
+
+/** Provides Jawn parser on both the JVM and JS. Technically we already have
+  * one on the JVM, but since this is test only code doing the platforming
+  * work seems like bloat here.
+  *
+  * The reason this is needed is for testing the printing of Json values
+  * complying to some order. The default JS parser will apply an order out of
+  * the box that deviates slightly from `Order[String]` and thus causes tests
+  * to fail. Note, the issue is not and has never been with the printer. The
+  * printer has been emitting values in the correct order, it is the parser
+  * that has been re-ordering values.
+  *
+  * @note If it is decided that circe should use Jawn on JS in the future
+  *       (https://github.com/circe/circe/issues/1941), then this can and
+  *       should be removed.
+  */
+private[circe] object TestParser {
+  val parser: JawnParser =
+    new JawnParser
+}


### PR DESCRIPTION
Fixes #1911

The `JSON.parse` call on native JS automatically and always sorts the keys when parsing, but slightly differently than the ordering prescribed by `Order[String]`. This causes tests on the sorted printers to fail under certain circumstances.

The fix for this is to use Jawn on JS to get consistent parsing. If we switch to Jawn in general for both JS and the JVM then we can undo this.

Note, the issue has never been with the printing, but always with the parsing.