### PR TITLE
Move anonymous classes out of inlined code and into constructor methods

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -22,35 +22,41 @@ import io.circe.{ Codec, Decoder, Encoder, HCursor, JsonObject }
 
 trait ConfiguredCodec[A] extends Codec.AsObject[A], ConfiguredDecoder[A], ConfiguredEncoder[A]
 object ConfiguredCodec:
+  def of[A](nme: String, decoders: => List[Decoder[?]], encoders: => List[Encoder[?]], labels: List[String])(using
+    conf: Configuration,
+    mirror: Mirror.Of[A],
+    defaults: Default[A]
+  ): ConfiguredCodec[A] = mirror match
+    case mirror: Mirror.ProductOf[A] =>
+      new ConfiguredCodec[A] with SumOrProduct:
+        val name = nme
+        lazy val elemDecoders = decoders
+        lazy val elemEncoders = encoders
+        lazy val elemLabels = labels
+        lazy val elemDefaults = defaults
+        def isSum = false
+        def apply(c: HCursor) = decodeProduct(c, mirror.fromProduct)
+        def encodeObject(a: A) = encodeProduct(a)
+        override def decodeAccumulating(c: HCursor) = decodeProductAccumulating(c, mirror.fromProduct)
+    case mirror: Mirror.SumOf[A] =>
+      new ConfiguredCodec[A] with SumOrProduct:
+        val name = nme
+        lazy val elemDecoders = decoders
+        lazy val elemEncoders = encoders
+        lazy val elemLabels = labels
+        lazy val elemDefaults = defaults
+        def isSum = true
+        def apply(c: HCursor) = decodeSum(c)
+        def encodeObject(a: A) = encodeSum(mirror.ordinal(a), a)
+        override def decodeAccumulating(c: HCursor) = decodeSumAccumulating(c)
 
-  inline final def derived[A](using conf: Configuration)(using
-    inline mirror: Mirror.Of[A]
-  ): ConfiguredCodec[A] =
-    new ConfiguredCodec[A] with SumOrProduct:
-      val name = constValue[mirror.MirroredLabel]
-      lazy val elemLabels: List[String] = summonLabels[mirror.MirroredElemLabels]
-      lazy val elemEncoders: List[Encoder[?]] = summonEncoders[mirror.MirroredElemTypes]
-      lazy val elemDecoders: List[Decoder[?]] = summonDecoders[mirror.MirroredElemTypes]
-      lazy val elemDefaults: Default[A] = Predef.summon[Default[A]]
-      lazy val isSum: Boolean =
-        inline mirror match
-          case _: Mirror.ProductOf[A] => false
-          case _: Mirror.SumOf[A]     => true
-
-      final def encodeObject(a: A): JsonObject =
-        inline mirror match
-          case _: Mirror.ProductOf[A] => encodeProduct(a)
-          case sum: Mirror.SumOf[A]   => encodeSum(sum.ordinal(a), a)
-
-      final def apply(c: HCursor): Decoder.Result[A] =
-        inline mirror match
-          case product: Mirror.ProductOf[A] => decodeProduct(c, product.fromProduct)
-          case _: Mirror.SumOf[A]           => decodeSum(c)
-
-      final override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[A] =
-        inline mirror match
-          case product: Mirror.ProductOf[A] => decodeProductAccumulating(c, product.fromProduct)
-          case _: Mirror.SumOf[A]           => decodeSumAccumulating(c)
+  inline final def derived[A](using conf: Configuration, mirror: Mirror.Of[A]): ConfiguredCodec[A] =
+    ConfiguredCodec.of(
+      constValue[mirror.MirroredLabel],
+      summonDecoders[mirror.MirroredElemTypes],
+      summonEncoders[mirror.MirroredElemTypes],
+      summonLabels[mirror.MirroredElemLabels]
+    )
 
   inline final def derive[A: Mirror.Of](
     transformMemberNames: String => String = Configuration.default.transformMemberNames,

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumCodec.scala
@@ -17,16 +17,17 @@
 package io.circe.derivation
 
 import scala.deriving.Mirror
-import io.circe.{ Codec, Decoder, HCursor, Json }
+import io.circe.{ Codec, Decoder, Encoder, HCursor, Json }
 
 trait ConfiguredEnumCodec[A] extends Codec[A]
 object ConfiguredEnumCodec:
-  inline final def derived[A](using conf: Configuration)(using Mirror.SumOf[A]): ConfiguredEnumCodec[A] =
-    val decoder = ConfiguredEnumDecoder.derived[A]
-    val encoder = ConfiguredEnumEncoder.derived[A]
+  def of[A](decoder: Decoder[A], encoder: Encoder[A]): ConfiguredEnumCodec[A] =
     new ConfiguredEnumCodec[A]:
-      override def apply(c: HCursor): Decoder.Result[A] = decoder(c)
-      override def apply(a: A): Json = encoder(a)
+      def apply(c: HCursor) = decoder(c)
+      def apply(a: A) = encoder(a)
+
+  inline final def derived[A: Mirror.SumOf](using conf: Configuration): ConfiguredEnumCodec[A] =
+    ConfiguredEnumCodec.of[A](ConfiguredEnumDecoder.derived[A], ConfiguredEnumEncoder.derived[A])
 
   inline final def derive[R: Mirror.SumOf](
     transformConstructorNames: String => String = Configuration.default.transformConstructorNames

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumEncoder.scala
@@ -23,12 +23,15 @@ import io.circe.{ Encoder, Json }
 
 trait ConfiguredEnumEncoder[A] extends Encoder[A]
 object ConfiguredEnumEncoder:
-  inline final def derived[A](using conf: Configuration)(using mirror: Mirror.SumOf[A]): ConfiguredEnumEncoder[A] =
+  def of[A](labels: List[String])(using conf: Configuration, mirror: Mirror.SumOf[A]): ConfiguredEnumEncoder[A] =
+    new ConfiguredEnumEncoder[A]:
+      private val labelOf = labels.toArray.map(conf.transformConstructorNames)
+      def apply(a: A) = Json.fromString(labelOf(mirror.ordinal(a)))
+
+  inline final def derived[A](using conf: Configuration, mirror: Mirror.SumOf[A]): ConfiguredEnumEncoder[A] =
     // Only used to validate if all cases are singletons
     summonSingletonCases[mirror.MirroredElemTypes, A](constValue[mirror.MirroredLabel])
-    val labels = summonLabels[mirror.MirroredElemLabels].toArray.map(conf.transformConstructorNames)
-    new ConfiguredEnumEncoder[A]:
-      def apply(a: A): Json = Json.fromString(labels(mirror.ordinal(a)))
+    ConfiguredEnumEncoder.of[A](summonLabels[mirror.MirroredElemLabels])
 
   inline final def derive[A: Mirror.SumOf](
     transformConstructorNames: String => String = Configuration.default.transformConstructorNames

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/Default.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/Default.scala
@@ -34,14 +34,15 @@ trait Default[T] extends Serializable:
     case defaults: NonEmptyTuple => defaults(index).asInstanceOf[Option[Any]]
 
 object Default:
+  def of[T, O <: Tuple](values: => O) = new Default[T]:
+    type Out = O
+    lazy val defaults: Out = values
+
   transparent inline given mkDefault[T](using mirror: Mirror.Of[T]): Default[T] =
-    new Default[T]:
-      type Out = Tuple.Map[mirror.MirroredElemTypes, Option]
-      lazy val defaults: Out =
-        // summon the size of mirror.MirroredElemLabels (not mirror.MirroredElemTypes) because
-        // in some rare edge cases, the latter fails (and both always have the same size)
-        val size = constValue[Tuple.Size[mirror.MirroredElemLabels]]
-        getDefaults[T](size).asInstanceOf[Out]
+    // summon the size of mirror.MirroredElemLabels (not mirror.MirroredElemTypes) because
+    // in some rare edge cases, the latter fails (and both always have the same size)
+    val size = constValue[Tuple.Size[mirror.MirroredElemLabels]]
+    Default.of(getDefaults[T](size).asInstanceOf[Tuple.Map[mirror.MirroredElemTypes, Option]])
 
   inline def getDefaults[T](inline s: Int): Tuple = ${ getDefaultsImpl[T]('s) }
 


### PR DESCRIPTION
Inlining anonymous classes generates a new class file per call.