### PR TITLE
remove `cats.instances` imports

### DIFF
--- a/modules/benchmark/src/main/scala-2/io/circe/benchmark/JsonObjectBenchmark.scala
+++ b/modules/benchmark/src/main/scala-2/io/circe/benchmark/JsonObjectBenchmark.scala
@@ -16,7 +16,6 @@
 
 package io.circe.benchmark
 
-import cats.instances.list._
 import io.circe.{ Json, JsonObject }
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -16,7 +16,6 @@
 
 package io.circe.testing
 
-import cats.instances.list._
 import io.circe.DecodingFailure.Reason
 import io.circe.DecodingFailure.Reason.CustomReason
 import io.circe.DecodingFailure.Reason.MissingField

--- a/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/CodecTests.scala
@@ -16,7 +16,6 @@
 
 package io.circe.testing
 
-import cats.instances.either._
 import cats.kernel.Eq
 import cats.kernel.laws.SerializableLaws
 import cats.laws._

--- a/modules/testing/shared/src/main/scala/io/circe/testing/EqInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/EqInstances.scala
@@ -16,9 +16,6 @@
 
 package io.circe.testing
 
-import cats.instances.either._
-import cats.instances.option._
-import cats.instances.string._
 import cats.kernel.Eq
 import io.circe.Decoder
 import io.circe.Encoder

--- a/modules/testing/shared/src/main/scala/io/circe/testing/KeyCodecLaws.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/KeyCodecLaws.scala
@@ -16,7 +16,6 @@
 
 package io.circe.testing
 
-import cats.instances.option._
 import cats.kernel.Eq
 import cats.kernel.laws.IsEq
 import cats.kernel.laws.SerializableLaws

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
@@ -18,7 +18,6 @@ package io.circe.testing
 
 import cats.data.Validated
 import cats.data.ValidatedNel
-import cats.instances.either._
 import cats.kernel.laws.SerializableLaws
 import cats.laws._
 import cats.laws.discipline._

--- a/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/PrinterTests.scala
@@ -16,7 +16,6 @@
 
 package io.circe.testing
 
-import cats.instances.option._
 import cats.kernel.Eq
 import cats.kernel.laws.SerializableLaws
 import cats.laws._

--- a/modules/tests/shared/src/test/scala-2.13/io/circe/ArraySeqSuite.scala
+++ b/modules/tests/shared/src/test/scala-2.13/io/circe/ArraySeqSuite.scala
@@ -18,8 +18,6 @@ package io.circe
 
 import io.circe.tests.CirceMunitSuite
 import io.circe.syntax.EncoderOps
-import cats.instances.int.catsKernelStdOrderForInt
-import cats.instances.string.catsKernelStdOrderForString
 import io.circe.testing.CodecTests
 import org.scalacheck.Prop._
 import scala.collection.immutable.ArraySeq

--- a/modules/tests/shared/src/test/scala/io/circe/ACursorSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/ACursorSuite.scala
@@ -16,7 +16,6 @@
 
 package io.circe
 
-import cats.instances.all._
 import cats.syntax.eq._
 import io.circe.syntax._
 import io.circe.tests.CirceMunitSuite

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -27,7 +27,6 @@ import cats.data.{
   NonEmptyVector,
   Validated
 }
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline.arbitrary._
 import cats.syntax.contravariant._

--- a/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonObjectSuite.scala
@@ -17,7 +17,6 @@
 package io.circe
 
 import cats.data.Const
-import cats.instances.all._
 import cats.syntax.functor._
 import cats.kernel.Eq
 import io.circe.tests.CirceMunitSuite

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -16,7 +16,6 @@
 
 package io.circe
 
-import cats.instances.all._
 import cats.syntax.eq._
 import io.circe.syntax._
 import io.circe.tests.CirceMunitSuite

--- a/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/KeyCodecSuite.scala
@@ -19,7 +19,6 @@ package io.circe
 import java.net.URI
 import java.util.UUID
 
-import cats.instances.all._
 import io.circe.testing.KeyCodecTests
 import io.circe.tests.CirceMunitSuite
 


### PR DESCRIPTION
https://github.com/typelevel/cats/releases/tag/v2.2.0

> all Cats type class instances for standard library types are now available in implicit scope, and no longer have to be imported. This has a number of benefits, including faster compile times and fewer things to think about. Please see https://github.com/typelevel/cats/pull/3043, [this blog post](https://meta.plasm.us/posts/2019/09/30/implicit-scope-and-cats/), [the 2.2.0-M1 release notes](https://github.com/typelevel/cats/releases/tag/v2.2.0-M1), and the migration guide below for more detailed information about this change.