### PR TITLE
use ISO_OFFSET_DATE_TIME formatter Encoder[ZonedDateTime]

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -52,8 +52,7 @@ import java.time.format.DateTimeFormatter.{
   ISO_LOCAL_DATE_TIME,
   ISO_LOCAL_TIME,
   ISO_OFFSET_DATE_TIME,
-  ISO_OFFSET_TIME,
-  ISO_ZONED_DATE_TIME
+  ISO_OFFSET_TIME
 }
 import java.time.temporal.{ ChronoField, TemporalAccessor }
 import java.util.Currency
@@ -731,11 +730,17 @@ object Encoder
     }
 
   /**
+   * Encodes a `ZonedDateTime` following the ISO-8601 format by using
+   * `java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME`.
+   * In comparison `java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME` does not strictly follow the ISO-8601
+   * standard as it adds the zone ID in brackets in the format of `Region/City` which is not part of the standard and
+   * breaks other non-JVM parsers e.g. `the Date.parse(...)` in JavaScript
+   *
    * @group Time
    */
   implicit final lazy val encodeZonedDateTime: Encoder[ZonedDateTime] =
     new JavaTimeEncoder[ZonedDateTime] {
-      protected final def format: DateTimeFormatter = ISO_ZONED_DATE_TIME
+      protected final def format: DateTimeFormatter = ISO_OFFSET_DATE_TIME
     }
 
   /**

--- a/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
@@ -158,15 +158,23 @@ class JavaTimeCodecSuite extends CirceMunitSuite {
     def check(s: String): Unit =
       assertEquals(Encoder[ZonedDateTime].apply(ZonedDateTime.parse(s)), Json.fromString(s))
 
-    check("2018-07-10T00:00:00Z[UTC]")
-    check("2018-07-10T00:00:00.1Z[UTC]")
-    check("2018-07-10T00:00:00.01Z[UTC]")
-    check("2018-07-10T00:00:00.001Z[UTC]")
-    check("2018-07-10T00:00:00.0001Z[UTC]")
-    check("2018-07-10T00:00:00.00001Z[UTC]")
-    check("2018-07-10T00:00:00.000001Z[UTC]")
-    check("2018-07-10T00:00:00.0000001Z[UTC]")
-    check("2018-07-10T00:00:00.00000001Z[UTC]")
+    check("2018-07-10T00:00:00Z")
+    check("2018-07-10T00:00:00.1Z")
+    check("2018-07-10T00:00:00.01Z")
+    check("2018-07-10T00:00:00.001Z")
+    check("2018-07-10T00:00:00.0001Z")
+    check("2018-07-10T00:00:00.00001Z")
+    check("2018-07-10T00:00:00.000001Z")
+    check("2018-07-10T00:00:00.0000001Z")
+    check("2018-07-10T00:00:00.00000001Z")
+  }
+
+  test("Encoder[ZonedDateTime] should use strict ISO-8601 without adding the zone ID in brackets as a suffix") {
+    def check(s: String): Unit =
+      assertEquals(Encoder[ZonedDateTime].apply(ZonedDateTime.parse(s)), Json.fromString(s))
+
+    check("2018-07-10T00:00:00Z")
+    check("2018-07-10T00:00:00+01:00")
   }
 
   test("Decoder[OffsetDateTime] should fail on invalid values") {


### PR DESCRIPTION
fixes https://github.com/circe/circe/issues/2239