### PR TITLE
Make ArbitraryInstances extend ArbitraryInstances

### DIFF
--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -149,4 +149,4 @@ trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with CogenInstan
   )
 }
 
-object ArbitraryInstances {}
+object ArbitraryInstances extends ArbitraryInstances


### PR DESCRIPTION
Currently, you have to extend the trait in your test suite to get the instances (which are needed for codec laws). My preference is to import the instances instead, that way it feels like using a less powerful feature, as it doesn't give my test suite an extra supertype.

I also suppose this was intended to be possible before, but was omitted/removed by accident.