### PR TITLE
Derivation for fat structures

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -22,7 +22,7 @@ import io.circe.{ Codec, Decoder, Encoder }
 
 private[circe] inline final def summonLabels[T <: Tuple]: List[String] =
   loopUnrolledNoArg[String, T](
-    constString,
+    constString
   )
 
 @deprecated("Use summonEncoders(derivingForSum: Boolean) instead", "0.14.7")
@@ -91,23 +91,23 @@ private[circe] inline final def loopUnrolled[A, Arg, T <: Tuple](f: Inliner[A, A
 private[circe] inline def loopUnrolledNoArg[A, T <: Tuple](f: Inliner[A, Unit]): List[A] =
   loopUnrolled[A, Unit, T](f, ())
 
-private[circe] abstract class Inliner[A, Arg]:
+private[circe] trait Inliner[A, Arg]:
   inline def apply[T](inline arg: Arg): A
 
 private[circe] object constString extends Inliner[String, Unit]:
   inline def apply[T](inline arg: Unit): String = constValue[T].asInstanceOf[String]
 
-private[circe] class EncoderDeriveSum(using config: Configuration) extends Inliner[Encoder[?], Unit]:
-  inline def apply[T](inline arg: Unit): Encoder[?] = summonEncoder[T](true)
+private[circe] class EncoderDeriveSum(using config: Configuration) extends Inliner[Encoder[_], Unit]:
+  inline def apply[T](inline arg: Unit): Encoder[_] = summonEncoder[T](true)
 
-private[circe] class EncoderNotDeriveSum(using config: Configuration) extends Inliner[Encoder[?], Unit]:
-  inline def apply[T](inline arg: Unit): Encoder[?] = summonEncoder[T](false)
+private[circe] class EncoderNotDeriveSum(using config: Configuration) extends Inliner[Encoder[_], Unit]:
+  inline def apply[T](inline arg: Unit): Encoder[_] = summonEncoder[T](false)
 
-private[circe] class DecoderDeriveSum(using Configuration) extends Inliner[Decoder[?], Unit]:
-  inline def apply[T](inline arg: Unit): Decoder[?] = summonDecoder[T](true)
+private[circe] class DecoderDeriveSum(using Configuration) extends Inliner[Decoder[_], Unit]:
+  inline def apply[T](inline arg: Unit): Decoder[_] = summonDecoder[T](true)
 
-private[circe] class DecoderNotDeriveSum(using Configuration) extends Inliner[Decoder[?], Unit]:
-  inline def apply[T](inline arg: Unit): Decoder[?] = summonDecoder[T](false)
+private[circe] class DecoderNotDeriveSum(using Configuration) extends Inliner[Decoder[_], Unit]:
+  inline def apply[T](inline arg: Unit): Decoder[_] = summonDecoder[T](false)
 
 private[circe] class SummonSingleton[A] extends Inliner[A, Any]:
   inline def apply[T](inline typeName: Any): A =

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -21,9 +21,7 @@ import scala.deriving.Mirror
 import io.circe.{ Codec, Decoder, Encoder }
 
 private[circe] inline final def summonLabels[T <: Tuple]: List[String] =
-  inline erasedValue[T] match
-    case _: EmptyTuple => Nil
-    case _: (t *: ts)  => constValue[t].asInstanceOf[String] :: summonLabels[ts]
+  loopUnrolled[String, T](constString)
 
 @deprecated("Use summonEncoders(derivingForSum: Boolean) instead", "0.14.7")
 private[circe] inline final def summonEncoders[T <: Tuple](using Configuration): List[Encoder[_]] =
@@ -32,9 +30,9 @@ private[circe] inline final def summonEncoders[T <: Tuple](using Configuration):
 private[circe] inline final def summonEncoders[T <: Tuple](inline derivingForSum: Boolean)(using
   Configuration
 ): List[Encoder[_]] =
-  inline erasedValue[T] match
-    case _: EmptyTuple => Nil
-    case _: (t *: ts)  => summonEncoder[t](derivingForSum) :: summonEncoders[ts](derivingForSum)
+  loopUnrolled[Encoder[_], T](
+    inline if (derivingForSum) new EncoderDeriveSum else new EncoderNotDeriveSum
+  )
 
 @deprecated("Use summonEncoder(derivingForSum: Boolean) instead", "0.14.7")
 private[circe] inline final def summonEncoder[A](using Configuration): Encoder[A] =
@@ -55,9 +53,9 @@ private[circe] inline final def summonDecoders[T <: Tuple](using Configuration):
 private[circe] inline final def summonDecoders[T <: Tuple](inline derivingForSum: Boolean)(using
   Configuration
 ): List[Decoder[_]] =
-  inline erasedValue[T] match
-    case _: EmptyTuple => Nil
-    case _: (t *: ts)  => summonDecoder[t](derivingForSum) :: summonDecoders[ts](derivingForSum)
+  loopUnrolled[Decoder[_], T](
+    inline if (derivingForSum) new DecoderDeriveSum else new DecoderNotDeriveSum
+  )
 
 @deprecated("Use summonDecoder(derivingForSum: Boolean) instead", "0.14.7")
 private[circe] inline final def summonDecoder[A](using Configuration): Decoder[A] =
@@ -72,10 +70,41 @@ private[circe] inline final def summonDecoder[A](inline derivingForSum: Boolean)
   }
 
 private[circe] inline def summonSingletonCases[T <: Tuple, A](inline typeName: Any): List[A] =
+  loopUnrolled[A, T](new SummonSingleton[A](typeName))
+
+private[circe] inline final def loopUnrolled[A, T <: Tuple](f: Inliner[A]): List[A] =
   inline erasedValue[T] match
     case _: EmptyTuple => Nil
-    case _: (h *: t) =>
-      inline summonInline[Mirror.Of[h]] match
-        case m: Mirror.Singleton => m.fromProduct(EmptyTuple).asInstanceOf[A] :: summonSingletonCases[t, A](typeName)
-        case m: Mirror =>
-          error("Enum " + codeOf(typeName) + " contains non singleton case " + codeOf(constValue[m.MirroredLabel]))
+    case _: (h1 *: h2 *: h3 *: h4 *: h5 *: h6 *: h7 *: h8 *: h9 *: h10 *: h11 *: h12 *: h13 *: h14 *: h15 *: h16 *:
+          ts) =>
+      f[h1] :: f[h2] :: f[h3] :: f[h4] :: f[h5] :: f[h6] :: f[h7] :: f[h8]
+        :: f[h9] :: f[h10] :: f[h11] :: f[h12] :: f[h13] :: f[h14] :: f[h15] :: f[h16]
+        :: loopUnrolled[A, ts](f)
+    case _: (h1 *: h2 *: h3 *: h4 *: ts) =>
+      f[h1] :: f[h2] :: f[h3] :: f[h4] :: loopUnrolled[A, ts](f)
+    case _: (h *: ts) => f[h] :: loopUnrolled[A, ts](f)
+
+private[circe] abstract class Inliner[A]:
+  inline def apply[T]: A
+
+private[circe] object constString extends Inliner[String]:
+  inline def apply[T]: String = constValue[T].asInstanceOf[String]
+
+private[circe] class EncoderDeriveSum(using config: Configuration) extends Inliner[Encoder[?]]:
+  inline def apply[T]: Encoder[?] = summonEncoder[T](true)
+
+private[circe] class EncoderNotDeriveSum(using config: Configuration) extends Inliner[Encoder[?]]:
+  inline def apply[T]: Encoder[?] = summonEncoder[T](false)
+
+private[circe] class DecoderDeriveSum(using Configuration) extends Inliner[Decoder[?]]:
+  inline def apply[T]: Decoder[?] = summonDecoder[T](true)
+
+private[circe] class DecoderNotDeriveSum(using Configuration) extends Inliner[Decoder[?]]:
+  inline def apply[T]: Decoder[?] = summonDecoder[T](false)
+
+private[circe] class SummonSingleton[A](typeName: Any) extends Inliner[A]:
+  inline def apply[T]: A =
+    inline summonInline[Mirror.Of[T]] match
+      case m: Mirror.Singleton => m.fromProduct(EmptyTuple).asInstanceOf[A]
+      case m: Mirror =>
+        error("Enum " + codeOf(typeName) + " contains non singleton case " + codeOf(constValue[m.MirroredLabel]))

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -98,16 +98,16 @@ private[circe] object constString extends Inliner[String, Unit]:
   inline def apply[T](inline arg: Unit): String = constValue[T].asInstanceOf[String]
 
 private[circe] class EncoderDeriveSum(using config: Configuration) extends Inliner[Encoder[_], Unit]:
-  inline def apply[T](inline arg: Unit): Encoder[_] = summonEncoder[T](true)
+  inline def apply[T](inline arg: Unit): Encoder[?] = summonEncoder[T](true)
 
 private[circe] class EncoderNotDeriveSum(using config: Configuration) extends Inliner[Encoder[_], Unit]:
-  inline def apply[T](inline arg: Unit): Encoder[_] = summonEncoder[T](false)
+  inline def apply[T](inline arg: Unit): Encoder[?] = summonEncoder[T](false)
 
 private[circe] class DecoderDeriveSum(using Configuration) extends Inliner[Decoder[_], Unit]:
-  inline def apply[T](inline arg: Unit): Decoder[_] = summonDecoder[T](true)
+  inline def apply[T](inline arg: Unit): Decoder[?] = summonDecoder[T](true)
 
 private[circe] class DecoderNotDeriveSum(using Configuration) extends Inliner[Decoder[_], Unit]:
-  inline def apply[T](inline arg: Unit): Decoder[_] = summonDecoder[T](false)
+  inline def apply[T](inline arg: Unit): Decoder[?] = summonDecoder[T](false)
 
 private[circe] class SummonSingleton[A] extends Inliner[A, Any]:
   inline def apply[T](inline typeName: Any): A =

--- a/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredEnumDerivesSuites.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredEnumDerivesSuites.scala
@@ -54,7 +54,6 @@ class ConfiguredEnumDerivesSuites extends CirceMunitSuite:
           case SingletonCase
           case NonSingletonCase(field: Int)""")
     val expectedError = """error: Enum "WithNonSingletonCase" contains non singleton case "NonSingletonCase""""
-    println(error)
     assert(error.contains(expectedError) == true)
   }
 

--- a/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredEnumDerivesSuites.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredEnumDerivesSuites.scala
@@ -54,6 +54,7 @@ class ConfiguredEnumDerivesSuites extends CirceMunitSuite:
           case SingletonCase
           case NonSingletonCase(field: Int)""")
     val expectedError = """error: Enum "WithNonSingletonCase" contains non singleton case "NonSingletonCase""""
+    println(error)
     assert(error.contains(expectedError) == true)
   }
 

--- a/modules/tests/shared/src/test/scala-3/io/circe/DerivesSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/DerivesSuite.scala
@@ -258,14 +258,92 @@ object DerivesSuite {
     v31: String,
     v32: String,
     v33: String
-  ) derives Encoder,
+  ) derives Encoder.AsObject,
         Decoder
+
+  object LongClass:
+    given Eq[LongClass] = Eq.fromUniversalEquals
+    given Arbitrary[LongClass] = Arbitrary {
+      for
+        s1 <- Arbitrary.arbitrary[String]
+        s2 <- Arbitrary.arbitrary[String]
+        s3 <- Arbitrary.arbitrary[String]
+        s4 <- Arbitrary.arbitrary[String]
+        s5 <- Arbitrary.arbitrary[String]
+        s6 <- Arbitrary.arbitrary[String]
+        s7 <- Arbitrary.arbitrary[String]
+        s8 <- Arbitrary.arbitrary[String]
+        s9 <- Arbitrary.arbitrary[String]
+        s10 <- Arbitrary.arbitrary[String]
+        s11 <- Arbitrary.arbitrary[String]
+        s12 <- Arbitrary.arbitrary[String]
+        s13 <- Arbitrary.arbitrary[String]
+        s14 <- Arbitrary.arbitrary[String]
+        s15 <- Arbitrary.arbitrary[String]
+        s16 <- Arbitrary.arbitrary[String]
+        s17 <- Arbitrary.arbitrary[String]
+        s18 <- Arbitrary.arbitrary[String]
+        s19 <- Arbitrary.arbitrary[String]
+        s20 <- Arbitrary.arbitrary[String]
+        s21 <- Arbitrary.arbitrary[String]
+        s22 <- Arbitrary.arbitrary[String]
+        s23 <- Arbitrary.arbitrary[String]
+        s24 <- Arbitrary.arbitrary[String]
+        s25 <- Arbitrary.arbitrary[String]
+        s26 <- Arbitrary.arbitrary[String]
+        s27 <- Arbitrary.arbitrary[String]
+        s28 <- Arbitrary.arbitrary[String]
+        s29 <- Arbitrary.arbitrary[String]
+        s30 <- Arbitrary.arbitrary[String]
+        s31 <- Arbitrary.arbitrary[String]
+        s32 <- Arbitrary.arbitrary[String]
+        s33 <- Arbitrary.arbitrary[String]
+      yield LongClass(
+        s1,
+        s2,
+        s3,
+        s4,
+        s5,
+        s6,
+        s7,
+        s8,
+        s9,
+        s10,
+        s11,
+        s12,
+        s13,
+        s14,
+        s15,
+        s16,
+        s17,
+        s18,
+        s19,
+        s20,
+        s21,
+        s22,
+        s23,
+        s24,
+        s25,
+        s26,
+        s27,
+        s28,
+        s29,
+        s30,
+        s31,
+        s32,
+        s33
+      )
+    }
 
   enum LongEnum derives Encoder, Decoder:
     case v1, v2, v3, v4, v5, v6, v7, v8, v9, v10,
       v11, v12, v13, v14, v15, v16, v17, v18, v19, v20,
       v21, v22, v23, v24, v25, v26, v27, v28, v29, v30,
       v31, v32, v33
+
+  object LongEnum:
+    given Eq[LongEnum] = Eq.fromUniversalEquals
+    given Arbitrary[LongEnum] = Arbitrary(Gen.oneOf(LongEnum.values))
 
   enum LongSum derives Encoder, Decoder:
     case v1(str: String)
@@ -301,6 +379,51 @@ object DerivesSuite {
     case v31(str: String)
     case v32(str: String)
     case v33(str: String)
+
+  object LongSum:
+    given Eq[LongSum] = Eq.fromUniversalEquals
+    given Arbitrary[LongSum] = Arbitrary(
+      for
+        v <- Arbitrary.arbitrary[String]
+        res <- Gen.oneOf(
+          Seq(
+            v1(v),
+            v2(v),
+            v3(v),
+            v4(v),
+            v5(v),
+            v6(v),
+            v7(v),
+            v8(v),
+            v9(v),
+            v10(v),
+            v11(v),
+            v12(v),
+            v13(v),
+            v14(v),
+            v15(v),
+            v16(v),
+            v17(v),
+            v18(v),
+            v19(v),
+            v20(v),
+            v21(v),
+            v22(v),
+            v23(v),
+            v24(v),
+            v25(v),
+            v26(v),
+            v27(v),
+            v28(v),
+            v29(v),
+            v30(v),
+            v31(v),
+            v32(v),
+            v33(v)
+          )
+        )
+      yield res
+    )
 }
 
 class DerivesSuite extends CirceMunitSuite {
@@ -320,6 +443,9 @@ class DerivesSuite extends CirceMunitSuite {
   checkAll("Codec[ADTWithSubTraitExample]", CodecTests[ADTWithSubTraitExample].codec)
   checkAll("Codec[ProductWithTaggedMember] (#2135)", CodecTests[ProductWithTaggedMember].codec)
   checkAll("Codec[Outer]", CodecTests[Outer].codec)
+  checkAll("Codec[LongClass]", CodecTests[LongClass].codec)
+  checkAll("Codec[LongSum]", CodecTests[LongSum].codec)
+  checkAll("Codec[LongEnum]", CodecTests[LongEnum].codec)
 
   test("Nested sums should not be encoded redundantly") {
     val foo: ADTWithSubTraitExample = TheClass(0)

--- a/modules/tests/shared/src/test/scala-3/io/circe/DerivesSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/DerivesSuite.scala
@@ -266,6 +266,41 @@ object DerivesSuite {
       v11, v12, v13, v14, v15, v16, v17, v18, v19, v20,
       v21, v22, v23, v24, v25, v26, v27, v28, v29, v30,
       v31, v32, v33
+
+  enum LongSum derives Encoder, Decoder:
+    case v1(str: String)
+    case v2(str: String)
+    case v3(str: String)
+    case v4(str: String)
+    case v5(str: String)
+    case v6(str: String)
+    case v7(str: String)
+    case v8(str: String)
+    case v9(str: String)
+    case v10(str: String)
+    case v11(str: String)
+    case v12(str: String)
+    case v13(str: String)
+    case v14(str: String)
+    case v15(str: String)
+    case v16(str: String)
+    case v17(str: String)
+    case v18(str: String)
+    case v19(str: String)
+    case v20(str: String)
+    case v21(str: String)
+    case v22(str: String)
+    case v23(str: String)
+    case v24(str: String)
+    case v25(str: String)
+    case v26(str: String)
+    case v27(str: String)
+    case v28(str: String)
+    case v29(str: String)
+    case v30(str: String)
+    case v31(str: String)
+    case v32(str: String)
+    case v33(str: String)
 }
 
 class DerivesSuite extends CirceMunitSuite {

--- a/modules/tests/shared/src/test/scala-3/io/circe/DerivesSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/DerivesSuite.scala
@@ -223,6 +223,49 @@ object DerivesSuite {
     given Eq[Outer] = Eq.fromUniversalEquals
     given Arbitrary[Outer] =
       Arbitrary(Gen.option(Arbitrary.arbitrary[String].map(Inner.apply)).map(Outer.apply))
+
+  case class LongClass(
+    v1: String,
+    v2: String,
+    v3: String,
+    v4: String,
+    v5: String,
+    v6: String,
+    v7: String,
+    v8: String,
+    v9: String,
+    v10: String,
+    v11: String,
+    v12: String,
+    v13: String,
+    v14: String,
+    v15: String,
+    v16: String,
+    v17: String,
+    v18: String,
+    v19: String,
+    v20: String,
+    v21: String,
+    v22: String,
+    v23: String,
+    v24: String,
+    v25: String,
+    v26: String,
+    v27: String,
+    v28: String,
+    v29: String,
+    v30: String,
+    v31: String,
+    v32: String,
+    v33: String
+  ) derives Encoder,
+        Decoder
+
+  enum LongEnum derives Encoder, Decoder:
+    case v1, v2, v3, v4, v5, v6, v7, v8, v9, v10,
+      v11, v12, v13, v14, v15, v16, v17, v18, v19, v20,
+      v21, v22, v23, v24, v25, v26, v27, v28, v29, v30,
+      v31, v32, v33
 }
 
 class DerivesSuite extends CirceMunitSuite {


### PR DESCRIPTION
Currently scala3 derivations of `Encoder`, `Decoder` for long structures (more than 28 fields) is not supported (at least for standard compiler options).
This happens because of the error:

```
Maximal number of successive inlines (32) exceeded,
Maybe this is caused by a recursive inline method?
You can use -Xmax-inlines to change the limit.
```

Example: 
https://scastie.scala-lang.org/road21/DQVmLQVuQIO18zEde0Omcw/31

This pr provides derivation for longer data structures by unrolling inline loops.
The idea is stolen from:

https://github.com/getkyo/kyo/blob/c33fba7e3c4954533819d6a1fa68df414676ec0a/kyo-data/shared/src/main/scala/kyo/internal/TypeIntersection.scala#L120

And I was too lazy to unroll each `summon**` аnd made `Inliner` abstraction to implement unrolling logic only once.