### PR TITLE
feat: allow to derive enumeration codec for nested sealed hierarchies

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumDecoder.scala
@@ -4,12 +4,13 @@ import scala.deriving.Mirror
 import scala.compiletime.constValue
 import Predef.genericArrayOps
 import io.circe.{ Decoder, DecodingFailure, HCursor }
+import scala.collection.mutable.ArraySeq
 
 trait ConfiguredEnumDecoder[A] extends Decoder[A]
 object ConfiguredEnumDecoder:
   inline final def derived[A](using conf: Configuration)(using mirror: Mirror.SumOf[A]): ConfiguredEnumDecoder[A] =
-    val cases = summonSingletonCases[mirror.MirroredElemTypes, A](constValue[mirror.MirroredLabel])
-    val labels = summonLabels[mirror.MirroredElemLabels].toArray.map(conf.transformConstructorNames)
+    val cases = summonSingletonCases[mirror.MirroredElemTypes, A](constValue[mirror.MirroredLabel]).toVector
+    val labels = summonLabelsRecursively[mirror.MirroredElemTypes].toArray.map(conf.transformConstructorNames)
     new ConfiguredEnumDecoder[A]:
       def apply(c: HCursor): Decoder.Result[A] =
         c.as[String].flatMap { caseName =>

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumEncoder.scala
@@ -10,9 +10,19 @@ object ConfiguredEnumEncoder:
   inline final def derived[A](using conf: Configuration)(using mirror: Mirror.SumOf[A]): ConfiguredEnumEncoder[A] =
     // Only used to validate if all cases are singletons
     summonSingletonCases[mirror.MirroredElemTypes, A](constValue[mirror.MirroredLabel])
-    val labels = summonLabels[mirror.MirroredElemLabels].toArray.map(conf.transformConstructorNames)
+    val typeTests = summonTypeTestRecursively[mirror.MirroredElemTypes, A]
+    val labels = summonLabelsRecursively[mirror.MirroredElemTypes].toArray.map(conf.transformConstructorNames)
+
+    def findIndex(a: A): Int =
+      def loop(n: Int): Int = 
+        if n >= typeTests.length then mirror.ordinal(a) // well this should never happen :|
+        else if typeTests(n).unapply(a).isDefined then n
+        else loop(n + 1)
+      loop(0)
     new ConfiguredEnumEncoder[A]:
-      def apply(a: A): Json = Json.fromString(labels(mirror.ordinal(a)))
+      def apply(a: A): Json =
+        val index = findIndex(a)
+        Json.fromString(labels(index))
 
   inline final def derive[A: Mirror.SumOf](
     transformConstructorNames: String => String = Configuration.default.transformConstructorNames

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -3,11 +3,33 @@ package io.circe.derivation
 import scala.compiletime.{ codeOf, constValue, erasedValue, error, summonFrom, summonInline }
 import scala.deriving.Mirror
 import io.circe.{ Codec, Decoder, Encoder }
+import scala.reflect.TypeTest
 
 private[circe] inline final def summonLabels[T <: Tuple]: List[String] =
   inline erasedValue[T] match
     case _: EmptyTuple => Nil
     case _: (t *: ts)  => constValue[t].asInstanceOf[String] :: summonLabels[ts]
+
+private[circe] inline final def summonLabelsRecursively[T <: Tuple]: List[String] =
+  inline erasedValue[T] match
+    case _: EmptyTuple => Nil
+    case _: (t *: ts) =>
+      inline summonInline[Mirror.Of[t]] match
+        case mirror: Mirror.SumOf[t] =>
+          Predef.println(s"sum of: ${constValue[mirror.MirroredLabel]}")
+          summonLabelsRecursively[mirror.MirroredElemTypes] ::: summonLabelsRecursively[ts]
+        case mirror: Mirror.ProductOf[t] =>
+          Predef.println(s"product of: ${constValue[mirror.MirroredLabel]}")
+          constValue[mirror.MirroredLabel] :: summonLabelsRecursively[ts]
+
+private inline def summonTypeTestRecursively[T <: Tuple, A]: List[TypeTest[A, ?]] = inline erasedValue[T] match
+    case _: (t *: ts)  =>
+        inline summonInline[Mirror.Of[t]] match
+            case mirror: Mirror.SumOf[t]     =>
+                summonTypeTestRecursively[mirror.MirroredElemTypes, A] ::: summonTypeTestRecursively[ts, A]
+            case mirror: Mirror.ProductOf[t] =>
+                summon[TypeTest[A, t]] :: summonTypeTestRecursively[ts, A]
+    case _: EmptyTuple => Nil
 
 private[circe] inline final def summonEncoders[T <: Tuple](using Configuration): List[Encoder[_]] =
   inline erasedValue[T] match
@@ -36,6 +58,9 @@ private[circe] inline def summonSingletonCases[T <: Tuple, A](inline typeName: A
     case _: EmptyTuple => Nil
     case _: (h *: t) =>
       inline summonInline[Mirror.Of[h]] match
-        case m: Mirror.Singleton => m.fromProduct(EmptyTuple).asInstanceOf[A] :: summonSingletonCases[t, A](typeName)
+        case m: Mirror.Singleton => 
+          m.fromProduct(EmptyTuple).asInstanceOf[A] :: summonSingletonCases[t, A](typeName)
+        case m: Mirror.SumOf[h]  => 
+          summonSingletonCases[m.MirroredElemTypes, A](constValue[m.MirroredLabel]) ::: summonSingletonCases[t, A](typeName)
         case m: Mirror =>
           error("Enum " + codeOf(typeName) + " contains non singleton case " + codeOf(constValue[m.MirroredLabel]))

--- a/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredEnumDerivesSuites.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredEnumDerivesSuites.scala
@@ -27,6 +27,24 @@ object ConfiguredEnumDerivesSuites:
         Gen.const(IntercardinalDirections.NorthWest)
       )
     )
+
+  sealed trait Animal
+
+  object Animal:
+    sealed trait Mammal extends Animal
+    case object Dog extends Mammal
+    case object Cat extends Mammal
+    case object Bird extends Animal
+
+    given Eq[Animal] = Eq.fromUniversalEquals
+    given Arbitrary[Animal] = Arbitrary(
+      Gen.oneOf(
+        Gen.const(Animal.Dog),
+        Gen.const(Animal.Cat),
+        Gen.const(Animal.Bird)
+      )
+    )
+
 class ConfiguredEnumDerivesSuites extends CirceMunitSuite:
   import ConfiguredEnumDerivesSuites.*
 
@@ -54,6 +72,30 @@ class ConfiguredEnumDerivesSuites extends CirceMunitSuite:
     val failure = DecodingFailure("enum IntercardinalDirections does not contain case: NorthNorth", List())
     assert(Decoder[IntercardinalDirections].decodeJson(json) === Left(failure))
     assert(Decoder[IntercardinalDirections].decodeAccumulating(json.hcursor) === Validated.invalidNel(failure))
+  }
+
+  test("nested hierarchy") {
+    given Configuration = Configuration.default
+    given Codec[Animal] = ConfiguredEnumCodec.derived
+    {
+      val animal = Animal.Dog
+      val json = Json.fromString("Dog")
+      assertEquals(summon[Encoder[Animal]].apply(animal), json)
+      assertEquals(summon[Decoder[Animal]].decodeJson(json), Right(animal))
+    }
+
+    {
+      val animal = Animal.Bird
+      val json = Json.fromString("Bird")
+      assertEquals(summon[Encoder[Animal]].apply(animal), json)
+      assertEquals(summon[Decoder[Animal]].decodeJson(json), Right(animal))
+    }
+  }
+
+  {
+    given Configuration = Configuration.default
+    given Codec[Animal] = ConfiguredEnumCodec.derived
+    checkAll("Codec[Animal] (default configuration)", CodecTests[Animal].codec)
   }
 
   test("Configuration#transformConstructorNames should support constructor name transformation with snake_case") {


### PR DESCRIPTION
Hey folks! Current logic for deriving enum codec lacks ability to derive it for nested hierarchies. What do you think about adding it? In case answer is yes, here's the PR.

There is one caveat though, `Mirror.Of[A].ordinal` doesn't work as expected for nested hierarchies, that's why I needed to use `summonTypeTestRecursively` (credits to @odomontois and https://github.com/evolution-gaming/derivation). Here's scala-cli snippet for quick showcase what's the problem
```scala
//> using scala "3.3.0"

import scala.deriving.Mirror

sealed trait Animal
object Animal:
  sealed trait Mammal extends Animal
  case object Dog extends Mammal
  case object Cat extends Mammal
  case object Bird extends Animal

object Main extends App {
  val mirror = summon[Mirror.Of[Animal]]
  assert(mirror.ordinal(Animal.Dog) == 0)
  assert(mirror.ordinal(Animal.Cat) == 0) // <<< HERE
  assert(mirror.ordinal(Animal.Bird) == 1)
}
```