### PR TITLE
Fix Flaky ZoneId Decoding Test

### DIFF
--- a/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
@@ -162,7 +162,6 @@ class JavaTimeCodecSuite extends CirceMunitSuite {
           case DecodingFailure.Reason.CustomReason(_) => true
           case _                                      => false
         })
-        assert(decodingResult.swap.exists(_.message.contains("invalid format")))
       }
     )
   }


### PR DESCRIPTION
One of the test assertions was checking for a string in the error message which is not always present.

```scala
Left(DecodingFailure(Invalid ID for ZoneOffset, non numeric characters found: -0@, List()))
```

For

```scala
Decoder[ZoneId].decodeJson(Json.fromString("-\u0000"))
```