### PR TITLE
Normalize Module Name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,15 +87,16 @@ lazy val allSettings = Seq(
   Compile / scalastyleSources ++= (Compile / unmanagedSourceDirectories).value
 )
 
-/** Replace '/' with '-' in a path which represents a module name.
-  *
-  * The circe module's path is used in most cases to derive the module
-  * name. For some modules, this path includes sub-directories, e.g. scalafix
-  * internal rules. When this is the case, since the path is represented as a
-  * simple String, the '/' character can cause problems as the module name is
-  * used inside SBT and Coursier for Maven style artifact operations and '/'
-  * is not a valid character in a module name.
-  */
+/**
+ * Replace '/' with '-' in a path which represents a module name.
+ *
+ * The circe module's path is used in most cases to derive the module
+ * name. For some modules, this path includes sub-directories, e.g. scalafix
+ * internal rules. When this is the case, since the path is represented as a
+ * simple String, the '/' character can cause problems as the module name is
+ * used inside SBT and Coursier for Maven style artifact operations and '/'
+ * is not a valid character in a module name.
+ */
 def normalizeModuleNameFromPath(path: String): String =
   path.replaceAll("/", "-")
 

--- a/build.sbt
+++ b/build.sbt
@@ -87,11 +87,23 @@ lazy val allSettings = Seq(
   Compile / scalastyleSources ++= (Compile / unmanagedSourceDirectories).value
 )
 
+/** Replace '/' with '-' in a path which represents a module name.
+  *
+  * The circe module's path is used in most cases to derive the module
+  * name. For some modules, this path includes sub-directories, e.g. scalafix
+  * internal rules. When this is the case, since the path is represented as a
+  * simple String, the '/' character can cause problems as the module name is
+  * used inside SBT and Coursier for Maven style artifact operations and '/'
+  * is not a valid character in a module name.
+  */
+def normalizeModuleNameFromPath(path: String): String =
+  path.replaceAll("/", "-")
+
 def circeProject(path: String)(project: Project) = {
   val docName = path.split("[-/]").mkString(" ")
   project.settings(
     description := s"circe $docName",
-    moduleName := s"circe-$path",
+    moduleName := s"circe-${normalizeModuleNameFromPath(path)}",
     name := s"Circe $docName",
     allSettings
   )


### PR DESCRIPTION
This commit adds a new function to the `build.sbt` which normalizes the module name in the cases where the module name is derived from a path with a sub-directory, and thus will include a `'/'` character. These characters are replaced with `'-'`, which is both valid and probably want we intended in the first place.