### PR TITLE
Update munit to 1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,9 @@ ThisBuild / scalafixAll / skip := tlIsScala3.value
 ThisBuild / ScalafixConfig / skip := tlIsScala3.value
 ThisBuild / circeRootOfCodeCoverage := Some("rootJVM")
 
-ThisBuild / evictionErrorLevel := Level.Info
+//This is really bad, but we need to add the _native0.5 for this: https://github.com/sbt/sbt/issues/7140
+ThisBuild / libraryDependencySchemes +=
+  "org.scala-native" %% "test-interface_native0.5" % VersionScheme.Always
 
 val catsVersion = "2.12.0"
 val jawnVersion = "1.6.0"

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ val paradiseVersion = "2.1.1"
 
 val scalaCheckVersion = "1.18.0"
 val munitVersion = "1.0.1"
+val munitScalaCheckVersion = "1.0.0"
 val disciplineVersion = "1.7.0"
 val disciplineScalaTestVersion = "2.3.0"
 val disciplineMunitVersion = "2.0.0"
@@ -322,7 +323,7 @@ lazy val literal = circeCrossModule("literal", CrossType.Pure)
     libraryDependencies ++= Seq(
       "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test,
       "org.scalameta" %%% "munit" % munitVersion % Test,
-      "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test
+      "org.scalameta" %%% "munit-scalacheck" % munitScalaCheckVersion % Test
     ) ++ (if (tlIsScala3.value) Seq("org.typelevel" %%% "jawn-parser" % jawnVersion % Provided)
           else Seq("com.chuusai" %%% "shapeless" % shapelessVersion))
   )
@@ -471,7 +472,7 @@ lazy val pointerLiteral = circeCrossModule("pointer-literal", CrossType.Pure)
     tlVersionIntroduced += "3" -> "0.14.2",
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % munitVersion % Test,
-      "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test
+      "org.scalameta" %%% "munit-scalacheck" % munitScalaCheckVersion % Test
     )
   )
   .nativeSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val refinedNativeVersion = "0.11.2"
 val paradiseVersion = "2.1.1"
 
 val scalaCheckVersion = "1.18.0"
-val munitVersion = "1.0.0"
+val munitVersion = "1.0.1"
 val disciplineVersion = "1.7.0"
 val disciplineScalaTestVersion = "2.3.0"
 val disciplineMunitVersion = "2.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,8 @@ ThisBuild / scalafixAll / skip := tlIsScala3.value
 ThisBuild / ScalafixConfig / skip := tlIsScala3.value
 ThisBuild / circeRootOfCodeCoverage := Some("rootJVM")
 
+ThisBuild / evictionErrorLevel := Level.Info
+
 val catsVersion = "2.12.0"
 val jawnVersion = "1.6.0"
 val shapelessVersion = "2.3.12"


### PR DESCRIPTION
munit-scalacheck is now versioned independently of munit

```
[error] (testsNative / update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* org.scala-native:test-interface_native0.5_2.13:0.5.4 (strict) is selected over {0.5.1}
[error] 	    +- org.scalameta:munit_native0.5_2.13:1.0.1           (depends on 0.5.4)
[error] 	    +- org.scalatest:scalatest-core_native0.5_2.13:3.2.18 (depends on 0.5.1)
[error] 	    +- org.scalacheck:scalacheck_native0.5_2.13:1.18.0    (depends on 0.5.1)
[error]
[error]
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
```

Using `libraryDependencySchemes` wasn't working 😢 
I tried
```Scala
ThisBuild / libraryDependencySchemes ++= Seq(
    "org.scala-native" %% "test-interface" % VersionScheme.Always
)
```
and 
```Scala
ThisBuild / libraryDependencySchemes ++= Seq(
    "org.scala-native" %%% "test-interface" % VersionScheme.Always
)
```
closes: #2294 