### PR TITLE
Make it easier to derive a `Codec` without an explicit `Codec`

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Codec.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Codec.scala
@@ -93,6 +93,19 @@ object Codec extends ProductCodecs with ProductTypedCodecs with EnumerationCodec
       def apply(a: A): Json = encodeA(a)
     }
 
+  /**
+   * A shortcut for `Codec.from[Foo](implicitly, implicitly)`
+   *
+   * This is useful when deriving a codec for a wrapper type that has a `Decoder` and `Encoder`, but no
+   * explicit `Codec`
+   *
+   * {{{
+   *   implicit val explicitly: Codec[Foo] = Codec.from[Boolean](implicitly, implicitly).imap(Foo(_))(_.value)
+   *   implicit val viaImplied: Codec[Bar] = Codec.implied[Boolean].imap(Bar(_))(_.value)
+   * }}}
+   */
+  def implied[A: Decoder: Encoder]: Codec[A] = from[A](Decoder[A], Encoder[A])
+
   trait AsRoot[A] extends Codec[A] with Encoder.AsRoot[A]
 
   object AsRoot {


### PR DESCRIPTION
This should help address part of #1542 

Specifically, the first use case (the proposed `bimap` has been added as `iemap` since the issue was opened)

```scala
implicit val hostnameCodec: Codec[Hostname] = Codec.implied[String].iemap(s => Hostname(s).toRight(s"Could not parse $s as a valid Hostname"))(_.normalized.toString)
```