### PR TITLE
Fix nested wrapped element in scala 3 macro derivation

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.data.{ Chain, NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector, Validated }
+import cats.data.{ Chain, NonEmptyChain, NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector, Validated }
 import cats.kernel.Order
 
 import scala.collection.immutable.SortedSet
@@ -52,6 +52,8 @@ object Derivation {
       case _: (Map[k, t] *: ts) => Decoder.decodeMap(summonKeyDecoder[k], summonDecoder[t]) :: summonDecodersRec[ts]
       case _: (NonEmptyMap[k, t] *: ts) => // NonEmptyMap is a NewType, matching does not seem to work
         Decoder.decodeNonEmptyMap(summonKeyDecoder[k], summonOrder[k], summonDecoder[t]) :: summonDecodersRec[ts]
+      case _: (NonEmptyChain[t] *: ts) => // NonEmptyChain is a NewType, matching does not seem to work
+        Decoder.decodeNonEmptyChain(summonDecoder[t]) :: summonDecodersRec[ts]
       case _: (t *: ts) => summonDecoder[t] :: summonDecodersRec[ts]
     }
 
@@ -73,6 +75,8 @@ object Derivation {
       case _: (Map[k, t] *: ts) => Encoder.encodeMap(summonKeyEncoder[k], summonEncoder[t]) :: summonEncodersRec[ts]
       case _: (NonEmptyMap[k, t] *: ts) => // NonEmptyMap is a NewType, matching does not seem to work
         Encoder.encodeNonEmptyMap(summonKeyEncoder[k], summonEncoder[t]) :: summonEncodersRec[ts]
+      case _: (NonEmptyChain[t] *: ts) => // NonEmptyChain is a NewType, matching does not seem to work
+        Encoder.encodeNonEmptyChain(summonEncoder[t]) :: summonEncodersRec[ts]
       case _: (t *: ts) => summonEncoder[t] :: summonEncodersRec[ts]
     }
 }

--- a/modules/tests/shared/src/test/scala-3/io/circe/NestedDerivingSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/NestedDerivingSuite.scala
@@ -3,7 +3,7 @@ package io.circe
 import io.circe.tests.CirceMunitSuite
 import cats.Functor
 import cats.implicits.*
-import cats.data.{ Chain, NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector }
+import cats.data.{ Chain, NonEmptyChain, NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector }
 import cats.kernel.Order
 import io.circe.syntax.*
 import org.scalacheck.Prop.forAll
@@ -279,6 +279,36 @@ class NestedDerivingSuite extends CirceMunitSuite {
       assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
     }
   }
+  /*
+  // NonEmptyList
+  case class OuterNonEmptyChain(inner: NonEmptyChain[Inner])
+  implicit val genOuterNonEmptyChain: Gen[OuterNonEmptyChain] =
+    for {
+      head <- genInner
+      tail <- Gen.listOf(genInner)
+    } yield OuterNonEmptyChain(NonEmptyChain.of(head, tail*))
+  property("NonEmptyChain[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterNonEmptyChain] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterNonEmptyChain] = Encoder.AsObject.derived
+
+    forAll(genOuterNonEmptyChain) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("NonEmptyChain[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterNonEmptyChain] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterNonEmptyChain] = Decoder.derived
+
+    forAll(genOuterNonEmptyChain) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+   */
   // Map
   case class OuterMap(inner: Map[Long, Inner])
   implicit val genOuterMap: Gen[OuterMap] =
@@ -306,7 +336,7 @@ class NestedDerivingSuite extends CirceMunitSuite {
       assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
     }
   }
-/*
+  /*
   // NonEmptyMap
   case class OuterNonEmptyMap(inner: NonEmptyMap[Long, Inner])
   implicit val genOuterNonEmptyMap: Gen[OuterNonEmptyMap] =
@@ -339,5 +369,5 @@ class NestedDerivingSuite extends CirceMunitSuite {
       assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
     }
   }
-*/
+   */
 }

--- a/modules/tests/shared/src/test/scala-3/io/circe/NestedDerivingSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/NestedDerivingSuite.scala
@@ -1,0 +1,343 @@
+package io.circe
+
+import io.circe.tests.CirceMunitSuite
+import cats.Functor
+import cats.implicits.*
+import cats.data.{ Chain, NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector }
+import cats.kernel.Order
+import io.circe.syntax.*
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{ Gen, Prop }
+import org.typelevel.discipline.Laws
+
+import scala.collection.immutable.SortedSet
+
+class NestedDerivingSuite extends CirceMunitSuite {
+  case class Inner(a: Long)
+  val genInner: Gen[Inner] = Gen.long.map(Inner.apply)
+  implicit val innerOrder: Order[Inner] = Order.by(_.a)
+
+  // Option
+  case class OuterOption(inner: Option[Inner])
+  implicit val genOuterOption: Gen[OuterOption] = Gen.option(genInner).map(OuterOption.apply)
+  property("Option[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterOption] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterOption] = Encoder.AsObject.derived
+
+    forAll(genOuterOption) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("Option[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterOption] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterOption] = Decoder.derived
+
+    forAll(genOuterOption) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+
+  // List
+  case class OuterList(inner: List[Inner])
+  implicit val genOuterList: Gen[OuterList] = Gen.listOf(genInner).map(OuterList.apply)
+  property("List[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterList] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterList] = Encoder.AsObject.derived
+
+    forAll(genOuterList) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("List[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterList] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterList] = Decoder.derived
+
+    forAll(genOuterList) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+
+  // Vector
+  case class OuterVector(inner: Vector[Inner])
+  implicit val genOuterVector: Gen[OuterVector] = Gen.listOf(genInner).map(l => OuterVector(l.toVector))
+  property("Vector[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterVector] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterVector] = Encoder.AsObject.derived
+
+    forAll(genOuterVector) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("Vector[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterVector] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterVector] = Decoder.derived
+
+    forAll(genOuterVector) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+
+  // Seq
+  case class OuterSeq(inner: Seq[Inner])
+  implicit val genOuterSeq: Gen[OuterSeq] = Gen.listOf(genInner).map(OuterSeq.apply)
+  property("Seq[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterSeq] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterSeq] = Encoder.AsObject.derived
+
+    forAll(genOuterSeq) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("Seq[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterSeq] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterSeq] = Decoder.derived
+
+    forAll(genOuterSeq) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+
+  // Set
+  case class OuterSet(inner: Set[Inner])
+  implicit val genOuterSet: Gen[OuterSet] = Gen.listOf(genInner).map(list => OuterSet(list.toSet))
+  property("Set[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterSet] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterSet] = Encoder.AsObject.derived
+
+    forAll(genOuterSet) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("Set[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterSet] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterSet] = Decoder.derived
+
+    forAll(genOuterSet) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+
+  // SortedSet
+  case class OuterSortedSet(inner: SortedSet[Inner])
+  implicit val genOuterSortedSet: Gen[OuterSortedSet] =
+    Gen.listOf(genInner).map(list => OuterSortedSet(list.to(SortedSet)))
+  property("SortedSet[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterSortedSet] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterSortedSet] = Encoder.AsObject.derived
+
+    forAll(genOuterSortedSet) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("SortedSet[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterSortedSet] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterSortedSet] = Decoder.derived
+
+    forAll(genOuterSet) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+
+  // Chain
+  case class OuterChain(inner: Chain[Inner])
+  implicit val genOuterChain: Gen[OuterChain] = Gen.listOf(genInner).map(list => OuterChain(Chain.fromSeq(list)))
+  property("Chain[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterChain] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterChain] = Encoder.AsObject.derived
+
+    forAll(genOuterChain) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("Chain[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterChain] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterChain] = Decoder.derived
+
+    forAll(genOuterChain) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+
+  // NonEmptyVector
+  case class OuterNonEmptyVector(inner: NonEmptyVector[Inner])
+  implicit val genOuterNonEmptyVector: Gen[OuterNonEmptyVector] =
+    for {
+      head <- genInner
+      tail <- Gen.listOf(genInner)
+    } yield OuterNonEmptyVector(NonEmptyVector.of(head, tail*))
+  property("NonEmptyVector[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterNonEmptyVector] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterNonEmptyVector] = Encoder.AsObject.derived
+
+    forAll(genOuterNonEmptyVector) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("NonEmptyVector[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterNonEmptyVector] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterNonEmptyVector] = Decoder.derived
+
+    forAll(genOuterNonEmptyVector) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+  /*
+  // NonEmptySet
+  case class OuterNonEmptySet(inner: NonEmptySet[Inner])
+  implicit val genOuterNonEmptySet: Gen[OuterNonEmptySet] =
+    for {
+      head <- genInner
+      tail <- Gen.listOf(genInner)
+    } yield OuterNonEmptySet(NonEmptySet.of(head, tail*))
+  property("NonEmptySet[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterNonEmptySet] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterNonEmptySet] = Encoder.AsObject.derived
+
+    forAll(genOuterNonEmptySet) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("NonEmptySet[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterNonEmptySet] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterNonEmptySet] = Decoder.derived
+
+    forAll(genOuterNonEmptySet) { outer =>
+      val json = Json.obj("inner" -> outer.inner.toSortedSet.toSet.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+   */
+  // NonEmptyList
+  case class OuterNonEmptyList(inner: NonEmptyList[Inner])
+  implicit val genOuterNonEmptyList: Gen[OuterNonEmptyList] =
+    for {
+      head <- genInner
+      tail <- Gen.listOf(genInner)
+    } yield OuterNonEmptyList(NonEmptyList.of(head, tail*))
+  property("NonEmptyList[A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterNonEmptyList] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterNonEmptyList] = Encoder.AsObject.derived
+
+    forAll(genOuterNonEmptyList) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("NonEmptyList[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterNonEmptyList] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterNonEmptyList] = Decoder.derived
+
+    forAll(genOuterNonEmptyList) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map(i => Json.obj("a" -> i.a.asJson)).asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+  // Map
+  case class OuterMap(inner: Map[Long, Inner])
+  implicit val genOuterMap: Gen[OuterMap] =
+    Gen.listOf(genInner).map(list => OuterMap(list.map(i => (i.a -> i)).toMap))
+  property("Map[Long, A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterMap] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterMap] = Encoder.AsObject.derived
+
+    forAll(genOuterMap) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("Map[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterMap] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterMap] = Decoder.derived
+
+    forAll(genOuterMap) { outer =>
+      val json = Json.obj("inner" -> outer.inner.map {
+        case (k, v) => Json.obj(k.toString -> Json.obj("a" -> v.a.asJson))
+      }.asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+/*
+  // NonEmptyMap
+  case class OuterNonEmptyMap(inner: NonEmptyMap[Long, Inner])
+  implicit val genOuterNonEmptyMap: Gen[OuterNonEmptyMap] =
+    for {
+      head <- genInner
+      tail <- Gen.listOf(genInner)
+      headElement = head.a -> head
+      tailElements = tail.map(i => i.a -> i)
+    } yield OuterNonEmptyMap(NonEmptyMap.of(headElement, tailElements*))
+  property("NonEmptyMap[Long, A] Encoder derivation should not depend on not whether A is derived or not") {
+    val derivedEncoder: Encoder[OuterNonEmptyMap] = {
+      implicit val enc: Encoder[Inner] = Encoder.AsObject.derived
+      Encoder.AsObject.derived
+    }
+    val nonDerivedEncoder: Encoder[OuterNonEmptyMap] = Encoder.AsObject.derived
+
+    forAll(genOuterNonEmptyMap) { outer => assert(derivedEncoder(outer) == nonDerivedEncoder(outer)) }
+  }
+  property("NonEmptyMap[A] Decoder derivation should not depend on not whether A is derived or not") {
+    val derivedDecoder: Decoder[OuterNonEmptyMap] = {
+      implicit val enc: Decoder[Inner] = Decoder.derived
+      Decoder.derived
+    }
+    val nonDerivedDecoder: Decoder[OuterNonEmptyMap] = Decoder.derived
+
+    forAll(genOuterNonEmptyMap) { outer =>
+      val json = Json.obj("inner" -> outer.inner.toSortedMap.toMap.map {
+        case (k, v) => Json.obj(k.toString -> Json.obj("a" -> v.a.asJson))
+      }.asJson)
+      assert(derivedDecoder(json.hcursor) == nonDerivedDecoder(json.hcursor))
+    }
+  }
+*/
+}


### PR DESCRIPTION
This works stared as an attempt to fix #2001 but also should now fix #1695 

Derivation of systems like the one described below for standard F's like `List`, `Option` and `Vector` is currently not working unless the inner value (Inner here) ALSO is derived. This PR attempts to remedy this.

# System
## Not working
If we derive ONLY the wrapper type, it will derive wrongly (see below for issues for concrete wrappers). Here implicit vals are used, but using `given` or `derives` also has these issues because they all just forward to the same `derived` method. This is also what `generic.semiAuto.{deriveEncoder, deriveDecoder}` forwards too. This PR also does not include Codec instances as they also just forwards to the Decoder/Encoder implementations addressed here. 
```scala
type Wrapper[A] = Option[A]
case class Inner(a: Long)
case class Outer(inner: Wrapper[Inner])
implicit val encoder: Encoder[Outer] = Encoder.AsObject.derived
implicit val decoder: Decoder[Outer] = Decoder.derived
```

## Working
Given the same system as above with the added encoder/decoder of inner. They will be correct.
```scala
type Wrapper[A] = Option[A]
case class Inner(a: Long)
case class Outer(inner: Wrapper[Inner])
implicit val innerEncoder: Encoder[Inner] = Encoder.AsObject.derived
implicit val innerDecoder: Decoder[Inner] = Decoder.derived
implicit val encoder: Encoder[Outer] = Encoder.AsObject.derived
implicit val decoder: Decoder[Outer] = Decoder.derived
```

# Wrappers
There are 2 main ways wrappers currently break

## Option
Option breaks by encoding Some and None as values. *NOTE* that this means that `Codec` laws actually currently work since they all test round-tripping (which is upheld by encoding `Some` and `None` as objects) 👍 .
Console reproducer:
```scala
import io.circe.{Encoder, Decoder, Json}
case class Inner(a: Long)
case class Outer(inner: Option[Inner])
implicit val encoder: Encoder[Outer] = Encoder.AsObject.derived
implicit val decoder: Decoder[Outer] = Decoder.derived

encoder(Outer(Some(Inner(5))))
decoder(Json.obj("inner" -> Json.obj("a" -> Json.fromInt(5))).hcursor)
encoder(Outer(None))
decoder(Json.obj("inner" -> Json.Null).hcursor)
```
Gives console output
```scala
// defined case class Inner
// defined case class Outer
val encoder: io.circe.Encoder[Outer] = anon$1@27853997
val decoder: io.circe.Decoder[Outer] = anon$2@73e6b44c
val res0: io.circe.Json = {
  "inner" : {
    "Some" : {
      "value" : {
        "a" : 5
      }
    }
  }
}
val res1: io.circe.Decoder.Result[Outer] = Left(DecodingFailure(Option, List(DownField(inner))))
val res2: io.circe.Json = {
  "inner" : {
    "None$" : null
  }
}
val res3: io.circe.Decoder.Result[Outer] = Left(DecodingFailure(Option, List(DownField(inner))))
```

## List/Seq-like types
Changing Wrapper type from Option to something sequence like (List, Vector, Map, Chain, etcetc) fails to compile.
```scala
import io.circe.{Encoder, Decoder, Json}
case class Inner(a: Long)
case class Outer(inner: List[Inner])
implicit val encoder: Encoder[Outer] = Encoder.AsObject.derived
implicit val decoder: Decoder[Outer] = Decoder.derived

encoder(Outer(List(Inner(5))))
decoder(Json.obj("inner" -> Json.arr(Json.obj("a" -> Json.fromInt(5)))).hcursor)
encoder(Outer(List.empty))
decoder(Json.obj("inner" -> Json.arr).hcursor)
```

Console output
```scala
-- Error:
4 |implicit val encoder: Encoder[Outer] = Encoder.AsObject.derived
  |                                       ^^^^^^^^^^^^^^^^^^^^^^^^
  |                       Maximal number of successive inlines (32) exceeded,
  |                       Maybe this is caused by a recursive inline method?
  |                       You can use -Xmax-inlines to change the limit.
  | This location contains code that was inlined from rs$line$1:4
  | This location contains code that was inlined from Derivation.scala:85
  | This location contains code that was inlined from Derivation.scala:19
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:15
  | This location contains code that was inlined from Derivation.scala:88
  | This location contains code that was inlined from Derivation.scala:19
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:15
  | This location contains code that was inlined from Derivation.scala:88
  | This location contains code that was inlined from Derivation.scala:19
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:15
  | This location contains code that was inlined from Derivation.scala:88
  | This location contains code that was inlined from Derivation.scala:19
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:15
  | This location contains code that was inlined from Derivation.scala:88
  | This location contains code that was inlined from Derivation.scala:19
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:15
  | This location contains code that was inlined from Derivation.scala:88
  | This location contains code that was inlined from Derivation.scala:19
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:15
  | This location contains code that was inlined from Derivation.scala:88
  | This location contains code that was inlined from Derivation.scala:19
  | This location contains code that was inlined from Derivation.scala:76
  | This location contains code that was inlined from Derivation.scala:15
  | This location contains code that was inlined from Derivation.scala:88
-- Error:
5 |implicit val decoder: Decoder[Outer] = Decoder.derived
  |                                       ^^^^^^^^^^^^^^^
  |                       Maximal number of successive inlines (32) exceeded,
  |                       Maybe this is caused by a recursive inline method?
  |                       You can use -Xmax-inlines to change the limit.
  | This location contains code that was inlined from rs$line$1:5
  | This location contains code that was inlined from Derivation.scala:106
  | This location contains code that was inlined from Derivation.scala:24
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:14
  | This location contains code that was inlined from Derivation.scala:109
  | This location contains code that was inlined from Derivation.scala:24
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:14
  | This location contains code that was inlined from Derivation.scala:109
  | This location contains code that was inlined from Derivation.scala:24
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:14
  | This location contains code that was inlined from Derivation.scala:109
  | This location contains code that was inlined from Derivation.scala:24
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:14
  | This location contains code that was inlined from Derivation.scala:109
  | This location contains code that was inlined from Derivation.scala:24
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:14
  | This location contains code that was inlined from Derivation.scala:109
  | This location contains code that was inlined from Derivation.scala:24
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:14
  | This location contains code that was inlined from Derivation.scala:109
  | This location contains code that was inlined from Derivation.scala:24
  | This location contains code that was inlined from Derivation.scala:55
  | This location contains code that was inlined from Derivation.scala:14
  | This location contains code that was inlined from Derivation.scala:109
```


# Reason
Both of these issues are the same, just manifest themselves differently.  
Call stack of issue in object `Derivation` is
`derived -> summon{Decoders, Encoders} -> summon{Decoders, Encoders}Rec -> summon{Decoder, Encoder}`

SummonEncoder is implemented as:
```scala
  inline final def summonEncoder[A]: Encoder[A] = summonFrom {
    case encodeA: Encoder[A] => encodeA
    case _: Mirror.Of[A]     => Encoder.AsObject.derived[A]
  }
  ```
For Option this means that A=Option[Inner]. It then checks if there exists an `implicit Encoder[Option[Inner]]` in scope. In the companion object of `Encoder` there is an implicit def that can produce that for all types Option[A] where A has a Encoder. 
```scala 
implicit final def encodeOption[A](implicit e: Encoder[A]): Encoder[Option[A]] = ...
```

But here we do not have that! Since we chose/forgot to derive an `Encoder` for `Inner`, there is no `Encoder[A]` available. And such there is also no `Encoder[Option[A]]` available. Well, then the code goes to the next thing and attempts to make that. It can then introspect `Option` and see that.. Well this is a Sum type with 2 known members, `Some` and `None`. Okay then it can just derive those based on the classnames!

For `List` the same thing happens. But `List` is not as easy for the compiler to produce encoder/decoder for because.. Well at top level it is fine as a Sum type with `Nil` and `::`, but `::` contains another `List`, hence the recursive inline method issue.

# Solution
The solution used here is to match on the A in `summon{Decoders, Encoders}Rec` with the wrapper type and extract the wrapped type out. Then we forward that to `summon{Decoder, Encoder}` to get the inner value, then pass that on to the respective wrapper `encoder/decoder` implementation in the companion objects of `Encoder/Decoder`

The implemented tests are added in a scala-3 folder in tests module. They are able to compile for scala-2 also, but they would then need to depend on the generic modules for semiAuto derivation. Since that module is only a forwarder to core for scala 3, I felt they belonged more in core (even though that means they can only run on 3). If someone feels otherwise I can move them to generic and replace all derived with `semiAuto.derive{Encoder, Decoder}` to get them running on both 2 and 3.

# Fixed Wrappers
I have based this list on the wrapper that has instances custom made in the Encoder/Decoder companion objects.

- [x] Option
- [x] Map
- [x] Seq
- [x] Set
- [x] List
- [x] Vector
- [x] Chain
- [x] NonEmptyList
- [x] NonEmptyVector
- [ ] NonEmptySet
- [ ] NonEmptyMap
- [ ] NonEmptyChain