### PR TITLE
Add `autoRecursiveDerivation` config option

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/Configuration.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/Configuration.scala
@@ -21,7 +21,8 @@ case class Configuration(
   transformConstructorNames: String => String = Predef.identity,
   useDefaults: Boolean = false,
   discriminator: Option[String] = None,
-  strictDecoding: Boolean = false
+  strictDecoding: Boolean = false,
+  autoRecursiveDerivation: Boolean = true
 ):
   def withTransformMemberNames(f: String => String): Configuration = copy(transformMemberNames = f)
   def withSnakeCaseMemberNames: Configuration = withTransformMemberNames(renaming.snakeCase)
@@ -43,3 +44,6 @@ case class Configuration(
 
   def withStrictDecoding: Configuration = copy(strictDecoding = true)
   def withoutStrictDecoding: Configuration = copy(strictDecoding = false)
+
+  def withAutoRecursiveDerivation: Configuration = copy(autoRecursiveDerivation = true)
+  def withoutAutoRecursiveDerivation: Configuration = copy(autoRecursiveDerivation = false)

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -41,8 +41,16 @@ object ConfiguredCodec:
     transformConstructorNames: String => String = Configuration.default.transformConstructorNames,
     useDefaults: Boolean = Configuration.default.useDefaults,
     discriminator: Option[String] = Configuration.default.discriminator,
-    strictDecoding: Boolean = Configuration.default.strictDecoding
+    strictDecoding: Boolean = Configuration.default.strictDecoding,
+    autoRecursiveDerivation: Boolean = Configuration.default.autoRecursiveDerivation
   ): ConfiguredCodec[A] =
     derived[A](using
-      Configuration(transformMemberNames, transformConstructorNames, useDefaults, discriminator, strictDecoding)
+      Configuration(
+        transformMemberNames,
+        transformConstructorNames,
+        useDefaults,
+        discriminator,
+        strictDecoding,
+        autoRecursiveDerivation
+      )
     )

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -201,8 +201,16 @@ object ConfiguredDecoder:
     transformConstructorNames: String => String = Configuration.default.transformConstructorNames,
     useDefaults: Boolean = Configuration.default.useDefaults,
     discriminator: Option[String] = Configuration.default.discriminator,
-    strictDecoding: Boolean = Configuration.default.strictDecoding
+    strictDecoding: Boolean = Configuration.default.strictDecoding,
+    autoRecursiveDerivation: Boolean = Configuration.default.autoRecursiveDerivation
   ): ConfiguredDecoder[A] =
     derived[A](using
-      Configuration(transformMemberNames, transformConstructorNames, useDefaults, discriminator, strictDecoding)
+      Configuration(
+        transformMemberNames,
+        transformConstructorNames,
+        useDefaults,
+        discriminator,
+        strictDecoding,
+        autoRecursiveDerivation
+      )
     )

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
@@ -56,6 +56,15 @@ object ConfiguredEncoder:
   inline final def derive[A: Mirror.Of](
     transformMemberNames: String => String = Configuration.default.transformMemberNames,
     transformConstructorNames: String => String = Configuration.default.transformConstructorNames,
-    discriminator: Option[String] = Configuration.default.discriminator
+    discriminator: Option[String] = Configuration.default.discriminator,
+    autoRecursiveDerivation: Boolean = Configuration.default.autoRecursiveDerivation
   ): ConfiguredEncoder[A] =
-    derived[A](using Configuration(transformMemberNames, transformConstructorNames, useDefaults = false, discriminator))
+    derived[A](using
+      Configuration(
+        transformMemberNames,
+        transformConstructorNames,
+        useDefaults = false,
+        discriminator,
+        autoRecursiveDerivation
+      )
+    )

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -14,22 +14,38 @@ private[circe] inline final def summonEncoders[T <: Tuple](using Configuration):
     case _: EmptyTuple => Nil
     case _: (t *: ts)  => summonEncoder[t] :: summonEncoders[ts]
 
-private[circe] inline final def summonEncoder[A](using Configuration): Encoder[A] =
+private[circe] inline final def summonEncoderAutoRecurse[A](using conf: Configuration): Encoder[A] =
   summonFrom {
     case encodeA: Encoder[A] => encodeA
     case _: Mirror.Of[A]     => ConfiguredEncoder.derived[A]
   }
+
+private[circe] inline final def summonEncoderNoAutoRecurse[A](using conf: Configuration): Encoder[A] =
+  summonFrom {
+    case encodeA: Encoder[A] => encodeA
+  }
+
+private[circe] inline final def summonEncoder[A](using conf: Configuration): Encoder[A] =
+  if (conf.autoRecursiveDerivation) summonEncoderAutoRecurse[A] else summonEncoderNoAutoRecurse[A]
 
 private[circe] inline final def summonDecoders[T <: Tuple](using Configuration): List[Decoder[_]] =
   inline erasedValue[T] match
     case _: EmptyTuple => Nil
     case _: (t *: ts)  => summonDecoder[t] :: summonDecoders[ts]
 
-private[circe] inline final def summonDecoder[A](using Configuration): Decoder[A] =
+private[circe] inline final def summonDecoderAutoRecurse[A](using Configuration): Decoder[A] =
   summonFrom {
     case decodeA: Decoder[A] => decodeA
     case _: Mirror.Of[A]     => ConfiguredDecoder.derived[A]
   }
+
+private[circe] inline final def summonDecoderNoAutoRecurse[A](using conf: Configuration): Decoder[A] =
+  summonFrom {
+    case decodeA: Decoder[A] => decodeA
+  }
+
+private[circe] inline final def summonDecoder[A](using conf: Configuration): Decoder[A] =
+  if (conf.autoRecursiveDerivation) summonDecoderAutoRecurse[A] else summonDecoderNoAutoRecurse[A]
 
 private[circe] inline def summonSingletonCases[T <: Tuple, A](inline typeName: Any): List[A] =
   inline erasedValue[T] match

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -23,6 +23,10 @@ private[circe] inline final def summonEncoderAutoRecurse[A](using conf: Configur
 private[circe] inline final def summonEncoderNoAutoRecurse[A](using conf: Configuration): Encoder[A] =
   summonFrom {
     case encodeA: Encoder[A] => encodeA
+    case m: Mirror.Of[A] =>
+      inline m match
+        case _: Mirror.Singleton => ConfiguredEncoder.derived[A]
+        case m: Mirror           => error("Failed to find an instance of Encoder[" + constValue[m.MirroredLabel] + "]")
   }
 
 private[circe] inline final def summonEncoder[A](using conf: Configuration): Encoder[A] =
@@ -42,6 +46,10 @@ private[circe] inline final def summonDecoderAutoRecurse[A](using Configuration)
 private[circe] inline final def summonDecoderNoAutoRecurse[A](using conf: Configuration): Decoder[A] =
   summonFrom {
     case decodeA: Decoder[A] => decodeA
+    case m: Mirror.Of[A] =>
+      inline m match
+        case _: Mirror.Singleton => ConfiguredDecoder.derived[A]
+        case m: Mirror           => error("Failed to find an instance of Decoder[" + constValue[m.MirroredLabel] + "]")
   }
 
 private[circe] inline final def summonDecoder[A](using conf: Configuration): Decoder[A] =


### PR DESCRIPTION
Resolves #2126

This adds an `autoRecursiveDerivation: Boolean` config option that controls whether derivation should auto-recurse when it encounters a nested type with a `Mirror` instance. The default behavior is unchanged -- derivation will auto-recurse. When the config option is set to `false`, auto-recursion will only happen for types with a `Mirror.Singleton` instance, i.e. `case object`s. This allows for code like this to still compile:

```scala
sealed trait Foo
case object Bar extends Foo

given conf: Configuration = Configuration.default.withoutAutoRecursiveDerivation

// Compiles even though we haven't defined an `Encoder[Bar.type]`
Encoder.derivedConfigured[Foo]
```

## Note on binary compatibility

The change to `Configuration` is currently not binary compatible -- is this an issue? If so, I think there are ways to get it to be binary compatible but they'd likely be verbose