### PR TITLE
Add JsonObject#toJson

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -118,6 +118,13 @@ sealed abstract class JsonObject extends Serializable {
   final def toVector: Vector[(String, Json)] = toIterable.toVector
 
   /**
+   * Return this `JsonObject` as a `Json`
+   *
+   * @group Conversions
+   */
+  final def toJson: Json = Json.fromJsonObject(this)
+
+  /**
    * Insert the given key and value.
    *
    * @group Modification


### PR DESCRIPTION
This PR adds a method to `JsonObject` that promotes it to `Json`. It was already possible to go from JsonObject to Json, but I find this a little cleaner and more convenient.

When writing tests, I find it convenient to build test subjects with `JsonObject(...)` rather than `Json.obj` because it lets me call `.add` to poke in an extra field where necessary. This will then involve either calling `Json.fromJsonObject(obj).nospaces` which is rather verbose and mixes prefix and postfix function application, or `obj.asJson.nospaces`, which involves a syntax import and type class usage. I don't really like using the type class here because "promoting from JsonObject to Json" is not really the _intention_ of the `Encoder` type class (although it _does it_ perfectly well). It's also slightly less discoverable, since the right import is needed for the method to appear.

Another alternative offering the same level of convenience is duplicating `nospaces` `spaces2` `spaces4` and others to `JsonObject`, which I'd also be happy with, but I suspect that would be annoying to maintain (since it would be easy for them to get out of sync).

As for tests, I wasn't really sure how to test this. I could write a property-based test to ensure that `Json.fromJsonObject(obj) === obj.toJson` but that seems a bit vacuous.