### PR TITLE
fix #2135

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/Default.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/Default.scala
@@ -38,7 +38,9 @@ object Default:
     new Default[T]:
       type Out = Tuple.Map[mirror.MirroredElemTypes, Option]
       lazy val defaults: Out =
-        val size = constValue[Tuple.Size[mirror.MirroredElemTypes]]
+        // summon the size of mirror.MirroredElemLabels (not mirror.MirroredElemTypes) because
+        // in some rare edge cases, the latter fails (and both always have the same size)
+        val size = constValue[Tuple.Size[mirror.MirroredElemLabels]]
         getDefaults[T](size).asInstanceOf[Out]
 
   inline def getDefaults[T](inline s: Int): Tuple = ${ getDefaultsImpl[T]('s) }

--- a/modules/tests/shared/src/test/scala-3/io/circe/DerivesSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/DerivesSuite.scala
@@ -191,6 +191,32 @@ object DerivesSuite {
   object ADTWithSubTraitExample:
     given Arbitrary[ADTWithSubTraitExample] = Arbitrary(Arbitrary.arbitrary[Int].map(TheClass.apply))
     given Eq[ADTWithSubTraitExample] = Eq.fromUniversalEquals
+
+  case class ProductWithTaggedMember(x: ProductWithTaggedMember.TaggedString) derives Codec.AsObject
+
+  object ProductWithTaggedMember:
+    sealed trait Tag
+
+    type TaggedString = String with Tag
+
+    object TaggedString:
+      val decoder: Decoder[TaggedString] =
+        summon[Decoder[String]].map(_.asInstanceOf[TaggedString])
+      val encoder: Encoder[TaggedString] =
+        summon[Encoder[String]].contramap(x => x)
+
+    given Codec[TaggedString] =
+      Codec.from(TaggedString.decoder, TaggedString.encoder)
+
+    def fromUntagged(x: String): ProductWithTaggedMember =
+      ProductWithTaggedMember(x.asInstanceOf[TaggedString])
+
+    given Arbitrary[ProductWithTaggedMember] =
+      Arbitrary {
+        Arbitrary.arbitrary[String].map(fromUntagged)
+      }
+    given Eq[ProductWithTaggedMember] = Eq.fromUniversalEquals
+
 }
 
 class DerivesSuite extends CirceMunitSuite {
@@ -205,6 +231,7 @@ class DerivesSuite extends CirceMunitSuite {
   checkAll("Codec[Vegetable]", CodecTests[Vegetable].codec)
   checkAll("Codec[RecursiveEnumAdt]", CodecTests[RecursiveEnumAdt].codec)
   checkAll("Codec[ADTWithSubTraitExample]", CodecTests[ADTWithSubTraitExample].codec)
+  checkAll("Codec[ProductWithTaggedMember] (#2135)", CodecTests[ProductWithTaggedMember].codec)
 
   test("Nested sums should not be encoded redundantly") {
     import io.circe.syntax._


### PR DESCRIPTION
Use `constValue[Tuple.Size[mirror.MirroredElemLabels]]` instead of `constValue[Tuple.Size[mirror.MirroredElemTypes]]` because the latter fails for tagged types.