### PR TITLE
Making `of` methods on Configured Encoders/Decoders Private.

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -22,7 +22,8 @@ import io.circe.{ Codec, Decoder, Encoder, HCursor, JsonObject }
 
 trait ConfiguredCodec[A] extends Codec.AsObject[A], ConfiguredDecoder[A], ConfiguredEncoder[A]
 object ConfiguredCodec:
-  def of[A](nme: String, decoders: => List[Decoder[?]], encoders: => List[Encoder[?]], labels: List[String])(using
+  private def of[A](nme: String, decoders: => List[Decoder[?]], encoders: => List[Encoder[?]], labels: List[String])(
+    using
     conf: Configuration,
     mirror: Mirror.Of[A],
     defaults: Default[A]

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -189,7 +189,7 @@ trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
     }
 
 object ConfiguredDecoder:
-  def of[A](nme: String, decoders: => List[Decoder[?]], labels: List[String])(using
+  private def of[A](nme: String, decoders: => List[Decoder[?]], labels: List[String])(using
     conf: Configuration,
     mirror: Mirror.Of[A],
     defaults: Default[A]

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
@@ -54,7 +54,7 @@ trait ConfiguredEncoder[A](using conf: Configuration) extends Encoder.AsObject[A
           JsonObject.singleton(constructorName, json)
 
 object ConfiguredEncoder:
-  def of[A](encoders: => List[Encoder[?]], labels: List[String])(using
+  private def of[A](encoders: => List[Encoder[?]], labels: List[String])(using
     conf: Configuration,
     mirror: Mirror.Of[A]
   ): ConfiguredEncoder[A] = mirror match

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumCodec.scala
@@ -21,7 +21,7 @@ import io.circe.{ Codec, Decoder, Encoder, HCursor, Json }
 
 trait ConfiguredEnumCodec[A] extends Codec[A]
 object ConfiguredEnumCodec:
-  def of[A](decoder: Decoder[A], encoder: Encoder[A]): ConfiguredEnumCodec[A] =
+  private def of[A](decoder: Decoder[A], encoder: Encoder[A]): ConfiguredEnumCodec[A] =
     new ConfiguredEnumCodec[A]:
       def apply(c: HCursor) = decoder(c)
       def apply(a: A) = encoder(a)

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumDecoder.scala
@@ -23,7 +23,7 @@ import io.circe.{ Decoder, DecodingFailure, HCursor }
 
 trait ConfiguredEnumDecoder[A] extends Decoder[A]
 object ConfiguredEnumDecoder:
-  def of[A](name: String, cases: List[A], labels: List[String])(using
+  private def of[A](name: String, cases: List[A], labels: List[String])(using
     conf: Configuration
   ): ConfiguredEnumDecoder[A] = new ConfiguredEnumDecoder[A]:
     private val caseOf = cases.toVector

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumEncoder.scala
@@ -23,7 +23,9 @@ import io.circe.{ Encoder, Json }
 
 trait ConfiguredEnumEncoder[A] extends Encoder[A]
 object ConfiguredEnumEncoder:
-  def of[A](labels: List[String])(using conf: Configuration, mirror: Mirror.SumOf[A]): ConfiguredEnumEncoder[A] =
+  private def of[A](
+    labels: List[String]
+  )(using conf: Configuration, mirror: Mirror.SumOf[A]): ConfiguredEnumEncoder[A] =
     new ConfiguredEnumEncoder[A]:
       private val labelOf = labels.toArray.map(conf.transformConstructorNames)
       def apply(a: A) = Json.fromString(labelOf(mirror.ordinal(a)))

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/Default.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/Default.scala
@@ -34,7 +34,7 @@ trait Default[T] extends Serializable:
     case defaults: NonEmptyTuple => defaults(index).asInstanceOf[Option[Any]]
 
 object Default:
-  def of[T, O <: Tuple](values: => O) = new Default[T]:
+  private def of[T, O <: Tuple](values: => O) = new Default[T]:
     type Out = O
     lazy val defaults: Out = values
 


### PR DESCRIPTION
Trying to minimize changes to the public interface that might expose internal implementation details.  Exposing those details makes it hard to correct scala 3 derivations issues in bin-compat ways going forward.

(See #2230 for when these got added)