### PR TITLE
Align Scala 3 semiauto derivation with `circe-generic` behavior in Scala 2

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
@@ -26,18 +26,18 @@ import io.circe.derivation._
 object Derivation {
   inline final def summonLabels[T <: Tuple]: Array[String] = summonLabelsRec[T].toArray
   inline final def summonDecoders[T <: Tuple]: Array[Decoder[_]] =
-    derivation.summonDecoders[T](using Configuration.default).toArray
+    derivation.summonDecoders[T](false)(using Configuration.default).toArray
   inline final def summonEncoders[T <: Tuple]: Array[Encoder[_]] =
-    derivation.summonEncoders[T](using Configuration.default).toArray
+    derivation.summonEncoders[T](false)(using Configuration.default).toArray
 
-  inline final def summonEncoder[A]: Encoder[A] = derivation.summonEncoder[A](using Configuration.default)
-  inline final def summonDecoder[A]: Decoder[A] = derivation.summonDecoder[A](using Configuration.default)
+  inline final def summonEncoder[A]: Encoder[A] = derivation.summonEncoder[A](false)(using Configuration.default)
+  inline final def summonDecoder[A]: Decoder[A] = derivation.summonDecoder[A](false)(using Configuration.default)
 
   inline final def summonLabelsRec[T <: Tuple]: List[String] = derivation.summonLabels[T]
   inline final def summonDecodersRec[T <: Tuple]: List[Decoder[_]] =
-    derivation.summonDecoders[T](using Configuration.default)
+    derivation.summonDecoders[T](false)(using Configuration.default)
   inline final def summonEncodersRec[T <: Tuple]: List[Encoder[_]] =
-    derivation.summonEncoders[T](using Configuration.default)
+    derivation.summonEncoders[T](false)(using Configuration.default)
 }
 
 @deprecated(since = "0.14.4")

--- a/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
@@ -26,18 +26,18 @@ import io.circe.derivation._
 object Derivation {
   inline final def summonLabels[T <: Tuple]: Array[String] = summonLabelsRec[T].toArray
   inline final def summonDecoders[T <: Tuple]: Array[Decoder[_]] =
-    derivation.summonDecoders[T](false)(using Configuration.default).toArray
+    derivation.summonDecoders[T](derivingForSum = false)(using Configuration.default).toArray
   inline final def summonEncoders[T <: Tuple]: Array[Encoder[_]] =
-    derivation.summonEncoders[T](false)(using Configuration.default).toArray
+    derivation.summonEncoders[T](derivingForSum = false)(using Configuration.default).toArray
 
   inline final def summonEncoder[A]: Encoder[A] = derivation.summonEncoder[A](false)(using Configuration.default)
   inline final def summonDecoder[A]: Decoder[A] = derivation.summonDecoder[A](false)(using Configuration.default)
 
   inline final def summonLabelsRec[T <: Tuple]: List[String] = derivation.summonLabels[T]
   inline final def summonDecodersRec[T <: Tuple]: List[Decoder[_]] =
-    derivation.summonDecoders[T](false)(using Configuration.default)
+    derivation.summonDecoders[T](derivingForSum = false)(using Configuration.default)
   inline final def summonEncodersRec[T <: Tuple]: List[Encoder[_]] =
-    derivation.summonEncoders[T](false)(using Configuration.default)
+    derivation.summonEncoders[T](derivingForSum = false)(using Configuration.default)
 }
 
 @deprecated(since = "0.14.4")

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -54,8 +54,8 @@ object ConfiguredCodec:
   inline final def derived[A](using conf: Configuration, mirror: Mirror.Of[A]): ConfiguredCodec[A] =
     ConfiguredCodec.of(
       constValue[mirror.MirroredLabel],
-      summonDecoders[mirror.MirroredElemTypes],
-      summonEncoders[mirror.MirroredElemTypes],
+      ConfiguredDecoder.decoders[A],
+      ConfiguredEncoder.encoders[A],
       summonLabels[mirror.MirroredElemLabels]
     )
 

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -214,7 +214,7 @@ object ConfiguredDecoder:
         override def decodeAccumulating(c: HCursor) = decodeSumAccumulating(c)
 
   private[derivation] inline final def decoders[A](using conf: Configuration, mirror: Mirror.Of[A]): List[Decoder[?]] =
-    summonDecoders[mirror.MirroredElemTypes](inline mirror match {
+    summonDecoders[mirror.MirroredElemTypes](derivingForSum = inline mirror match {
       case _: Mirror.ProductOf[A] => false
       case _: Mirror.SumOf[A]     => true
     })

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -213,12 +213,14 @@ object ConfiguredDecoder:
         def apply(c: HCursor) = decodeSum(c)
         override def decodeAccumulating(c: HCursor) = decodeSumAccumulating(c)
 
+  private[derivation] inline final def decoders[A](using conf: Configuration, mirror: Mirror.Of[A]): List[Decoder[?]] =
+    summonDecoders[mirror.MirroredElemTypes](inline mirror match {
+      case _: Mirror.ProductOf[A] => false
+      case _: Mirror.SumOf[A]     => true
+    })
+
   inline final def derived[A](using conf: Configuration, mirror: Mirror.Of[A]): ConfiguredDecoder[A] =
-    ConfiguredDecoder.of[A](
-      constValue[mirror.MirroredLabel],
-      summonDecoders[mirror.MirroredElemTypes],
-      summonLabels[mirror.MirroredElemLabels]
-    )
+    ConfiguredDecoder.of[A](constValue[mirror.MirroredLabel], decoders[A], summonLabels[mirror.MirroredElemLabels])
 
   inline final def derive[A: Mirror.Of](
     transformMemberNames: String => String = Configuration.default.transformMemberNames,

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
@@ -71,8 +71,14 @@ object ConfiguredEncoder:
         def isSum = true
         def encodeObject(a: A) = encodeSum(mirror.ordinal(a), a)
 
+  private[derivation] inline final def encoders[A](using conf: Configuration, mirror: Mirror.Of[A]): List[Encoder[?]] =
+    summonEncoders[mirror.MirroredElemTypes](inline mirror match {
+      case _: Mirror.ProductOf[A] => false
+      case _: Mirror.SumOf[A]     => true
+    })
+
   inline final def derived[A](using conf: Configuration, mirror: Mirror.Of[A]): ConfiguredEncoder[A] =
-    ConfiguredEncoder.of[A](summonEncoders[mirror.MirroredElemTypes], summonLabels[mirror.MirroredElemLabels])
+    ConfiguredEncoder.of[A](encoders[A], summonLabels[mirror.MirroredElemLabels])
 
   inline final def derive[A: Mirror.Of](
     transformMemberNames: String => String = Configuration.default.transformMemberNames,

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
@@ -72,7 +72,7 @@ object ConfiguredEncoder:
         def encodeObject(a: A) = encodeSum(mirror.ordinal(a), a)
 
   private[derivation] inline final def encoders[A](using conf: Configuration, mirror: Mirror.Of[A]): List[Encoder[?]] =
-    summonEncoders[mirror.MirroredElemTypes](inline mirror match {
+    summonEncoders[mirror.MirroredElemTypes](derivingForSum = inline mirror match {
       case _: Mirror.ProductOf[A] => false
       case _: Mirror.SumOf[A]     => true
     })

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/TypeName.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/TypeName.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.circe.derivation
+
+import scala.quoted.*
+
+private def typeNameImpl[A: Type](using Quotes): Expr[String] = Expr(Type.show[A])
+
+private[derivation] inline def typeName[A]: String = ${ typeNameImpl[A] }

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -25,26 +25,50 @@ private[circe] inline final def summonLabels[T <: Tuple]: List[String] =
     case _: EmptyTuple => Nil
     case _: (t *: ts)  => constValue[t].asInstanceOf[String] :: summonLabels[ts]
 
+@deprecated("Use summonEncoders(derivingForSum: Boolean) instead", "0.14.7")
 private[circe] inline final def summonEncoders[T <: Tuple](using Configuration): List[Encoder[_]] =
+  summonEncoders(false)
+
+private[circe] inline final def summonEncoders[T <: Tuple](inline derivingForSum: Boolean)(using
+  Configuration
+): List[Encoder[_]] =
   inline erasedValue[T] match
     case _: EmptyTuple => Nil
-    case _: (t *: ts)  => summonEncoder[t] :: summonEncoders[ts]
+    case _: (t *: ts)  => summonEncoder[t](derivingForSum) :: summonEncoders[ts](derivingForSum)
 
+@deprecated("Use summonEncoder(derivingForSum: Boolean) instead", "0.14.7")
 private[circe] inline final def summonEncoder[A](using Configuration): Encoder[A] =
+  summonEncoder(false)
+
+private[circe] inline final def summonEncoder[A](inline derivingForSum: Boolean)(using Configuration): Encoder[A] =
   summonFrom {
     case encodeA: Encoder[A] => encodeA
-    case _: Mirror.Of[A]     => ConfiguredEncoder.derived[A]
+    case m: Mirror.Of[A] =>
+      inline if (derivingForSum) ConfiguredEncoder.derived[A]
+      else error("Failed to find an instance of Encoder[" + typeName[A] + "]")
   }
 
+@deprecated("Use summonDecoders(derivingForSum: Boolean) instead", "0.14.7")
 private[circe] inline final def summonDecoders[T <: Tuple](using Configuration): List[Decoder[_]] =
+  summonDecoders(false)
+
+private[circe] inline final def summonDecoders[T <: Tuple](inline derivingForSum: Boolean)(using
+  Configuration
+): List[Decoder[_]] =
   inline erasedValue[T] match
     case _: EmptyTuple => Nil
-    case _: (t *: ts)  => summonDecoder[t] :: summonDecoders[ts]
+    case _: (t *: ts)  => summonDecoder[t](derivingForSum) :: summonDecoders[ts](derivingForSum)
 
+@deprecated("Use summonDecoder(derivingForSum: Boolean) instead", "0.14.7")
 private[circe] inline final def summonDecoder[A](using Configuration): Decoder[A] =
+  summonDecoder(false)
+
+private[circe] inline final def summonDecoder[A](inline derivingForSum: Boolean)(using Configuration): Decoder[A] =
   summonFrom {
     case decodeA: Decoder[A] => decodeA
-    case _: Mirror.Of[A]     => ConfiguredDecoder.derived[A]
+    case m: Mirror.Of[A] =>
+      inline if (derivingForSum) ConfiguredDecoder.derived[A]
+      else error("Failed to find an instance of Decoder[" + typeName[A] + "]")
   }
 
 private[circe] inline def summonSingletonCases[T <: Tuple, A](inline typeName: Any): List[A] =

--- a/modules/tests/shared/src/test/scala-3/io/circe/SemiautoDerivationSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/SemiautoDerivationSuite.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2024 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.circe
+
+import cats.kernel.Eq
+import cats.syntax.eq.*
+import io.circe.{ Decoder, Encoder }
+import io.circe.testing.CodecTests
+import io.circe.tests.CirceMunitSuite
+import org.scalacheck.{ Arbitrary, Gen }
+
+object SemiautoDerivationSuite {
+  case class Box[A](a: A)
+
+  object Box {
+    given decoder[A: Decoder]: Decoder[Box[A]] = Decoder.derived
+    given encoder[A: Encoder]: Encoder.AsObject[Box[A]] = Encoder.AsObject.derived
+
+    given eq[A: Eq]: Eq[Box[A]] = Eq.by(_.a)
+    given arbitrary[A](using A: Arbitrary[A]): Arbitrary[Box[A]] = Arbitrary(A.arbitrary.map(Box(_)))
+  }
+
+  case class Foo(int: Int)
+
+  object Foo {
+    given decoder: Decoder[Foo] = Decoder.derived
+    given encoder: Encoder.AsObject[Foo] = Encoder.AsObject.derived
+
+    given eq: Eq[Foo] = Eq.by(_.int)
+    given arbitrary: Arbitrary[Foo] = Arbitrary(Arbitrary.arbitrary[Int].map(Foo(_)))
+  }
+
+  case class Bar(foo: Box[Foo])
+
+  object Bar {
+    // We can derive a `Decoder` and `Encoder` for `Bar` because instances of each exist for `Foo`
+    given decoder: Decoder[Bar] = Decoder.derived
+    given encoder: Encoder.AsObject[Bar] = Encoder.AsObject.derived
+
+    given eq: Eq[Bar] = Eq.by(_.foo)
+    given arbitrary: Arbitrary[Bar] = Arbitrary(Arbitrary.arbitrary[Box[Foo]].map(Bar(_)))
+  }
+
+  case class Baz(str: String)
+
+  // We cannot derive a `Decoder` or `Encoder` for `Quux` because no instances exist for `Baz`
+  // see test below for proof that deriving instances fails to compile
+  case class Quux(baz: Box[Baz])
+
+  sealed trait Adt1
+  object Adt1 {
+    case class Class1(int: Int) extends Adt1
+    object Class1 {
+      given decoder: Decoder[Class1] = Decoder.derived
+      given encoder: Encoder.AsObject[Class1] = Encoder.AsObject.derived
+
+      given eq: Eq[Class1] = Eq.by(_.int)
+      given arbitrary: Arbitrary[Class1] = Arbitrary(Arbitrary.arbitrary[Int].map(Class1(_)))
+    }
+
+    case object Object1 extends Adt1
+
+    // We can derive a `Decoder` and `Encoder` for `Adt1` because instances of each exist for `Class1`
+    given decoder: Decoder[Adt1] = Decoder.derived
+    given encoder: Encoder.AsObject[Adt1] = Encoder.AsObject.derived
+
+    given eq: Eq[Adt1] = Eq.instance {
+      case (x: Class1, y: Class1) => x === y
+      case (Object1, Object1)     => true
+      case _                      => false
+    }
+    given arbitrary: Arbitrary[Adt1] = Arbitrary(Gen.oneOf(Arbitrary.arbitrary[Class1], Gen.const(Object1)))
+  }
+
+  sealed trait Adt2
+  object Adt2 {
+    case object Object1 extends Adt2
+    case object Object2 extends Adt2
+
+    // We can derive a `Decoder` and `Encoder` for `Adt2` because its members are all `case object`s
+    given decoder: Decoder[Adt2] = Decoder.derived
+    given encoder: Encoder.AsObject[Adt2] = Encoder.AsObject.derived
+
+    given eq: Eq[Adt2] = Eq.fromUniversalEquals
+    given arbitrary: Arbitrary[Adt2] = Arbitrary(Gen.oneOf(Gen.const(Object1), Gen.const(Object2)))
+  }
+
+  sealed trait Adt3
+  object Adt3 {
+    case class Class1() extends Adt3
+    case object Object1 extends Adt3
+
+    given decoder: Decoder[Adt3] = Decoder.derived
+    given encoder: Encoder.AsObject[Adt3] = Encoder.AsObject.derived
+
+    given eq: Eq[Adt3] = Eq.fromUniversalEquals
+    given arbitrary: Arbitrary[Adt3] = Arbitrary(Gen.oneOf(Gen.const(Class1()), Gen.const(Object1)))
+  }
+
+  sealed trait Adt4
+  object Adt4 {
+    sealed trait SubTrait1 extends Adt4
+    case class Class1() extends SubTrait1
+    sealed trait SubTrait2 extends Adt4
+    case object Object1 extends SubTrait2
+
+    given decoder: Decoder[Adt4] = Decoder.derived
+    given encoder: Encoder.AsObject[Adt4] = Encoder.AsObject.derived
+
+    given eq: Eq[Adt4] = Eq.fromUniversalEquals
+    given arbitrary: Arbitrary[Adt4] = Arbitrary(Gen.oneOf(Gen.const(Class1()), Gen.const(Object1)))
+  }
+
+  sealed trait Adt5
+  object Adt5 {
+    case class Nested()
+    case class Class1(nested: Nested) extends Adt5
+    case object Object1 extends Adt5
+
+    // We cannot derive a `Decoder` or `Encoder` for `Adt5` because no instances exist for `Nested`
+    // see test below for proof that deriving instances fails to compile
+  }
+}
+
+class SemiautoDerivationSuite extends CirceMunitSuite {
+  import SemiautoDerivationSuite.*
+
+  checkAll("Codec[Foo]", CodecTests[Foo].codec)
+  checkAll("Codec[Box[Foo]]", CodecTests[Box[Foo]].codec)
+  checkAll("Codec[Bar]", CodecTests[Bar].codec)
+  checkAll("Codec[Box[Bar]]", CodecTests[Box[Bar]].codec)
+  checkAll("Codec[Adt1]", CodecTests[Adt1].codec)
+  checkAll("Codec[Adt2]", CodecTests[Adt2].codec)
+  checkAll("Codec[Adt3]", CodecTests[Adt3].codec)
+  checkAll("Codec[Adt4]", CodecTests[Adt4].codec)
+
+  test("Nested case classes cannot be derived") {
+    assert(compileErrors("Decoder.derived[Quux]").nonEmpty)
+    assert(compileErrors("Encoder.AsObject.derived[Quux]").nonEmpty)
+  }
+
+  test("Nested ADTs cannot be derived") {
+    assert(compileErrors("Decoder.derived[Adt5]").nonEmpty)
+    assert(compileErrors("Encoder.AsObject.derived[Adt5]").nonEmpty)
+  }
+}


### PR DESCRIPTION
Fixes #2111 
Fixes #2126 
Fixes #2212 
Closes #1923 
Closes #2183 
Closes #2213 

Updates semiauto derivation in Scala 3 -- `Codec.AsObject.derived`, `Decoder.derived`, and `Encoder.AsObject.derived` -- to align it with `circe-generic` behavior in Scala 2 and follow the rules specified in 1.i and 2.iv of this comment: https://github.com/circe/circe/pull/2183#issuecomment-1839047060

> 1. How should semiauto derivation work by default for case classes?
    i. It should fail if any case class field does not have a Decoder/Encoder
> ...
> 2. How should semiauto derivation work by default for sealed traits?
> ...
>    iv. It should automatically derive a Decoder/Encoder for all subtypes

Some other notes:

- 2.iv is subject to the same rule as 1.i for `case class`es that are part of a `sealed trait` hierarchy -- derivation will not auto-recurse for the `case class` fields, e.g.
    ```scala
    sealed trait Color
    case object Red extends Color
    case object Green extends Color

    sealed trait Bird
    final case class Parrot(color: Color) extends Bird

    // This fails because there's no `Decoder[Color]` in scope
    io.circe.Decoder.derived[Bird]
    ```
- Multi-layered `sealed trait` hierarchies are handled properly -- derivation will auto-recurse for any nested sum type, e.g.
    ```scala
    sealed trait Animal
    final case class Fox() extends Animal
    sealed trait Dog
    final case class Corgi(color: String) extends Dog

    // This succeeds and automatically derives an instance of `Decoder[Dog]`
    io.circe.Decoder.derived[Animal]
    ```