### PR TITLE
Use values from a constant pool when possible

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -500,7 +500,7 @@ object Json {
   /**
    * Create a `Json` value representing a JSON array from a collection of values.
    */
-  final def fromValues(values: Iterable[Json]): Json = 
+  final def fromValues(values: Iterable[Json]): Json =
     if (values.isEmpty) EmptyArray
     else JArray(values.toVector)
 

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -543,7 +543,7 @@ object Json {
   /**
    * Create a `Json` value representing a JSON number from an `Int`.
    */
-  final def fromInt(value: Int): Json = JNumber(JsonNumber.fromLong(value.toLong))
+  final def fromInt(value: Int): Json = JsonNumber.fromLong(value.toLong)
 
   /**
    * Create a `Json` value representing a JSON number or a null from an `Option[Int]`.
@@ -553,7 +553,7 @@ object Json {
   /**
    * Create a `Json` value representing a JSON number from a `Long`.
    */
-  final def fromLong(value: Long): Json = JNumber(JsonNumber.fromLong(value))
+  final def fromLong(value: Long): Json = JsonNumber.fromLong(value)
 
   /**
    * Create a `Json` value representing a JSON number or null from an optional `Long`.

--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -479,6 +479,8 @@ object Json {
   final val Null: Json = JNull
   final val True: Json = JBoolean(true)
   final val False: Json = JBoolean(false)
+  private[this] final val EmptyArray: Json = JArray(Vector.empty)
+  private[this] final val EmptyString: Json = JString("")
 
   /**
    * Create a `Json` value representing a JSON object from key-value pairs.
@@ -498,7 +500,9 @@ object Json {
   /**
    * Create a `Json` value representing a JSON array from a collection of values.
    */
-  final def fromValues(values: Iterable[Json]): Json = JArray(values.toVector)
+  final def fromValues(values: Iterable[Json]): Json = 
+    if (values.isEmpty) EmptyArray
+    else JArray(values.toVector)
 
   /**
    * Create a `Json` value representing a JSON object from a [[JsonObject]].
@@ -515,7 +519,9 @@ object Json {
    *
    * Note that this does not parse the argument.
    */
-  final def fromString(value: String): Json = JString(value)
+  final def fromString(value: String): Json =
+    if (value.isEmpty) EmptyString
+    else JString(value)
 
   /**
    * Create a `Json` value representing a JSON String or null from an `Option[String]`.
@@ -537,7 +543,7 @@ object Json {
   /**
    * Create a `Json` value representing a JSON number from an `Int`.
    */
-  final def fromInt(value: Int): Json = JNumber(JsonLong(value.toLong))
+  final def fromInt(value: Int): Json = JNumber(JsonNumber.fromLong(value.toLong))
 
   /**
    * Create a `Json` value representing a JSON number or a null from an `Option[Int]`.
@@ -547,7 +553,7 @@ object Json {
   /**
    * Create a `Json` value representing a JSON number from a `Long`.
    */
-  final def fromLong(value: Long): Json = JNumber(JsonLong(value))
+  final def fromLong(value: Long): Json = JNumber(JsonNumber.fromLong(value))
 
   /**
    * Create a `Json` value representing a JSON number or null from an optional `Long`.

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -241,10 +241,13 @@ object JsonNumber {
   * Constant pool of integer numbers between -128 to 127, similar to the JVM's constant pool for integers.
   */
   private val jsonLongConstantPool: ArraySeq[JsonLong] =
-    ArraySeq.tabulate(255)(x => JsonLong((x - 128).toLong))
+    ArraySeq.tabulate(256)(x => JsonLong((x - 128).toLong))
 
-  private[circe] final def fromLong(value: Long): JsonLong =
-    jsonLongConstantPool.applyOrElse[Int, JsonLong]((value - 128).toInt, _ => JsonLong(value))
+  private[circe] final def fromLong(value: Long): JsonLong = {
+    val idx = value + 128
+    if (idx >= 0 && idx < jsonLongConstantPool.size) jsonLongConstantPool.apply(idx.toInt)
+    else JsonLong(value)
+  }
 
   /**
    * Return a `JsonNumber` whose value is the valid JSON number in `value`.

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -238,8 +238,8 @@ private[circe] final case class JsonFloat(value: Float) extends JsonNumber {
 object JsonNumber {
 
   /**
-  * Constant pool of integer numbers between -128 to 127, similar to the JVM's constant pool for integers.
-  */
+   * Constant pool of integer numbers between -128 to 127, similar to the JVM's constant pool for integers.
+   */
   private[this] val jsonLongConstantPool: Array[JsonLong] =
     Array.tabulate(256)(x => JsonLong((x - 128).toLong))
 

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -245,7 +245,7 @@ object JsonNumber {
 
   private[circe] final def fromLong(value: Long): JsonLong = {
     val idx = value + 128
-    if (idx >= 0 && idx < jsonLongConstantPool.size) jsonLongConstantPool.apply(idx.toInt)
+    if (idx >= 0 && idx < jsonLongConstantPool.length) jsonLongConstantPool.apply(idx.toInt)
     else JsonLong(value)
   }
 

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -239,13 +239,13 @@ object JsonNumber {
   /**
    * Constant pool of integer numbers between -128 to 127, similar to the JVM's constant pool for integers.
    */
-  private[this] val jsonLongConstantPool: Array[JsonNumber] =
-    Array.tabulate(256)(x => JsonLong((x - 128).toLong))
+  private[this] val jsonLongConstantPool: Array[Json.JNumber] =
+    Array.tabulate(256)(x => Json.JNumber(JsonLong((x - 128).toLong)))
 
-  private[circe] final def fromLong(value: Long): JsonNumber = {
+  private[circe] final def fromLong(value: Long): Json.JNumber = {
     val idx = value + 128
     if (idx >= 0 && idx < jsonLongConstantPool.length) jsonLongConstantPool.apply(idx.toInt)
-    else JsonLong(value)
+    else Json.JNumber(JsonLong(value))
   }
 
   /**
@@ -271,7 +271,7 @@ object JsonNumber {
     else {
       val longValue = java.lang.Long.parseLong(value)
 
-      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else fromLong(longValue)
+      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else fromLong(longValue).value
     }
 
   final def fromString(value: String): Option[JsonNumber] = {

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -22,7 +22,6 @@ import io.circe.numbers.BiggerDecimal
 import java.io.Serializable
 import java.lang.StringBuilder
 import java.math.{ BigDecimal => JavaBigDecimal }
-import scala.collection.immutable.ArraySeq
 
 /**
  * A JSON number with optimization by cases.

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -239,13 +239,13 @@ object JsonNumber {
   /**
    * Constant pool of integer numbers between -128 to 127, similar to the JVM's constant pool for integers.
    */
-  private[this] val jsonLongConstantPool: Array[JNumber] =
+  private[this] val jsonLongConstantPool: Array[JsonNumber] =
     Array.tabulate(256)(x => JsonLong((x - 128).toLong))
 
-  private[circe] final def fromLong(value: Long): JNumber = {
+  private[circe] final def fromLong(value: Long): JsonNumber = {
     val idx = value + 128
     if (idx >= 0 && idx < jsonLongConstantPool.length) jsonLongConstantPool.apply(idx.toInt)
-    else JNumber(value)
+    else JsonLong(value)
   }
 
   /**
@@ -271,7 +271,7 @@ object JsonNumber {
     else {
       val longValue = java.lang.Long.parseLong(value)
 
-      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else fromLong(longValue).value
+      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else fromLong(longValue)
     }
 
   final def fromString(value: String): Option[JsonNumber] = {

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -239,13 +239,13 @@ object JsonNumber {
   /**
    * Constant pool of integer numbers between -128 to 127, similar to the JVM's constant pool for integers.
    */
-  private[this] val jsonLongConstantPool: Array[JsonLong] =
+  private[this] val jsonLongConstantPool: Array[JNumber] =
     Array.tabulate(256)(x => JsonLong((x - 128).toLong))
 
-  private[circe] final def fromLong(value: Long): JsonLong = {
+  private[circe] final def fromLong(value: Long): JNumber = {
     val idx = value + 128
     if (idx >= 0 && idx < jsonLongConstantPool.length) jsonLongConstantPool.apply(idx.toInt)
-    else JsonLong(value)
+    else JNumber(value)
   }
 
   /**
@@ -271,7 +271,7 @@ object JsonNumber {
     else {
       val longValue = java.lang.Long.parseLong(value)
 
-      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else fromLong(longValue)
+      if (value.charAt(0) == '-' && longValue == 0L) JsonDecimal(value) else fromLong(longValue).value
     }
 
   final def fromString(value: String): Option[JsonNumber] = {

--- a/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -240,8 +240,8 @@ object JsonNumber {
   /**
   * Constant pool of integer numbers between -128 to 127, similar to the JVM's constant pool for integers.
   */
-  private val jsonLongConstantPool: ArraySeq[JsonLong] =
-    ArraySeq.tabulate(256)(x => JsonLong((x - 128).toLong))
+  private[this] val jsonLongConstantPool: Array[JsonLong] =
+    Array.tabulate(256)(x => JsonLong((x - 128).toLong))
 
   private[circe] final def fromLong(value: Long): JsonLong = {
     val idx = value + 128

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -253,16 +253,20 @@ object JsonObject {
    * Construct a [[JsonObject]] from an [[scala.collection.Iterable]] (provided for optimization).
    */
   final def fromIterable(fields: Iterable[(String, Json)]): JsonObject = {
-    val map = new LinkedHashMap[String, Json]
-    val iterator = fields.iterator
+    if (fields.isEmpty) {
+      empty
+    } else {
+      val map = new LinkedHashMap[String, Json]
+      val iterator = fields.iterator
 
-    while (iterator.hasNext) {
-      val (key, value) = iterator.next()
+      while (iterator.hasNext) {
+        val (key, value) = iterator.next()
 
-      map.put(key, value)
+        map.put(key, value)
+      }
+
+      fromLinkedHashMap(map)
     }
-
-    new LinkedHashMapJsonObject(map)
   }
 
   /**
@@ -270,7 +274,12 @@ object JsonObject {
    *
    * Note that the order of the fields is arbitrary.
    */
-  final def fromMap(map: Map[String, Json]): JsonObject = fromMapAndVector(map, map.keys.toVector)
+  final def fromMap(map: Map[String, Json]): JsonObject =
+    if (map.isEmpty) {
+      empty
+    } else {
+      fromMapAndVector(map, map.keys.toVector)
+    }
 
   private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject =
     new MapAndVectorJsonObject(map, keys)


### PR DESCRIPTION
Adds a constant pool of longs from -128 to 127 (like the JVM constant integer pool) end constant empty collections (strings, arrays and objects) to be reused when possible, to reduce allocations and memory usage.

Tested this on `file2.json` from https://www.kaggle.com/datasets/shrutimehta/zomato-restaurants-data (A 20MB JSON file with real world data) and got the following results (the `Dataset` object is the class retaining the full data, so that I can know the full retained size):

**Before**
![Screenshot 2024-07-22 at 23 15 41](https://github.com/user-attachments/assets/c100c372-e958-425d-b8c3-0dcb8152a71b)
![Screenshot 2024-07-22 at 23 16 01](https://github.com/user-attachments/assets/418f3ecf-2e63-44e2-9480-4c761e91271d)


**After**
![Screenshot 2024-07-22 at 23 42 53](https://github.com/user-attachments/assets/6c717175-dfd9-4f48-9283-47e3caee8492)
![Screenshot 2024-07-22 at 23 42 39](https://github.com/user-attachments/assets/eff29546-0d10-4714-8c3b-ee3f0c172565)


---

In this case, there was about a 2MB drop in retained size, mostly by allocating less `JsonLong`'s

I did not perform any speed benchmarks, as I'm currently working on battery and don't have my charger 😅 

Either way, I imagine that on large datasets the speed will be highly dependent on your available heap/GC impact.