### PR TITLE
fix warning in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ ThisBuild / scalaVersion := Scala213V
 ThisBuild / githubWorkflowJavaVersions := Seq("8", "11", "17").map(JavaSpec.temurin)
 
 ThisBuild / tlCiScalafixCheck := false // TODO: Address these in a follow up PR
-ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
 ThisBuild / scalafixAll / skip := tlIsScala3.value
 ThisBuild / ScalafixConfig / skip := tlIsScala3.value
 ThisBuild / circeRootOfCodeCoverage := Some("rootJVM")


### PR DESCRIPTION
```
/home/runner/work/circe/circe/build.sbt:21: warning: value scalafixScalaBinaryVersion in object autoImport is deprecated (since 0.12.1): scalafixScalaBinaryVersion now follows scalaVersion by default
ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
            ^
```