### PR TITLE
Fix stack overflow when deriving for local classes

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/Configuration.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/Configuration.scala
@@ -59,3 +59,11 @@ case class Configuration(
 
   def withStrictDecoding: Configuration = copy(strictDecoding = true)
   def withoutStrictDecoding: Configuration = copy(strictDecoding = false)
+
+private[circe] final class ConfigurationOrDefault(val conf: Configuration) extends AnyVal
+
+private[circe] trait ConfigurationOrDefaultLP:
+  final given fromDefault: ConfigurationOrDefault = ConfigurationOrDefault(Configuration.default)
+
+object ConfigurationOrDefault extends ConfigurationOrDefaultLP:
+  given fromConfig(using conf: Configuration): ConfigurationOrDefault = ConfigurationOrDefault(conf)

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -21,8 +21,12 @@ import io.circe.{ Codec, Decoder, Encoder, HCursor }
 
 trait ConfiguredCodec[A] extends Codec.AsObject[A], ConfiguredDecoder[A], ConfiguredEncoder[A]
 object ConfiguredCodec:
-  private def of[A](nme: String, decoders: => List[Decoder[?]], encoders: => List[Encoder[?]], labels: List[String])(
-    using
+  private def of[A](
+    nme: => String,
+    decoders: => List[Decoder[?]],
+    encoders: => List[Encoder[?]],
+    labels: => List[String]
+  )(using
     conf: Configuration,
     mirror: LazyMirror[A]
   ): ConfiguredCodec[A] = mirror match

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -21,6 +21,7 @@ import io.circe.{ Codec, Decoder, Encoder, HCursor }
 
 trait ConfiguredCodec[A] extends Codec.AsObject[A], ConfiguredDecoder[A], ConfiguredEncoder[A]
 object ConfiguredCodec:
+  // It's important that all of these parameters are by-name, see https://github.com/circe/circe/pull/2278
   private def of[A](
     nme: => String,
     decoders: => List[Decoder[?]],

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -16,9 +16,7 @@
 
 package io.circe.derivation
 
-import scala.deriving.Mirror
 import scala.compiletime.constValue
-import Predef.genericArrayOps
 import cats.data.{ NonEmptyList, Validated }
 import io.circe.{ ACursor, Decoder, DecodingFailure, HCursor }
 import io.circe.DecodingFailure.Reason.WrongTypeExpectation
@@ -191,38 +189,35 @@ trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
 object ConfiguredDecoder:
   private def of[A](nme: String, decoders: => List[Decoder[?]], labels: List[String])(using
     conf: Configuration,
-    mirror: Mirror.Of[A],
-    defaults: Default[A]
+    mirror: LazyMirror[A]
   ): ConfiguredDecoder[A] = mirror match
-    case mirror: Mirror.ProductOf[A] =>
+    case mirror: LazyMirror.Product[A] =>
       new ConfiguredDecoder[A] with SumOrProduct:
         val name = nme
         lazy val elemDecoders = decoders
         lazy val elemLabels = labels
-        lazy val elemDefaults = defaults
+        lazy val elemDefaults = mirror.default
         def isSum = false
         def apply(c: HCursor) = decodeProduct(c, mirror.fromProduct)
         override def decodeAccumulating(c: HCursor) = decodeProductAccumulating(c, mirror.fromProduct)
-    case _: Mirror.SumOf[A] =>
+    case _: LazyMirror.Sum[A] =>
       new ConfiguredDecoder[A] with SumOrProduct:
         val name = nme
         lazy val elemDecoders = decoders
         lazy val elemLabels = labels
-        lazy val elemDefaults = defaults
+        lazy val elemDefaults = mirror.default
         def isSum = true
         def apply(c: HCursor) = decodeSum(c)
         override def decodeAccumulating(c: HCursor) = decodeSumAccumulating(c)
 
-  private[derivation] inline final def decoders[A](using conf: Configuration, mirror: Mirror.Of[A]): List[Decoder[?]] =
-    summonDecoders[mirror.MirroredElemTypes](derivingForSum = inline mirror match {
-      case _: Mirror.ProductOf[A] => false
-      case _: Mirror.SumOf[A]     => true
-    })
+  inline final def derived[A](using
+    conf: Configuration,
+    mirror: LazyMirror[A],
+    decoders: Decoders[A]
+  ): ConfiguredDecoder[A] =
+    ConfiguredDecoder.of[A](mirror.mirroredLabel, decoders.decoders, mirror.mirroredElemLabels)
 
-  inline final def derived[A](using conf: Configuration, mirror: Mirror.Of[A]): ConfiguredDecoder[A] =
-    ConfiguredDecoder.of[A](constValue[mirror.MirroredLabel], decoders[A], summonLabels[mirror.MirroredElemLabels])
-
-  inline final def derive[A: Mirror.Of](
+  inline final def derive[A: LazyMirror: Decoders](
     transformMemberNames: String => String = Configuration.default.transformMemberNames,
     transformConstructorNames: String => String = Configuration.default.transformConstructorNames,
     useDefaults: Boolean = Configuration.default.useDefaults,

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -187,7 +187,7 @@ trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
     }
 
 object ConfiguredDecoder:
-  private def of[A](nme: String, decoders: => List[Decoder[?]], labels: List[String])(using
+  private def of[A](nme: => String, decoders: => List[Decoder[?]], labels: => List[String])(using
     conf: Configuration,
     mirror: LazyMirror[A]
   ): ConfiguredDecoder[A] = mirror match

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -187,6 +187,7 @@ trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
     }
 
 object ConfiguredDecoder:
+  // It's important that all of these parameters are by-name, see https://github.com/circe/circe/pull/2278
   private def of[A](nme: => String, decoders: => List[Decoder[?]], labels: => List[String])(using
     conf: Configuration,
     mirror: LazyMirror[A]

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
@@ -53,7 +53,7 @@ trait ConfiguredEncoder[A](using conf: Configuration) extends Encoder.AsObject[A
           JsonObject.singleton(constructorName, json)
 
 object ConfiguredEncoder:
-  private def of[A](encoders: => List[Encoder[?]], labels: List[String])(using
+  private def of[A](encoders: => List[Encoder[?]], labels: => List[String])(using
     conf: Configuration,
     mirror: LazyMirror[A]
   ): ConfiguredEncoder[A] = mirror match

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
@@ -53,6 +53,7 @@ trait ConfiguredEncoder[A](using conf: Configuration) extends Encoder.AsObject[A
           JsonObject.singleton(constructorName, json)
 
 object ConfiguredEncoder:
+  // It's important that all of these parameters are by-name, see https://github.com/circe/circe/pull/2278
   private def of[A](encoders: => List[Encoder[?]], labels: => List[String])(using
     conf: Configuration,
     mirror: LazyMirror[A]

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/Default.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/Default.scala
@@ -16,8 +16,8 @@
 
 package io.circe.derivation
 
+import scala.deriving.Mirror
 import scala.quoted.*
-import scala.deriving.*
 import scala.compiletime.constValue
 
 /**
@@ -38,11 +38,14 @@ object Default:
     type Out = O
     lazy val defaults: Out = values
 
+  private[derivation] transparent inline def mkDefault0[T, ET <: Tuple](inline s: Int): Default[T] =
+    Default.of(getDefaults[T](s).asInstanceOf[Tuple.Map[ET, Option]])
+
   transparent inline given mkDefault[T](using mirror: Mirror.Of[T]): Default[T] =
     // summon the size of mirror.MirroredElemLabels (not mirror.MirroredElemTypes) because
     // in some rare edge cases, the latter fails (and both always have the same size)
     val size = constValue[Tuple.Size[mirror.MirroredElemLabels]]
-    Default.of(getDefaults[T](size).asInstanceOf[Tuple.Map[mirror.MirroredElemTypes, Option]])
+    mkDefault0[T, mirror.MirroredElemTypes](size)
 
   inline def getDefaults[T](inline s: Int): Tuple = ${ getDefaultsImpl[T]('s) }
 

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/Instances.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/Instances.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.circe
+package derivation
+
+import scala.deriving.Mirror
+
+private[circe] sealed trait Decoders[A] extends Serializable {
+  def decoders(using conf: Configuration): List[Decoder[?]]
+}
+
+object Decoders {
+  final class Impl[A](ds: Configuration ?=> List[Decoder[?]]) extends Decoders[A] with Serializable {
+    final def decoders(using conf: Configuration): List[Decoder[?]] = ds
+  }
+
+  inline given inst[A, ET <: Tuple](using
+    inline m: Mirror.Of[A] { type MirroredElemTypes = ET }
+  ): Decoders[A] =
+    new Impl[A](summonDecoders[ET](inline m match {
+      case _: Mirror.SumOf[A]     => true
+      case _: Mirror.ProductOf[A] => false
+    }))
+}
+
+private[circe] sealed trait Encoders[A] extends Serializable {
+  def encoders(using conf: Configuration): List[Encoder[?]]
+}
+
+object Encoders {
+  final class Impl[A](es: Configuration ?=> List[Encoder[?]]) extends Encoders[A] with Serializable {
+    final def encoders(using conf: Configuration): List[Encoder[?]] = es
+  }
+
+  inline given inst[A, ET <: Tuple](using
+    inline m: Mirror.Of[A] { type MirroredElemTypes = ET }
+  ): Encoders[A] =
+    new Impl[A](summonEncoders[ET](inline m match {
+      case _: Mirror.SumOf[A]     => true
+      case _: Mirror.ProductOf[A] => false
+    }))
+}

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/LazyMirror.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/LazyMirror.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.circe
+package derivation
+
+import scala.compiletime.{ constValue, constValueTuple }
+import scala.deriving.Mirror
+
+sealed trait LazyMirror[A] extends Serializable {
+  lazy val mirroredLabel: String
+  lazy val mirroredElemLabels: List[String]
+
+  lazy val default: Default[A]
+}
+
+object LazyMirror {
+  trait Sum[A] extends LazyMirror[A] {
+    def ordinal(x: A): Int
+  }
+  trait Product[A] extends LazyMirror[A] {
+    def fromProduct(p: scala.Product): A
+  }
+
+  final class SumImpl[A, L <: String, EL <: Tuple, ET <: Tuple](
+    l: L,
+    el: EL,
+    d: Default[A],
+    ord: A => Int
+  ) extends Sum[A]
+      with Serializable {
+    final lazy val mirroredLabel: L = l
+    final lazy val mirroredElemLabels: List[String] = el.toList.asInstanceOf[List[String]]
+
+    final lazy val default: Default[A] = d
+
+    final def ordinal(a: A): Int = ord(a)
+  }
+
+  final class ProductImpl[A, L <: String, EL <: Tuple, ET <: Tuple](
+    l: L,
+    el: EL,
+    d: Default[A],
+    fp: scala.Product => A
+  ) extends Product[A]
+      with Serializable {
+    final lazy val mirroredLabel: L = l
+    final lazy val mirroredElemLabels: List[String] = el.toList.asInstanceOf[List[String]]
+
+    final lazy val default: Default[A] = d
+
+    final def fromProduct(p: scala.Product): A = fp(p)
+  }
+
+  inline given lazyMirrorSum[A, L <: String, EL <: Tuple, ET <: Tuple](using
+    inline m: Mirror.SumOf[A] {
+      type MirroredLabel = L
+      type MirroredElemLabels = EL
+      type MirroredElemTypes = ET
+    }
+  ): LazyMirror.Sum[A] =
+    new SumImpl[A, L, EL, ET](
+      constValue[L],
+      constValueTuple[EL],
+      Default.mkDefault0[A, ET](constValue[Tuple.Size[EL]]),
+      m.ordinal
+    )
+
+  inline given lazyMirrorProduct[A, L <: String, EL <: Tuple, ET <: Tuple](using
+    inline m: Mirror.ProductOf[A] {
+      type MirroredLabel = L
+      type MirroredElemLabels = EL
+      type MirroredElemTypes = ET
+    }
+  ): LazyMirror.Product[A] =
+    new ProductImpl[A, L, EL, ET](
+      constValue[L],
+      constValueTuple[EL],
+      Default.mkDefault0[A, ET](constValue[Tuple.Size[EL]]),
+      m.fromProduct
+    )
+
+  private[circe] inline def fromMirror[A](inline m: Mirror.Of[A]): LazyMirror[A] =
+    inline m match
+      case s: Mirror.SumOf[A]     => lazyMirrorSum(using s)
+      case p: Mirror.ProductOf[A] => lazyMirrorProduct(using p)
+}

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/LazyMirror.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/LazyMirror.scala
@@ -35,6 +35,7 @@ object LazyMirror {
     def fromProduct(p: scala.Product): A
   }
 
+  // It's important that all of these parameters are by-name, see https://github.com/circe/circe/pull/2278
   final class SumImpl[A, L <: String, EL <: Tuple, ET <: Tuple](
     l: => L,
     el: => EL,
@@ -50,6 +51,7 @@ object LazyMirror {
     final def ordinal(a: A): Int = ord(a)
   }
 
+  // It's important that all of these parameters are by-name, see https://github.com/circe/circe/pull/2278
   final class ProductImpl[A, L <: String, EL <: Tuple, ET <: Tuple](
     l: => L,
     el: => EL,

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/LazyMirror.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/LazyMirror.scala
@@ -36,10 +36,10 @@ object LazyMirror {
   }
 
   final class SumImpl[A, L <: String, EL <: Tuple, ET <: Tuple](
-    l: L,
-    el: EL,
-    d: Default[A],
-    ord: A => Int
+    l: => L,
+    el: => EL,
+    d: => Default[A],
+    ord: => A => Int
   ) extends Sum[A]
       with Serializable {
     final lazy val mirroredLabel: L = l
@@ -51,10 +51,10 @@ object LazyMirror {
   }
 
   final class ProductImpl[A, L <: String, EL <: Tuple, ET <: Tuple](
-    l: L,
-    el: EL,
-    d: Default[A],
-    fp: scala.Product => A
+    l: => L,
+    el: => EL,
+    d: => Default[A],
+    fp: => scala.Product => A
   ) extends Product[A]
       with Serializable {
     final lazy val mirroredLabel: L = l

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -18,7 +18,7 @@ package io.circe.derivation
 
 import scala.compiletime.{ codeOf, constValue, erasedValue, error, summonFrom, summonInline }
 import scala.deriving.Mirror
-import io.circe.{ Codec, Decoder, Encoder }
+import io.circe.{ Decoder, Encoder }
 
 private[circe] inline final def summonLabels[T <: Tuple]: List[String] =
   inline erasedValue[T] match
@@ -43,8 +43,8 @@ private[circe] inline final def summonEncoder[A](using Configuration): Encoder[A
 private[circe] inline final def summonEncoder[A](inline derivingForSum: Boolean)(using Configuration): Encoder[A] =
   summonFrom {
     case encodeA: Encoder[A] => encodeA
-    case m: Mirror.Of[A] =>
-      inline if (derivingForSum) ConfiguredEncoder.derived[A]
+    case m: LazyMirror[A] =>
+      inline if (derivingForSum) summonFrom { case e: Encoders[A] => ConfiguredEncoder.derived[A] }
       else error("Failed to find an instance of Encoder[" + typeName[A] + "]")
   }
 
@@ -66,8 +66,8 @@ private[circe] inline final def summonDecoder[A](using Configuration): Decoder[A
 private[circe] inline final def summonDecoder[A](inline derivingForSum: Boolean)(using Configuration): Decoder[A] =
   summonFrom {
     case decodeA: Decoder[A] => decodeA
-    case m: Mirror.Of[A] =>
-      inline if (derivingForSum) ConfiguredDecoder.derived[A]
+    case m: LazyMirror[A] =>
+      inline if (derivingForSum) summonFrom { case d: Decoders[A] => ConfiguredDecoder.derived[A] }
       else error("Failed to find an instance of Decoder[" + typeName[A] + "]")
   }
 

--- a/modules/generic/shared/src/main/scala-3/io/circe/generic/auto.scala
+++ b/modules/generic/shared/src/main/scala-3/io/circe/generic/auto.scala
@@ -17,8 +17,8 @@
 package io.circe.generic
 
 import io.circe.{ Decoder, Encoder }
+import io.circe.derivation.{ Decoders, Encoders, LazyMirror }
 import io.circe.`export`.Exported
-import scala.deriving.Mirror
 
 /**
  * Fully automatic codec derivation.
@@ -28,9 +28,15 @@ import scala.deriving.Mirror
  * trait hierarchies, etc.
  */
 trait AutoDerivation {
-  implicit inline final def deriveDecoder[A](using inline A: Mirror.Of[A]): Exported[Decoder[A]] =
+  implicit inline final def deriveDecoder[A](using
+    inline A: LazyMirror[A],
+    inline D: Decoders[A]
+  ): Exported[Decoder[A]] =
     Exported(Decoder.derived[A])
-  implicit inline final def deriveEncoder[A](using inline A: Mirror.Of[A]): Exported[Encoder.AsObject[A]] =
+  implicit inline final def deriveEncoder[A](using
+    inline A: LazyMirror[A],
+    inline E: Encoders[A]
+  ): Exported[Encoder.AsObject[A]] =
     Exported(Encoder.AsObject.derived[A])
 }
 

--- a/modules/generic/shared/src/main/scala-3/io/circe/generic/semiauto.scala
+++ b/modules/generic/shared/src/main/scala-3/io/circe/generic/semiauto.scala
@@ -17,7 +17,7 @@
 package io.circe.generic
 
 import io.circe.{ Codec, Decoder, Encoder }
-import scala.deriving.Mirror
+import io.circe.derivation.{ Decoders, Encoders, LazyMirror }
 
 /**
  * Semi-automatic codec derivation.
@@ -39,7 +39,13 @@ import scala.deriving.Mirror
  * }}}
  */
 object semiauto {
-  inline final def deriveDecoder[A](using inline A: Mirror.Of[A]): Decoder[A] = Decoder.derived[A]
-  inline final def deriveEncoder[A](using inline A: Mirror.Of[A]): Encoder.AsObject[A] = Encoder.AsObject.derived[A]
-  inline final def deriveCodec[A](using inline A: Mirror.Of[A]): Codec.AsObject[A] = Codec.AsObject.derived[A]
+  inline final def deriveDecoder[A](using inline A: LazyMirror[A], inline D: Decoders[A]): Decoder[A] =
+    Decoder.derived[A]
+  inline final def deriveEncoder[A](using inline A: LazyMirror[A], inline E: Encoders[A]): Encoder.AsObject[A] =
+    Encoder.AsObject.derived[A]
+  inline final def deriveCodec[A](using
+    inline A: LazyMirror[A],
+    inline D: Decoders[A],
+    inline E: Encoders[A]
+  ): Codec.AsObject[A] = Codec.AsObject.derived[A]
 }


### PR DESCRIPTION
Fixes #2263

There seem to be two things that cause the stack overflow:

1. Passing any values derived from the `Mirror`'s type members, e.g. `constValue[mirror.MirroredLabel]`, to a non-`inline` method as strict, by-value parameters
2. Referring to any of a `Mirror`'s type members as path-dependent types, e.g. `mirror.MirroredLabel`

The workaround for the first issue is pretty straightforward -- all values derived from the `Mirror` should be passed as by-name parameters.

The second issue is more complex. Marking the `Mirror` parameter as `inline` fixes it, which is why circe 0.14.6 didn't have the issue, but it only worked because 0.14.6 was using Scala 3.2.2. In Scala 3.3 and later using an `inline` parameter for path-dependent types results in an error:

```scala
(mirror : scala.deriving.Mirror.Of[A]) is not a valid type prefix, since it is not an immutable path
```

The solution is to take type parameters that represent the type members of the `Mirror` and use the type params in place of the path-dependent types, e.g.

```scala
def derived[A, L <: String](using inline m: Mirror.Of[A] { type MirroredLabel = L })
```

I don't think we want to do this in `def derived` though as it would break compatibility and proliferate to every method that calls `derived`.

Instead, this introduces a new `LazyMirror` type (definitely open to ideas on better names) that uses this pattern and captures the values from the `Mirror` that are necessary to support derivation. The `derived` methods then take a `LazyMirror` in place of a `Mirror`.