### PR TITLE
munit 1.0.0-M8 with test adaptation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ val refinedNativeVersion = "0.10.3"
 val paradiseVersion = "2.1.1"
 
 val scalaCheckVersion = "1.17.0"
-val munitVersion = "1.0.0-M7"
+val munitVersion = "1.0.0-M8"
 val disciplineVersion = "1.5.1"
 val disciplineScalaTestVersion = "2.2.0"
 val disciplineMunitVersion = "2.0.0-M3"

--- a/modules/tests/jvm-native/src/main/scala/io/circe/tests/PlatformSpecificPrinterTests.scala
+++ b/modules/tests/jvm-native/src/main/scala/io/circe/tests/PlatformSpecificPrinterTests.scala
@@ -5,5 +5,5 @@ import io.circe.testing.PrinterTests
 
 trait PlatformSpecificPrinterTests { self: PrinterSuite =>
   // Temporarily JVM-only because of problems round-tripping in Scala.js.
-  checkAll("Printing Long", PrinterTests[Long].printer(printer, parser))
+  checkAll("Printing Long", PrinterTests[Long].printer(circePrinter, parser))
 }

--- a/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -6,25 +6,28 @@ import io.circe.testing.PrinterTests
 import java.nio.charset.StandardCharsets.UTF_8
 import org.scalacheck.Prop._
 
-class PrinterSuite(val printer: Printer, val parser: Parser) extends CirceMunitSuite with PlatformSpecificPrinterTests {
-  checkAll("Printing Unit", PrinterTests[Unit].printer(printer, parser))
-  checkAll("Printing Boolean", PrinterTests[Boolean].printer(printer, parser))
-  checkAll("Printing Char", PrinterTests[Char].printer(printer, parser))
-  checkAll("Printing Float", PrinterTests[Float].printer(printer, parser))
-  checkAll("Printing Double", PrinterTests[Double].printer(printer, parser))
-  checkAll("Printing Short", PrinterTests[Short].printer(printer, parser))
-  checkAll("Printing Int", PrinterTests[Int].printer(printer, parser))
-  checkAll("Printing Map", PrinterTests[Map[String, List[Int]]].printer(printer, parser))
+class PrinterSuite(val circePrinter: Printer, val parser: Parser)
+    extends CirceMunitSuite
+    with PlatformSpecificPrinterTests {
+
+  checkAll("Printing Unit", PrinterTests[Unit].printer(circePrinter, parser))
+  checkAll("Printing Boolean", PrinterTests[Boolean].printer(circePrinter, parser))
+  checkAll("Printing Char", PrinterTests[Char].printer(circePrinter, parser))
+  checkAll("Printing Float", PrinterTests[Float].printer(circePrinter, parser))
+  checkAll("Printing Double", PrinterTests[Double].printer(circePrinter, parser))
+  checkAll("Printing Short", PrinterTests[Short].printer(circePrinter, parser))
+  checkAll("Printing Int", PrinterTests[Int].printer(circePrinter, parser))
+  checkAll("Printing Map", PrinterTests[Map[String, List[Int]]].printer(circePrinter, parser))
 
   property("printToByteBuffer should match print")(printToBufferProp)
   private lazy val printToBufferProp = forAll { (json: Json, predictSize: Boolean) =>
-    val buffer = printer.copy(predictSize = predictSize).printToByteBuffer(json)
+    val buffer = circePrinter.copy(predictSize = predictSize).printToByteBuffer(json)
 
     val bytes = new Array[Byte](buffer.limit)
     buffer.get(bytes)
 
     val asString = new String(bytes, UTF_8)
-    val expected = printer.print(json)
+    val expected = circePrinter.print(json)
 
     assert(asString == expected)
   }

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -9,7 +9,7 @@ class Spaces4PrinterSuite extends PrinterSuite(Printer.spaces4, parser.`package`
 class UnicodeEscapePrinterSuite extends PrinterSuite(Printer.noSpaces.copy(escapeNonAscii = true), parser.`package`) {
   import io.circe.syntax._
   test("Printing object should unicode-escape all non-ASCII chars") {
-    val actual = Json.obj("0 ℃" := "32 ℉").printWith(printer)
+    val actual = Json.obj("0 ℃" := "32 ℉").printWith(circePrinter)
     val expected = "{\"0 \\u2103\":\"32 \\u2109\"}"
     assertEquals(actual, expected)
   }

--- a/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/SortedKeysSuite.scala
@@ -14,7 +14,7 @@ trait SortedKeysSuite { this: PrinterSuite =>
       "three" -> Json.fromInt(3)
     )
 
-    parser.parse(printer.print(input)).toOption.flatMap(_.asObject) match {
+    parser.parse(circePrinter.print(input)).toOption.flatMap(_.asObject) match {
       case None => fail("Cannot parse result back to an object")
       case Some(output) =>
         assertEquals(output.keys.toList, List("one", "three", "two"))
@@ -23,7 +23,7 @@ trait SortedKeysSuite { this: PrinterSuite =>
 
   property("Printer with sortKeys should sort the object keys") {
     forAll { (value: Map[String, List[Int]]) =>
-      val printed = printer.print(implicitly[Encoder[Map[String, List[Int]]]].apply(value))
+      val printed = circePrinter.print(implicitly[Encoder[Map[String, List[Int]]]].apply(value))
       val parsed = TestParser.parser.parse(printed).toOption.flatMap(_.asObject).get
       val keys = parsed.keys.toVector
       keys.sorted =? keys
@@ -34,7 +34,7 @@ trait SortedKeysSuite { this: PrinterSuite =>
     // From https://github.com/circe/circe/issues/1911
     val testMap: Map[String, List[Int]] = Map("4" -> Nil, "" -> Nil)
 
-    val printed: String = printer.print(Encoder[Map[String, List[Int]]].apply(testMap))
+    val printed: String = circePrinter.print(Encoder[Map[String, List[Int]]].apply(testMap))
 
     TestParser.parser.parse(printed) match {
       case Left(e) => fail(e.getLocalizedMessage, e)


### PR DESCRIPTION
https://github.com/scalameta/munit/pull/640 requires to change the name of the `io.circe.Printer` val.

closes: #2155