### PR TITLE
Introduce forTypedProduct to work better with Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,7 +252,11 @@ lazy val numbers = circeCrossModule("numbers")
 lazy val core = circeCrossModule("core")
   .settings(
     libraryDependencies += "org.typelevel" %%% "cats-core" % catsVersion,
-    Compile / sourceGenerators += (Compile / sourceManaged).map(Boilerplate.gen).taskValue,
+    Compile / sourceGenerators += Def.task {
+      val managedSource = (Compile / sourceManaged).value
+      val currentScalaVersion = (Compile / scalaBinaryVersion).value
+      Boilerplate.gen(managedSource, currentScalaVersion)
+    },
     scalacOptions ~= (_.filterNot(Set("-source:3.0-migration")))
   )
   .dependsOn(numbers)

--- a/modules/core/shared/src/main/scala/io/circe/Codec.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Codec.scala
@@ -52,7 +52,7 @@ trait Codec[A] extends Decoder[A] with Encoder[A] {
 
 }
 
-object Codec extends ProductCodecs with ProductTupleCodecs with EnumerationCodecs {
+object Codec extends ProductCodecs with ProductTypedCodecs with EnumerationCodecs {
   def apply[A](implicit instance: Codec[A]): Codec[A] = instance
 
   implicit val codecInvariant: Invariant[Codec] = new Invariant[Codec] {

--- a/modules/core/shared/src/main/scala/io/circe/Codec.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Codec.scala
@@ -52,7 +52,7 @@ trait Codec[A] extends Decoder[A] with Encoder[A] {
 
 }
 
-object Codec extends ProductCodecs with EnumerationCodecs {
+object Codec extends ProductCodecs with ProductTupleCodecs with EnumerationCodecs {
   def apply[A](implicit instance: Codec[A]): Codec[A] = instance
 
   implicit val codecInvariant: Invariant[Codec] = new Invariant[Codec] {

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -135,6 +135,7 @@ trait Encoder[A] extends Serializable { self =>
 object Encoder
     extends TupleEncoders
     with ProductEncoders
+    with ProductTupleEncoders
     with LiteralEncoders
     with EnumerationEncoders
     with MidPriorityEncoders {

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -135,7 +135,7 @@ trait Encoder[A] extends Serializable { self =>
 object Encoder
     extends TupleEncoders
     with ProductEncoders
-    with ProductTupleEncoders
+    with ProductTypedEncoders
     with LiteralEncoders
     with EnumerationEncoders
     with MidPriorityEncoders {

--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -132,9 +132,9 @@ package examples {
     )
 
     val decodeBam: Decoder[Bam] = Decoder.forProduct2("w", "d")(Bam.apply)(Wub.decodeWub, implicitly)
-    val encodeBam: Encoder[Bam] = Encoder.forProduct2[Bam, Wub, Double]("w", "d") {
+    val encodeBam: Encoder[Bam] = Encoder.forTupleProduct2[Bam, Wub, Double]("w", "d") {
       case Bam(w, d) => (w, d)
-    }(Wub.encodeWub, implicitly, implicitly)
+    }(Wub.encodeWub, implicitly)
   }
 
   object Foo {

--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -132,7 +132,7 @@ package examples {
     )
 
     val decodeBam: Decoder[Bam] = Decoder.forProduct2("w", "d")(Bam.apply)(Wub.decodeWub, implicitly)
-    val encodeBam: Encoder[Bam] = Encoder.forTupleProduct2[Bam, Wub, Double]("w", "d") {
+    val encodeBam: Encoder[Bam] = Encoder.forTypedProduct2[Bam, Wub, Double]("w", "d") {
       case Bam(w, d) => (w, d)
     }(Wub.encodeWub, implicitly)
   }

--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -134,7 +134,7 @@ package examples {
     val decodeBam: Decoder[Bam] = Decoder.forProduct2("w", "d")(Bam.apply)(Wub.decodeWub, implicitly)
     val encodeBam: Encoder[Bam] = Encoder.forProduct2[Bam, Wub, Double]("w", "d") {
       case Bam(w, d) => (w, d)
-    }(Wub.encodeWub, implicitly)
+    }(Wub.encodeWub, implicitly, implicitly)
   }
 
   object Foo {

--- a/modules/tests/shared/src/test/scala-2.13/io/circe/RecursiveProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-2.13/io/circe/RecursiveProductSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.circe
+
+import syntax._
+import io.circe.tests.CirceMunitSuite
+
+class RecursiveProductSuite extends CirceMunitSuite {
+  test("recursive") {
+    case class Example(id: Int, children: List[Example])
+
+    implicit def codec: Codec[Example] = Codec.forTypedProduct2("id", "children")(Example.apply)(Example.unapply(_).get)
+
+    val example = Example(1, Nil)
+
+    val encoded = example.asJson
+    val decoded = encoded.as[Example]
+
+    assertEquals(decoded, Right(example))
+  }
+}

--- a/modules/tests/shared/src/test/scala-2/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-2/io/circe/FromProductSuite.scala
@@ -1,0 +1,34 @@
+package io.circe
+
+import syntax._
+import io.circe.tests.CirceMunitSuite
+
+class FromProductSuite extends CirceMunitSuite {
+
+  test("encode correctly Example(id: Int, value: String)") {
+    case class Example(id: Int, value: String)
+
+    implicit val encoder: Encoder[Example] = Encoder.forProduct2("id", "value")(Example.unapply(_).get)
+    implicit val decoder: Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
+
+    val example = Example(1, "hello")
+
+    val encoded = example.asJson
+    val decoded = encoded.as[Example]
+
+    assertEquals(decoded, Right(example))
+  }
+
+  test("codec encode/decode correctly Example(id: Int, value: String)") {
+    case class Example(id: Int, value: String)
+
+    implicit val encoder: Codec[Example] = Codec.forProduct2("id", "value")(Example.apply)(Example.unapply(_).get)
+
+    val example = Example(1, "hello")
+
+    val encoded = example.asJson
+    val decoded = encoded.as[Example]
+
+    assertEquals(decoded, Right(example))
+  }
+}

--- a/modules/tests/shared/src/test/scala-2/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-2/io/circe/FromProductSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.circe
 
 import syntax._
@@ -8,21 +24,7 @@ class FromProductSuite extends CirceMunitSuite {
   test("encode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
-    implicit val encoder: Encoder[Example] = Encoder.forProduct2("id", "value")(Example.unapply(_).get)
-    implicit val decoder: Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
-
-    val example = Example(1, "hello")
-
-    val encoded = example.asJson
-    val decoded = encoded.as[Example]
-
-    assertEquals(decoded, Right(example))
-  }
-
-  test("encode correctly Example(id: Int, value: String) tupled") {
-    case class Example(id: Int, value: String)
-
-    implicit val encoder: Encoder[Example] = Encoder.forTupledProduct2("id", "value")(Example.unapply(_).get)
+    implicit val encoder: Encoder[Example] = Encoder.forTupleProduct2("id", "value")(Example.unapply(_).get)
     implicit val decoder: Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
 
     val example = Example(1, "hello")
@@ -36,20 +38,7 @@ class FromProductSuite extends CirceMunitSuite {
   test("codec encode/decode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
-    implicit val encoder: Codec[Example] = Codec.forProduct2("id", "value")(Example.apply)(Example.unapply(_).get)
-
-    val example = Example(1, "hello")
-
-    val encoded = example.asJson
-    val decoded = encoded.as[Example]
-
-    assertEquals(decoded, Right(example))
-  }
-
-  test("codec encode/decode correctly Example(id: Int, value: String) tupled") {
-    case class Example(id: Int, value: String)
-
-    implicit val encoder: Codec[Example] = Codec.forTupledProduct2("id", "value")(Example.apply)(Example.unapply(_).get)
+    implicit val encoder: Codec[Example] = Codec.forTupleProduct2("id", "value")(Example.apply)(Example.unapply(_).get)
 
     val example = Example(1, "hello")
 

--- a/modules/tests/shared/src/test/scala-2/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-2/io/circe/FromProductSuite.scala
@@ -19,10 +19,37 @@ class FromProductSuite extends CirceMunitSuite {
     assertEquals(decoded, Right(example))
   }
 
+  test("encode correctly Example(id: Int, value: String) tupled") {
+    case class Example(id: Int, value: String)
+
+    implicit val encoder: Encoder[Example] = Encoder.forTupledProduct2("id", "value")(Example.unapply(_).get)
+    implicit val decoder: Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
+
+    val example = Example(1, "hello")
+
+    val encoded = example.asJson
+    val decoded = encoded.as[Example]
+
+    assertEquals(decoded, Right(example))
+  }
+
   test("codec encode/decode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
     implicit val encoder: Codec[Example] = Codec.forProduct2("id", "value")(Example.apply)(Example.unapply(_).get)
+
+    val example = Example(1, "hello")
+
+    val encoded = example.asJson
+    val decoded = encoded.as[Example]
+
+    assertEquals(decoded, Right(example))
+  }
+
+  test("codec encode/decode correctly Example(id: Int, value: String) tupled") {
+    case class Example(id: Int, value: String)
+
+    implicit val encoder: Codec[Example] = Codec.forTupledProduct2("id", "value")(Example.apply)(Example.unapply(_).get)
 
     val example = Example(1, "hello")
 

--- a/modules/tests/shared/src/test/scala-2/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-2/io/circe/FromProductSuite.scala
@@ -24,7 +24,7 @@ class FromProductSuite extends CirceMunitSuite {
   test("encode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
-    implicit val encoder: Encoder[Example] = Encoder.forTupleProduct2("id", "value")(Example.unapply(_).get)
+    implicit val encoder: Encoder[Example] = Encoder.forTypedProduct2("id", "value")(Example.unapply(_).get)
     implicit val decoder: Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
 
     val example = Example(1, "hello")
@@ -38,7 +38,7 @@ class FromProductSuite extends CirceMunitSuite {
   test("codec encode/decode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
-    implicit val encoder: Codec[Example] = Codec.forTupleProduct2("id", "value")(Example.apply)(Example.unapply(_).get)
+    implicit val encoder: Codec[Example] = Codec.forTypedProduct2("id", "value")(Example.apply)(Example.unapply(_).get)
 
     val example = Example(1, "hello")
 

--- a/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
@@ -1,0 +1,33 @@
+package io.circe
+
+import syntax.*
+import io.circe.tests.CirceMunitSuite
+
+class FromProductSuite extends CirceMunitSuite:
+
+    test("encode correctly Example(id: Int, value: String)") {
+        case class Example(id: Int, value: String)
+
+        given Encoder[Example] = Encoder.forProduct2("id", "value")(Tuple.fromProductTyped)
+        given Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
+
+        val example = Example(1, "hello")
+
+        val encoded = example.asJson
+        val decoded = encoded.as[Example]
+
+        assertEquals(decoded, Right(example))
+    }
+
+    test("codec encode/decode correctly Example(id: Int, value: String)") {
+        case class Example(id: Int, value: String)
+
+        given Codec[Example] = Codec.forProduct2("id", "value")(Example.apply)(Tuple.fromProductTyped)
+
+        val example = Example(1, "hello")
+
+        val encoded = example.asJson
+        val decoded = encoded.as[Example]
+
+        assertEquals(decoded, Right(example))
+    }

--- a/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
@@ -8,7 +8,7 @@ class FromProductSuite extends CirceMunitSuite:
   test("encode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
-    given Encoder[Example] = Encoder.forProduct2("id", "value")(Tuple.fromProductTyped[Example])
+    given Encoder[Example] = Encoder.forTupleProduct2("id", "value")(Tuple.fromProductTyped[Example])
     given Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
 
     val example = Example(1, "hello")
@@ -22,7 +22,7 @@ class FromProductSuite extends CirceMunitSuite:
   test("codec encode/decode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
-    given Codec[Example] = Codec.forProduct2("id", "value")(Example.apply)(Tuple.fromProductTyped[Example])
+    given Codec[Example] = Codec.forTupleProduct2("id", "value")(Example.apply)(Tuple.fromProductTyped[Example])
 
     val example = Example(1, "hello")
 

--- a/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.circe
 
 import syntax.*

--- a/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
@@ -5,29 +5,29 @@ import io.circe.tests.CirceMunitSuite
 
 class FromProductSuite extends CirceMunitSuite:
 
-    test("encode correctly Example(id: Int, value: String)") {
-        case class Example(id: Int, value: String)
+  test("encode correctly Example(id: Int, value: String)") {
+    case class Example(id: Int, value: String)
 
-        given Encoder[Example] = Encoder.forProduct2("id", "value")(Tuple.fromProductTyped)
-        given Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
+    given Encoder[Example] = Encoder.forProduct2("id", "value")(Tuple.fromProductTyped[Example])
+    given Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
 
-        val example = Example(1, "hello")
+    val example = Example(1, "hello")
 
-        val encoded = example.asJson
-        val decoded = encoded.as[Example]
+    val encoded = example.asJson
+    val decoded = encoded.as[Example]
 
-        assertEquals(decoded, Right(example))
-    }
+    assertEquals(decoded, Right(example))
+  }
 
-    test("codec encode/decode correctly Example(id: Int, value: String)") {
-        case class Example(id: Int, value: String)
+  test("codec encode/decode correctly Example(id: Int, value: String)") {
+    case class Example(id: Int, value: String)
 
-        given Codec[Example] = Codec.forProduct2("id", "value")(Example.apply)(Tuple.fromProductTyped)
+    given Codec[Example] = Codec.forProduct2("id", "value")(Example.apply)(Tuple.fromProductTyped[Example])
 
-        val example = Example(1, "hello")
+    val example = Example(1, "hello")
 
-        val encoded = example.asJson
-        val decoded = encoded.as[Example]
+    val encoded = example.asJson
+    val decoded = encoded.as[Example]
 
-        assertEquals(decoded, Right(example))
-    }
+    assertEquals(decoded, Right(example))
+  }

--- a/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/FromProductSuite.scala
@@ -24,7 +24,7 @@ class FromProductSuite extends CirceMunitSuite:
   test("encode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
-    given Encoder[Example] = Encoder.forTupleProduct2("id", "value")(Tuple.fromProductTyped[Example])
+    given Encoder[Example] = Encoder.forTypedProduct2("id", "value")(Tuple.fromProductTyped[Example])
     given Decoder[Example] = Decoder.forProduct2("id", "value")(Example.apply)
 
     val example = Example(1, "hello")
@@ -38,9 +38,22 @@ class FromProductSuite extends CirceMunitSuite:
   test("codec encode/decode correctly Example(id: Int, value: String)") {
     case class Example(id: Int, value: String)
 
-    given Codec[Example] = Codec.forTupleProduct2("id", "value")(Example.apply)(Tuple.fromProductTyped[Example])
+    given Codec[Example] = Codec.forTypedProduct2("id", "value")(Example.apply)(Tuple.fromProductTyped[Example])
 
     val example = Example(1, "hello")
+
+    val encoded = example.asJson
+    val decoded = encoded.as[Example]
+
+    assertEquals(decoded, Right(example))
+  }
+
+  test("recursive") {
+    case class Example(id: Int, children: List[Example])
+
+    given Codec[Example] = Codec.forTypedProduct2("id", "children")(Example.apply)(Tuple.fromProductTyped[Example])
+
+    val example = Example(1, Nil)
 
     val encoded = example.asJson
     val decoded = encoded.as[Example]

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -272,6 +272,10 @@ object Boilerplate {
         }
       val outputType = if (arity != 1) s"Product$arity[${`A..N`}]" else `A..N`
 
+      val deprecate = if (arity != 1)
+        s"""@deprecated(message="does not work correctly for Scala 3. Prefer forTupleProduct$arity", since="0.14.6")"""
+      else ""
+
       block"""
         |package io.circe
         |
@@ -279,6 +283,7 @@ object Boilerplate {
         -  /**
         -   * @group Product
         -   */
+        -  $deprecate
         -  final def forProduct$arity[Source, ${`A..N`}]($memberNames)(f: Source => $outputType)(implicit
         -    $instances
         -  ): Encoder.AsObject[Source] =
@@ -317,8 +322,8 @@ object Boilerplate {
         -  /**
         -   * @group Product
         -   */
-        -  final def forProduct$arity[Source, ${`A..N`}]($memberNames)(f: Source => $outputType)(implicit
-        -    $instances, dummy: DummyImplicit
+        -  final def forTupleProduct$arity[Source, ${`A..N`}]($memberNames)(f: Source => $outputType)(implicit
+        -    $instances
         -  ): Encoder.AsObject[Source] =
         -    new Encoder.AsObject[Source] {
         -      final def encodeObject(a: Source): JsonObject = {
@@ -365,6 +370,10 @@ object Boilerplate {
         }
       val outputType = if (arity != 1) s"Product$arity[${`A..N`}]" else `A..N`
 
+      val deprecate = if (arity != 1)
+        s"""@deprecated(message="does not work correctly for Scala 3. Prefer forTupleProduct$arity", since="0.14.6")"""
+      else ""
+
       block"""
         |package io.circe
         |
@@ -372,6 +381,7 @@ object Boilerplate {
         -  /**
         -   * @group Product
         -   */
+        -  $deprecate
         -  final def forProduct$arity[A, ${`A..N`}]($memberNames)(f: (${`A..N`}) => A)(g: A => $outputType)(implicit
         -    $decoderInstances,
         -    $encoderInstances
@@ -430,10 +440,9 @@ object Boilerplate {
         -  /**
         -   * @group Product
         -   */
-        -  final def forProduct$arity[A, ${`A..N`}]($memberNames)(f: (${`A..N`}) => A)(g: A => $outputType)(implicit
+        -  final def forTupleProduct$arity[A, ${`A..N`}]($memberNames)(f: (${`A..N`}) => A)(g: A => $outputType)(implicit
         -    $decoderInstances,
-        -    $encoderInstances,
-        -    dummy: DummyImplicit
+        -    $encoderInstances
         -  ): Codec.AsObject[A] =
         -    new Codec.AsObject[A] {
         -      final def apply(c: HCursor): Decoder.Result[A] = $result
@@ -466,6 +475,8 @@ object Boilerplate {
       val memberVariableNames = (0 until arity).map(i => s"s$i").mkString(", ")
       val memberArbitraryItems = (0 until arity).map(i => s"s$i <- Arbitrary.arbitrary[String]").mkString("; ")
 
+      val forProduct = if (arity != 1) "forTupleProduct" else "forProduct"
+
       block"""
         |package io.circe
         |
@@ -485,11 +496,11 @@ object Boilerplate {
         -      case Cc$arity($memberVariableNames) => ($memberVariableNames)
         -    }
         -    implicit val encodeCc$arity: Encoder[Cc$arity] =
-        -      Encoder.forProduct$arity($memberNames)(toTuple)
+        -      Encoder.$forProduct$arity($memberNames)(toTuple)
         -    implicit val decodeCc$arity: Decoder[Cc$arity] =
         -      Decoder.forProduct$arity($memberNames)(Cc$arity.apply)
         -    val codecForCc$arity: Codec[Cc$arity] =
-        -      Codec.forProduct$arity($memberNames)(Cc$arity.apply)(toTuple)
+        -      Codec.$forProduct$arity($memberNames)(Cc$arity.apply)(toTuple)
         -  }
         -  checkAll("Codec[Cc$arity]", CodecTests[Cc$arity].unserializableCodec)
         -  checkAll(

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -268,6 +268,19 @@ object Boilerplate {
         -      override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[Target] =
         -        $accumulatingResult
         -    }
+        -
+        -  /**
+        -   * @group Product
+        -   */
+        -  final def forTypedProduct$arity[Target, ${`A..N`}]($memberNames)(f: (${`A..N`}) => Target)(implicit
+        -    $instances
+        -  ): Decoder[Target] =
+        -    new Decoder[Target] {
+        -      final def apply(c: HCursor): Decoder.Result[Target] = $result
+        -
+        -      override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[Target] =
+        -        $accumulatingResult
+        -    }
         |}
       """
     }
@@ -432,7 +445,7 @@ object Boilerplate {
         -    implicit val encodeCc$arity: Encoder[Cc$arity] =
         -      Encoder.$forProduct$arity($memberNames)(toTuple)
         -    implicit val decodeCc$arity: Decoder[Cc$arity] =
-        -      Decoder.forProduct$arity($memberNames)(Cc$arity.apply)
+        -      Decoder.$forProduct$arity($memberNames)(Cc$arity.apply)
         -    val codecForCc$arity: Codec[Cc$arity] =
         -      Codec.$forProduct$arity($memberNames)(Cc$arity.apply)(toTuple)
         -  }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -298,7 +298,7 @@ object Boilerplate {
             case (tpe, i) => s"(name$tpe, encode$tpe(members._${i + 1}))"
           }.mkString(", ")
         }
-      val outputType = if (arity != 1) s"Product$arity[${`A..N`}]" else `A..N`
+      val outputType = outputTypeF(arity, `A..N`)
 
       block"""
         |package io.circe

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -268,7 +268,7 @@ object Boilerplate {
             case (tpe, i) => s"(name$tpe, encode$tpe(members._${i + 1}))"
           }.mkString(", ")
         }
-      val outputType = if (arity != 1) s"Product$arity[${`A..N`}]" else `A..N`
+      val outputType = if (arity != 1) s"(${`A..N`})" else `A..N`
 
       block"""
         |package io.circe
@@ -323,7 +323,7 @@ object Boilerplate {
             case (tpe, i) => s"(name$tpe, encode$tpe(members._${i + 1}))"
           }.mkString(", ")
         }
-      val outputType = if (arity != 1) s"Product$arity[${`A..N`}]" else `A..N`
+      val outputType = if (arity != 1) s"(${`A..N`})" else `A..N`
 
       block"""
         |package io.circe

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -283,8 +283,14 @@ object Boilerplate {
       import tv._
 
       val byn = if (byName) "=> " else ""
-      val instances = synTypes.map(tpe => s"encode$tpe: ${byn}Encoder[$tpe]").mkString(", ")
+      val prefixInstance = if (byName) "_" else ""
+      val instances = synTypes.map(tpe => s"${prefixInstance}encode$tpe: ${byn}Encoder[$tpe]").mkString(", ")
       val memberNames = synTypes.map(tpe => s"name$tpe: String").mkString(", ")
+      val cachedInstances =
+        if (byName)
+          synTypes.map(tpe => s"lazy val encode$tpe = ${prefixInstance}encode$tpe").mkString("", "\n-      ", "")
+        else ""
+
       val kvs =
         if (arity == 1) s"(name${synTypes.head}, encode${synTypes.head}(members))"
         else {
@@ -305,6 +311,7 @@ object Boilerplate {
         -    $instances
         -  ): Encoder.AsObject[Source] =
         -    new Encoder.AsObject[Source] {
+        -      $cachedInstances
         -      final def encodeObject(a: Source): JsonObject = {
         -        val members = f(a)
         -        JsonObject.fromIterable(Vector($kvs))
@@ -325,8 +332,17 @@ object Boilerplate {
       import tv._
 
       val byn = if (byName) "=> " else ""
-      val decoderInstances = synTypes.map(tpe => s"decode$tpe: ${byn}Decoder[$tpe]").mkString(", ")
-      val encoderInstances = synTypes.map(tpe => s"encode$tpe: ${byn}Encoder[$tpe]").mkString(", ")
+      val prefixInstance = if (byName) "_" else ""
+      val decoderInstances = synTypes.map(tpe => s"${prefixInstance}decode$tpe: ${byn}Decoder[$tpe]").mkString(", ")
+      val encoderInstances = synTypes.map(tpe => s"${prefixInstance}encode$tpe: ${byn}Encoder[$tpe]").mkString(", ")
+      val cachedEncoderInstances =
+        if (byName)
+          synTypes.map(tpe => s"lazy val encode$tpe = ${prefixInstance}encode$tpe").mkString("", "\n-      ", "")
+        else ""
+      val cachedDecoderInstances =
+        if (byName)
+          synTypes.map(tpe => s"lazy val decode$tpe = ${prefixInstance}decode$tpe").mkString("", "\n-      ", "")
+        else ""
 
       val memberNames = synTypes.map(tpe => s"name$tpe: String").mkString(", ")
 
@@ -363,6 +379,8 @@ object Boilerplate {
         -    $encoderInstances
         -  ): Codec.AsObject[A] =
         -    new Codec.AsObject[A] {
+        -      $cachedDecoderInstances
+        -      $cachedEncoderInstances
         -      final def apply(c: HCursor): Decoder.Result[A] = $result
         -
         -      override final def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -417,9 +417,9 @@ object Boilerplate {
         s"Decoder.accumulatingResultInstance.map$arity($accumulatingResults)(f)"
 
       val kvs =
-          synTypes.zipWithIndex.map {
-            case (tpe, i) => s"(name$tpe, encode$tpe(members._${i + 1}))"
-          }.mkString(", ")
+        synTypes.zipWithIndex.map {
+          case (tpe, i) => s"(name$tpe, encode$tpe(members._${i + 1}))"
+        }.mkString(", ")
 
       val outputType = s"(${`A..N`})"
 


### PR DESCRIPTION
When using Scala 3 we see that tuples does not always implement ProductN.
Meaning that we cannot use generic tuples, but only "named".

For instance while using the code

```Scala
case class Person(name: String, age: Int)

object Person:
 given Encoder.AsObject[Person] = Encoder.forProduct2("name",
"age")(Tuple.fromProductTyped[Person])
```

is not possible, since this type of tuple does not implement Product2.

The only way we can do this in Scala3 is by having an instance like
this:

```Scala
 given Encoder.AsObject[Person] = Encoder.forProduct2("name", "age")(x
=> (x.name, x.age))
```

which I think at least is less useful and more error prone than the
version above.

Related dotty bug. https://github.com/lampepfl/dotty/issues/15253

EDIT:

Added support for call-by-name implicits for Scala 2.13 and 3. to allow us to use recursive encoders.  