### PR TITLE
pointer literal macro must not mangle already escaped pointers

### DIFF
--- a/modules/pointer-literal/src/main/scala-2/io/circe/pointer/literal/PointerLiteralMacro.scala
+++ b/modules/pointer-literal/src/main/scala-2/io/circe/pointer/literal/PointerLiteralMacro.scala
@@ -36,7 +36,8 @@ private class PointerLiteralMacros(val c: blackbox.Context) {
 
         if (Pointer.parse(stringParts.mkString("X")).isRight) {
           val input = args.zip(stringParts.tail).foldLeft(q"${stringParts.head}") {
-            case (acc, (a, p)) => q"""$acc + $a.toString.replaceAll("~", "~0").replaceAll("/", "~1") + $p"""
+            case (acc, (a, p)) =>
+              q"""$acc + $a.toString.replaceAll("~1", "/").replaceAll("~0", "~").replaceAll("~", "~0").replaceAll("/", "~1") + $p"""
           }
 
           q"""_root_.io.circe.pointer.Pointer.parse($input)

--- a/modules/pointer-literal/src/main/scala-3/io/circe/pointer/literal/PointerLiteralMacro.scala
+++ b/modules/pointer-literal/src/main/scala-3/io/circe/pointer/literal/PointerLiteralMacro.scala
@@ -36,7 +36,13 @@ private object PointerLiteralMacros {
       val input = args.zip(stringParts.tail).foldLeft(Expr(stringParts.head)) {
         case (acc, (a, p)) =>
           val pExpr = Expr(p)
-          '{ $acc + $a.toString.replaceAll("~", "~0").replaceAll("/", "~1") + $pExpr }
+          '{
+            $acc + $a.toString
+              .replaceAll("~1", "/")
+              .replaceAll("~0", "~")
+              .replaceAll("~", "~0")
+              .replaceAll("/", "~1") + $pExpr
+          }
       }
 
       '{

--- a/modules/pointer-literal/src/test/scala/io/circe/pointer/literal/PointerInterpolatorSuite.scala
+++ b/modules/pointer-literal/src/test/scala/io/circe/pointer/literal/PointerInterpolatorSuite.scala
@@ -60,6 +60,11 @@ final class PointerInterpolatorSuite extends ScalaCheckSuite {
     assertEquals(Pointer.parse("/base/foo~0bar~1baz~1~0/leaf"), Right(pointer"/base/$s/leaf"))
   }
 
+  test("The pointer string interpolater should work with interpolated values that are already escaped") {
+    val s: String = "foo~0bar~1baz~1~0"
+    assertEquals(Pointer.parse("/base/foo~0bar~1baz~1~0/leaf"), Right(pointer"/base/$s/leaf"))
+  }
+
   property("The pointer string interpolater should work with arbitrary interpolated strings") {
     Prop.forAll(ScalaCheckInstances.genPointerReferenceString) { (v: String) =>
       Pointer.parse(s"/foo/$v/bar") ?= Right(pointer"/foo/$v/bar")


### PR DESCRIPTION
* Previously it would double escape the ~
* Now unescapes then re-escapes the ~0 and ~1 references

I am sure this can be done in a more efficient way, but this works.