### PR TITLE
Add accumulative equivalent of `Json#as[A]`: `asAccumulating[A]`

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -107,6 +107,11 @@ sealed abstract class Json extends Product with Serializable {
   final def as[A](implicit d: Decoder[A]): Decoder.Result[A] = d(hcursor)
 
   /**
+   * Attempts to decode this JSON value to another data type, accumulating failures.
+   */
+  final def asAccumulating[A](implicit d: Decoder[A]): Decoder.AccumulatingResult[A] = d.decodeAccumulating(hcursor)
+
+  /**
    * Pretty-print this JSON value to a string using the given pretty-printer.
    */
   final def printWith(p: Printer): String = p.print(this)


### PR DESCRIPTION
This pull request adds an equivalent of `Json#as[A]` method but accumulating errors.

While `json.as[A]` is equivalent to `summon[Decoder[A]](json.hcursor)`, `json.asAccumulating[A]` is equivalent to `summon[Decoder[A]].decodeAccumulating(json.hcursor)`

Example:
```scala
case class User(name: String, age: Int)


Json.obj(name -> Json.fromInt(5), age -> Json.fromBoolean(true)).as[User]
//Only the first failure got returned
//Left(DecodingFailure(Got value '5' with wrong type, expecting string, List(DownField(name))))

Json.obj(name -> Json.fromInt(5), age -> Json.fromBoolean(true)).asAccumulating[User]
//All failures are returned
//Invalid(NonEmptyList(DecodingFailure(Got value '5' with wrong type, expecting string, List(DownField(name))), DecodingFailure(Int, List(DownField(age)))))
```