### PR TITLE
Add missing rule to "unserializableCodec" in `CodecTests`

### DIFF
--- a/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
@@ -105,6 +105,9 @@ trait CodecTests[A] extends Laws {
     },
     "consistency with accumulating" -> Prop.forAll { (json: Json) =>
       laws.codecAccumulatingConsistency(json)
+    },
+    "consistency with Codec.from" -> Prop.forAll { (json: Json, a: A) =>
+      laws.codecFromConsistency(json, a)
     }
   )
 }


### PR DESCRIPTION
Rule "consistency with Codec.from" was introduced to `CodecTests` in #2131.
However, it was only added to the "codec" rule set but not the "unserializableCodec" one.
It doesn't seem though that the rule is specific to Java-level serialization,
therefore many tests that call for the "unserializableCodec" rule set only, miss the opportunity to check against that rule.
