### PR TITLE
Fix transitive derivation for ConfiguredEncoder

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
@@ -149,7 +149,9 @@ private[circe] trait DecoderDerivation:
 
 private[circe] trait CodecDerivation:
   inline final def derived[A](using inline A: Mirror.Of[A]): Codec.AsObject[A] =
-    ConfiguredCodec.derived[A](using Configuration.default)
+    given Configuration = Configuration.default
+    ConfiguredCodec.derived[A]
+
   inline final def derivedConfigured[A](using
     inline A: Mirror.Of[A],
     inline configuration: Configuration

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -27,6 +27,8 @@ object ConfiguredCodec:
     inline mirror: Mirror.Of[A]
   ): ConfiguredCodec[A] =
     new ConfiguredCodec[A] with SumOrProduct:
+      import ConfiguredDecoder.GivenDerivation.deriveDecoder
+      import ConfiguredEncoder.GivenDerivation.deriveEncoder
       val name = constValue[mirror.MirroredLabel]
       lazy val elemLabels: List[String] = summonLabels[mirror.MirroredElemLabels]
       lazy val elemEncoders: List[Encoder[?]] = summonEncoders[mirror.MirroredElemTypes]

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
@@ -57,7 +57,7 @@ trait ConfiguredEncoder[A](using conf: Configuration) extends Encoder.AsObject[A
 object ConfiguredEncoder:
 
   // needed to make derivation implicitly available when summoning elemEncoders:
-  private object GivenDerivation:
+  private[circe] object GivenDerivation:
     inline given deriveEncoder[A](using conf: Configuration)(using
       inline A: Mirror.Of[A]
     ): Exported[ConfiguredEncoder[A]] =

--- a/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredDerivesSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredDerivesSuite.scala
@@ -509,16 +509,49 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
     given Configuration = Configuration.default.withSnakeCaseMemberNames
 
     case class Bar(barValue: Int)
-    case class Foo(fooValue: Option[Bar]) derives ConfiguredEncoder
 
-    test("Transitive derivation should use default option encoding") {
+    object Bar:
+      given Arbitrary[Bar] = Arbitrary {
+        Arbitrary.arbitrary[Int].map(Bar.apply)
+      }
+
+    case class Foo(fooValue: Option[Bar])
+
+    object Foo:
+      given Eq[Foo] = Eq.fromUniversalEquals[Foo]
+      given Arbitrary[Foo] = Arbitrary {
+        Arbitrary.arbitrary[Option[Bar]].map(Foo.apply)
+      }
+
+    def testFoo(using encoder: Encoder[Foo], decoder: Decoder[Foo]): Unit = {
       val expected = Json.obj(
         "foo_value" -> Json.obj(
           "bar_value" -> 1.asJson
         )
       )
       val foo: Foo = Foo(Some(Bar(1)))
-      val json = Encoder.AsObject[Foo].apply(foo)
+      val json = encoder(foo)
+      val result = decoder.decodeJson(json)
       assert(json === expected, json)
+      assert(result === Right(foo), result)
+    }
+
+    { // tests for Foo with ConfiguredCodec.derived
+      given Codec[Foo] = ConfiguredCodec.derived[Foo]
+      test("Transitive derivation should use default option encoding for Codec") {
+        testFoo
+      }
+
+      checkAll("Codec[Foo]", CodecTests[Foo].codec)
+    }
+
+    { // tests for Foo with ConfiguredEncoder.derived and ConfiguredDecoder.derived
+      given Encoder[Foo] = ConfiguredEncoder.derived[Foo]
+      given Decoder[Foo] = ConfiguredDecoder.derived[Foo]
+      test("Transitive derivation should use default option encoding for Decoder & Encoder") {
+        testFoo
+      }
+
+      checkAll("Decoder[Foo] & Encoder[Foo]", CodecTests[Foo].codec)
     }
   }

--- a/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredDerivesSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredDerivesSuite.scala
@@ -504,3 +504,21 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
       assert(result === Right(tree), result)
     }
   }
+
+  {
+    given Configuration = Configuration.default.withSnakeCaseMemberNames
+
+    case class Bar(barValue: Int)
+    case class Foo(fooValue: Option[Bar]) derives ConfiguredEncoder
+
+    test("Transitive derivation should use default option encoding") {
+      val expected = Json.obj(
+        "foo_value" -> Json.obj(
+          "bar_value" -> 1.asJson
+        )
+      )
+      val foo: Foo = Foo(Some(Bar(1)))
+      val json = Encoder.AsObject[Foo].apply(foo)
+      assert(json === expected, json)
+    }
+  }


### PR DESCRIPTION
Fixes that derivation would not use existing givens if those depend on a given that needs to be derived (e.g. not using `encodeOption[A]` if the required `Encoder[A]` needs to be derived).

(Problem still prevails for all other derivable typeclasses.)

Fixes #2212