### PR TITLE
Use macros to fix stack overflow when deriving for local classes

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/Derivation.scala
@@ -142,7 +142,8 @@ private[circe] trait EncoderDerivation:
     ConfiguredEncoder.derived[A]
 
 private[circe] trait EncoderDerivationRelaxed:
-  inline final def derived[A: Mirror.Of](using
+  inline final def derived[A](using
+    inline A: Mirror.Of[A],
     configuration: Configuration = Configuration.default
   ): Encoder.AsObject[A] =
     ConfiguredEncoder.derived[A]
@@ -163,7 +164,8 @@ private[circe] trait CodecDerivation:
     ConfiguredCodec.derived[A]
 
 private[circe] trait CodecDerivationRelaxed:
-  inline final def derived[A: Mirror.Of](using
+  inline final def derived[A](using
+    inline A: Mirror.Of[A],
     configuration: Configuration = Configuration.default
   ): Codec.AsObject[A] =
     ConfiguredCodec.derived[A]

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -17,47 +17,97 @@
 package io.circe.derivation
 
 import scala.deriving.Mirror
-import scala.compiletime.constValue
+import scala.compiletime.{ constValue, summonInline }
+import scala.quoted.*
 import io.circe.{ Codec, Decoder, Encoder, HCursor, JsonObject }
 
 trait ConfiguredCodec[A] extends Codec.AsObject[A], ConfiguredDecoder[A], ConfiguredEncoder[A]
 object ConfiguredCodec:
-  private def of[A](nme: String, decoders: => List[Decoder[?]], encoders: => List[Encoder[?]], labels: List[String])(
-    using
-    conf: Configuration,
-    mirror: Mirror.Of[A],
-    defaults: Default[A]
-  ): ConfiguredCodec[A] = mirror match
-    case mirror: Mirror.ProductOf[A] =>
-      new ConfiguredCodec[A] with SumOrProduct:
-        val name = nme
-        lazy val elemDecoders = decoders
-        lazy val elemEncoders = encoders
-        lazy val elemLabels = labels
-        lazy val elemDefaults = defaults
-        def isSum = false
-        def apply(c: HCursor) = decodeProduct(c, mirror.fromProduct)
-        def encodeObject(a: A) = encodeProduct(a)
-        override def decodeAccumulating(c: HCursor) = decodeProductAccumulating(c, mirror.fromProduct)
-    case mirror: Mirror.SumOf[A] =>
-      new ConfiguredCodec[A] with SumOrProduct:
-        val name = nme
-        lazy val elemDecoders = decoders
-        lazy val elemEncoders = encoders
-        lazy val elemLabels = labels
-        lazy val elemDefaults = defaults
-        def isSum = true
-        def apply(c: HCursor) = decodeSum(c)
-        def encodeObject(a: A) = encodeSum(mirror.ordinal(a), a)
-        override def decodeAccumulating(c: HCursor) = decodeSumAccumulating(c)
+  private def ofProduct[A](
+    nme: String,
+    decoders: => List[Decoder[?]],
+    encoders: => List[Encoder[?]],
+    labels: List[String],
+    fromProduct: => Product => A
+  )(using conf: Configuration, defaults: Default[A]): ConfiguredCodec[A] =
+    new ConfiguredCodec[A] with SumOrProduct:
+      private lazy val fp: Product => A = fromProduct
 
-  inline final def derived[A](using conf: Configuration, mirror: Mirror.Of[A]): ConfiguredCodec[A] =
-    ConfiguredCodec.of(
-      constValue[mirror.MirroredLabel],
-      ConfiguredDecoder.decoders[A],
-      ConfiguredEncoder.encoders[A],
-      summonLabels[mirror.MirroredElemLabels]
-    )
+      val name = nme
+      lazy val elemDecoders = decoders
+      lazy val elemEncoders = encoders
+      lazy val elemLabels = labels
+      lazy val elemDefaults = defaults
+      def isSum = false
+      def apply(c: HCursor) = decodeProduct(c, fp)
+      def encodeObject(a: A) = encodeProduct(a)
+      override def decodeAccumulating(c: HCursor) = decodeProductAccumulating(c, fp)
+
+  private def ofSum[A](
+    nme: String,
+    decoders: => List[Decoder[?]],
+    encoders: => List[Encoder[?]],
+    labels: List[String],
+    ordinal: => A => Int
+  )(using conf: Configuration, defaults: Default[A]): ConfiguredCodec[A] =
+    new ConfiguredCodec[A] with SumOrProduct:
+      private lazy val o: A => Int = ordinal
+
+      val name = nme
+      lazy val elemDecoders = decoders
+      lazy val elemEncoders = encoders
+      lazy val elemLabels = labels
+      lazy val elemDefaults = defaults
+      def isSum = true
+      def apply(c: HCursor) = decodeSum(c)
+      def encodeObject(a: A) = encodeSum(o(a), a)
+      override def decodeAccumulating(c: HCursor) = decodeSumAccumulating(c)
+
+  private def derivedImpl[A: Type](
+    conf: Expr[Configuration],
+    mirror: Expr[Mirror.Of[A]]
+  )(using q: Quotes): Expr[ConfiguredCodec[A]] = {
+    import q.reflect.*
+
+    mirror match {
+      case '{
+            $m: Mirror.ProductOf[A] {
+              type MirroredLabel = l
+              type MirroredElemLabels = el
+              type MirroredElemTypes = et
+            }
+          } =>
+        '{
+          ConfiguredCodec.ofProduct[A](
+            constValue[l & String],
+            summonDecoders[et & Tuple](false)(using $conf),
+            summonEncoders[et & Tuple](false)(using $conf),
+            summonLabels[el & Tuple],
+            $m.fromProduct
+          )(using $conf, summonInline[Default[A]])
+        }
+
+      case '{
+            $m: Mirror.SumOf[A] {
+              type MirroredLabel = l
+              type MirroredElemLabels = el
+              type MirroredElemTypes = et
+            }
+          } =>
+        '{
+          ConfiguredCodec.ofSum[A](
+            constValue[l & String],
+            summonDecoders[et & Tuple](true)(using $conf),
+            summonEncoders[et & Tuple](true)(using $conf),
+            summonLabels[el & Tuple],
+            $m.ordinal
+          )(using $conf, summonInline[Default[A]])
+        }
+    }
+  }
+
+  inline final def derived[A](using conf: Configuration, inline mirror: Mirror.Of[A]): ConfiguredCodec[A] =
+    ${ derivedImpl[A]('conf, 'mirror) }
 
   inline final def derive[A: Mirror.Of](
     transformMemberNames: String => String = Configuration.default.transformMemberNames,

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -17,13 +17,14 @@
 package io.circe.derivation
 
 import scala.deriving.Mirror
-import scala.compiletime.constValue
+import scala.compiletime.{ constValue, summonInline }
 import Predef.genericArrayOps
 import cats.data.{ NonEmptyList, Validated }
 import io.circe.{ ACursor, Decoder, DecodingFailure, HCursor }
 import io.circe.DecodingFailure.Reason.WrongTypeExpectation
 import cats.implicits.*
 import scala.collection.immutable.Map
+import scala.quoted.*
 
 trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
   val name: String
@@ -189,38 +190,79 @@ trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
     }
 
 object ConfiguredDecoder:
-  private def of[A](nme: String, decoders: => List[Decoder[?]], labels: List[String])(using
-    conf: Configuration,
-    mirror: Mirror.Of[A],
-    defaults: Default[A]
-  ): ConfiguredDecoder[A] = mirror match
-    case mirror: Mirror.ProductOf[A] =>
-      new ConfiguredDecoder[A] with SumOrProduct:
-        val name = nme
-        lazy val elemDecoders = decoders
-        lazy val elemLabels = labels
-        lazy val elemDefaults = defaults
-        def isSum = false
-        def apply(c: HCursor) = decodeProduct(c, mirror.fromProduct)
-        override def decodeAccumulating(c: HCursor) = decodeProductAccumulating(c, mirror.fromProduct)
-    case _: Mirror.SumOf[A] =>
-      new ConfiguredDecoder[A] with SumOrProduct:
-        val name = nme
-        lazy val elemDecoders = decoders
-        lazy val elemLabels = labels
-        lazy val elemDefaults = defaults
-        def isSum = true
-        def apply(c: HCursor) = decodeSum(c)
-        override def decodeAccumulating(c: HCursor) = decodeSumAccumulating(c)
+  private def ofProduct[A](
+    nme: String,
+    decoders: => List[Decoder[?]],
+    labels: List[String],
+    fromProduct: => Product => A
+  )(using conf: Configuration, defaults: Default[A]): ConfiguredDecoder[A] =
+    new ConfiguredDecoder[A] with SumOrProduct:
+      private lazy val fp: Product => A = fromProduct
 
-  private[derivation] inline final def decoders[A](using conf: Configuration, mirror: Mirror.Of[A]): List[Decoder[?]] =
-    summonDecoders[mirror.MirroredElemTypes](derivingForSum = inline mirror match {
-      case _: Mirror.ProductOf[A] => false
-      case _: Mirror.SumOf[A]     => true
-    })
+      val name = nme
+      lazy val elemDecoders = decoders
+      lazy val elemLabels = labels
+      lazy val elemDefaults = defaults
+      def isSum = false
+      def apply(c: HCursor) = decodeProduct(c, fp)
+      override def decodeAccumulating(c: HCursor) = decodeProductAccumulating(c, fp)
 
-  inline final def derived[A](using conf: Configuration, mirror: Mirror.Of[A]): ConfiguredDecoder[A] =
-    ConfiguredDecoder.of[A](constValue[mirror.MirroredLabel], decoders[A], summonLabels[mirror.MirroredElemLabels])
+  private def ofSum[A](
+    nme: String,
+    decoders: => List[Decoder[?]],
+    labels: List[String]
+  )(using conf: Configuration, defaults: Default[A]): ConfiguredDecoder[A] =
+    new ConfiguredDecoder[A] with SumOrProduct:
+      val name = nme
+      lazy val elemDecoders = decoders
+      lazy val elemLabels = labels
+      lazy val elemDefaults = defaults
+      def isSum = true
+      def apply(c: HCursor) = decodeSum(c)
+      override def decodeAccumulating(c: HCursor) = decodeSumAccumulating(c)
+
+  private def derivedImpl[A: Type](
+    conf: Expr[Configuration],
+    mirror: Expr[Mirror.Of[A]]
+  )(using q: Quotes): Expr[ConfiguredDecoder[A]] = {
+    import q.reflect.*
+
+    mirror match {
+      case '{
+            $m: Mirror.ProductOf[A] {
+              type MirroredLabel = l
+              type MirroredElemLabels = el
+              type MirroredElemTypes = et
+            }
+          } =>
+        '{
+          ConfiguredDecoder.ofProduct[A](
+            constValue[l & String],
+            summonDecoders[et & Tuple](false)(using $conf),
+            summonLabels[el & Tuple],
+            $m.fromProduct
+          )(using $conf, summonInline[Default[A]])
+        }
+
+      case '{
+            $m: Mirror.SumOf[A] {
+              type MirroredLabel = l
+              type MirroredElemLabels = el
+              type MirroredElemTypes = et
+            }
+          } =>
+        '{
+          ConfiguredDecoder.ofSum[A](
+            constValue[l & String],
+            summonDecoders[et & Tuple](true)(using $conf),
+            summonLabels[el & Tuple]
+          )(using $conf, summonInline[Default[A]])
+        }
+    }
+  }
+
+  inline final def derived[A](using conf: Configuration, inline mirror: Mirror.Of[A]): ConfiguredDecoder[A] =
+    ${ derivedImpl[A]('conf, 'mirror) }
 
   inline final def derive[A: Mirror.Of](
     transformMemberNames: String => String = Configuration.default.transformMemberNames,

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEncoder.scala
@@ -18,6 +18,7 @@ package io.circe.derivation
 
 import scala.deriving.Mirror
 import scala.compiletime.constValue
+import scala.quoted.*
 import io.circe.{ Encoder, Json, JsonObject }
 
 trait ConfiguredEncoder[A](using conf: Configuration) extends Encoder.AsObject[A]:
@@ -54,31 +55,68 @@ trait ConfiguredEncoder[A](using conf: Configuration) extends Encoder.AsObject[A
           JsonObject.singleton(constructorName, json)
 
 object ConfiguredEncoder:
-  private def of[A](encoders: => List[Encoder[?]], labels: List[String])(using
-    conf: Configuration,
-    mirror: Mirror.Of[A]
-  ): ConfiguredEncoder[A] = mirror match
-    case _: Mirror.ProductOf[A] =>
-      new ConfiguredEncoder[A] with SumOrProduct:
-        lazy val elemEncoders = encoders
-        lazy val elemLabels = labels
-        def isSum = false
-        def encodeObject(a: A) = encodeProduct(a)
-    case mirror: Mirror.SumOf[A] =>
-      new ConfiguredEncoder[A] with SumOrProduct:
-        lazy val elemEncoders = encoders
-        lazy val elemLabels = labels
-        def isSum = true
-        def encodeObject(a: A) = encodeSum(mirror.ordinal(a), a)
+  private def ofProduct[A](encoders: => List[Encoder[?]], labels: List[String])(using
+    conf: Configuration
+  ): ConfiguredEncoder[A] =
+    new ConfiguredEncoder[A] with SumOrProduct:
+      lazy val elemEncoders = encoders
+      lazy val elemLabels = labels
+      def isSum = false
+      def encodeObject(a: A) = encodeProduct(a)
 
-  private[derivation] inline final def encoders[A](using conf: Configuration, mirror: Mirror.Of[A]): List[Encoder[?]] =
-    summonEncoders[mirror.MirroredElemTypes](derivingForSum = inline mirror match {
-      case _: Mirror.ProductOf[A] => false
-      case _: Mirror.SumOf[A]     => true
-    })
+  private def ofSum[A](
+    encoders: => List[Encoder[?]],
+    labels: List[String],
+    ordinal: => A => Int
+  )(using conf: Configuration): ConfiguredEncoder[A] =
+    new ConfiguredEncoder[A] with SumOrProduct:
+      private lazy val o: A => Int = ordinal
 
-  inline final def derived[A](using conf: Configuration, mirror: Mirror.Of[A]): ConfiguredEncoder[A] =
-    ConfiguredEncoder.of[A](encoders[A], summonLabels[mirror.MirroredElemLabels])
+      lazy val elemEncoders = encoders
+      lazy val elemLabels = labels
+      def isSum = true
+      def encodeObject(a: A) = encodeSum(o(a), a)
+
+  private def derivedImpl[A: Type](
+    conf: Expr[Configuration],
+    mirror: Expr[Mirror.Of[A]]
+  )(using q: Quotes): Expr[ConfiguredEncoder[A]] = {
+    import q.reflect.*
+
+    mirror match {
+      case '{
+            $m: Mirror.ProductOf[A] {
+              type MirroredLabel = l
+              type MirroredElemLabels = el
+              type MirroredElemTypes = et
+            }
+          } =>
+        '{
+          ConfiguredEncoder.ofProduct[A](
+            summonEncoders[et & Tuple](false)(using $conf),
+            summonLabels[el & Tuple]
+          )(using $conf)
+        }
+
+      case '{
+            $m: Mirror.SumOf[A] {
+              type MirroredLabel = l
+              type MirroredElemLabels = el
+              type MirroredElemTypes = et
+            }
+          } =>
+        '{
+          ConfiguredEncoder.ofSum[A](
+            summonEncoders[et & Tuple](true)(using $conf),
+            summonLabels[el & Tuple],
+            $m.ordinal
+          )(using $conf)
+        }
+    }
+  }
+
+  inline final def derived[A](using conf: Configuration, inline mirror: Mirror.Of[A]): ConfiguredEncoder[A] =
+    ${ derivedImpl[A]('conf, 'mirror) }
 
   inline final def derive[A: Mirror.Of](
     transformMemberNames: String => String = Configuration.default.transformMemberNames,


### PR DESCRIPTION
Fixes #2263 
Supersedes and closes #2278 if merged

@hamnis this is an alternate approach to what I did in #2278. By using macros for derivation we can match on the `Mirror` and extract the `MirroredLabel`, `MirroredElemLabels`, and `MirroredElemTypes` types without causing a stack overflow.

There are two caveats (the tests will fail if either of these things change in the future):

1. Any methods that call the macros must mark their `Mirror.Of` as `inline`
2. Any parameters derived from the `Mirror` in the macro must be passed by-name, e.g. `fromProduct` in `ConfiguredDecoder.ofProduct` and `ConfiguredEncoder.ofSum`