### PR TITLE
Optimize JSON equality fail fast

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -584,13 +584,14 @@ object Json {
    */
   private[this] def isReal(value: Float): Boolean = java.lang.Float.isFinite(value)
 
-  private[this] final def arrayEq(x: Seq[Json], y: Seq[Json]): Boolean = {
+  private[this] final def arrayEq(x: Vector[Json], y: Vector[Json]): Boolean = {
+    if (x.length != y.length) return false
     val it0 = x.iterator
     val it1 = y.iterator
-    while (it0.hasNext && it1.hasNext) {
+    while (it0.hasNext) {
       if (Json.eqJson.neqv(it0.next(), it1.next())) return false
     }
-    it0.hasNext == it1.hasNext
+    true
   }
 
   implicit final val eqJson: Eq[Json] = Eq.instance {

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -196,7 +196,7 @@ sealed abstract class JsonObject extends Serializable {
    * @group Other
    */
   final override def equals(that: Any): Boolean = that match {
-    case that: JsonObject => toMap == that.toMap
+    case that: JsonObject => this.size == that.size && this.toMap == that.toMap
     case _                => false
   }
 


### PR DESCRIPTION
I maintain a library that performs a large number of `JSON` equality tests to the extend that it shows in performance profiles.

![tomap](https://user-images.githubusercontent.com/606963/222830706-be28a9da-0894-4e12-a80a-c720254b81da.png)

The main issue is that a Scala `Map` is created every time two `JsonObject` backed by a `LinkedHashMapJsonObject` are compared.

The first commit proposes to detect possible differences by first comparing the size of the fields which is O(1), thus avoiding the creation of additional Maps.

A second commit applies a similar strategy to the `JArray` comparison to shortcut the Vector traversals. 

Those two optimizations should be able to save a large number of allocations on trivial failing comparisons.
  