### PR TITLE
Update versions for Scala Native 0.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,19 +22,19 @@ ThisBuild / scalafixAll / skip := tlIsScala3.value
 ThisBuild / ScalafixConfig / skip := tlIsScala3.value
 ThisBuild / circeRootOfCodeCoverage := Some("rootJVM")
 
-val catsVersion = "2.10.0"
-val jawnVersion = "1.5.1"
-val shapelessVersion = "2.3.11"
+val catsVersion = "2.12.0"
+val jawnVersion = "1.6.0"
+val shapelessVersion = "2.3.12"
 val refinedVersion = "0.9.29"
 val refinedNativeVersion = "0.11.1"
 
 val paradiseVersion = "2.1.1"
 
-val scalaCheckVersion = "1.17.1"
-val munitVersion = "1.0.0-M11"
-val disciplineVersion = "1.6.0"
-val disciplineScalaTestVersion = "2.2.0"
-val disciplineMunitVersion = "2.0.0-M3"
+val scalaCheckVersion = "1.18.0"
+val munitVersion = "1.0.0"
+val disciplineVersion = "1.7.0"
+val disciplineScalaTestVersion = "2.3.0"
+val disciplineMunitVersion = "2.0.0"
 val scalaJavaTimeVersion = "2.5.0"
 
 /**

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("io.circe" % "sbt-circe-org" % "0.4.1")


### PR DESCRIPTION
Remaining dependencies:
- https://github.com/cquiroz/scala-java-time/pull/508 (likely needs a Scala Native release, if workaround can't be found for tests)
- https://github.com/fthomas/refined/pull/1274 - needs a release