### PR TITLE
add empty/singleton implementations of `JsonObject` to optimize memory usage

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -335,7 +335,7 @@ object JsonObject {
 
     override def add(k: String, j: Json): JsonObject = new LinkedHashMapJsonObject(
       {
-        val map = new LinkedHashMap[String, Json]
+        val map = new LinkedHashMap[String, Json](2)
         map.put(field, value)
         map.put(k, j)
         map

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -258,7 +258,7 @@ object JsonObject {
       val fieldsSeq = fields.iterator.toSeq
       if (fields.sizeIs == 1) new SingletonJsonObject(fieldsSeq.head._1, fieldsSeq.head._2)
       else {
-        val map = new LinkedHashMap[String, Json]()
+        val map = new LinkedHashMap[String, Json](fields.size)
         val it = fields.iterator
         while (it.hasNext) {
           val (key, value) = it.next()

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -258,8 +258,8 @@ object JsonObject {
       case 1 =>
         val (key, value) = fieldsSeq.head
         new SingletonJsonObject(key, value)
-      case _ =>
-        val map = new LinkedHashMap[String, Json](fields.size)
+      case size =>
+        val map = new LinkedHashMap[String, Json](size)
         val it = fields.iterator
         while (it.hasNext) {
           val (key, value) = it.next()

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -344,13 +344,16 @@ object JsonObject {
     override def +:(field: (String, Json)): JsonObject =
       add(field._1, field._2)
 
-    override def remove(key: String): JsonObject =
-      empty
+    override def remove(key: String): JsonObject = {
+      if (key == field) empty
+      else this
+    }
 
     override def traverse[F[_]](f: Json => F[Json])(implicit F: Applicative[F]): F[JsonObject] =
       F.map(f(value))(new SingletonJsonObject(field, _))
 
-    override def mapValues(f: Json => Json): JsonObject = new SingletonJsonObject(field, f(value))
+    override def mapValues(f: Json => Json): JsonObject =
+      new SingletonJsonObject(field, f(value))
 
     override private[circe] def appendToFolder(folder: Printer.PrintingFolder): Unit = {
       val originalDepth = folder.depth

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -305,6 +305,10 @@ object JsonObject {
   implicit final val showJsonObject: Show[JsonObject] = Show.fromToString
   implicit final val eqJsonObject: Eq[JsonObject] = Eq.fromUniversalEquals
 
+  /**
+   * An implementation of [[JsonObject]] for objects containing a single field, with a lighter memory footprint
+   * than map based implementations.
+   */
   private[this] final class SingletonJsonObject(field: String, value: Json) extends JsonObject {
     override private[circe] def applyUnsafe(k: String): Json =
       if (k == field) value else null

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -298,7 +298,7 @@ object JsonObject {
   /**
    * Construct an empty [[JsonObject]].
    */
-  final val empty: JsonObject = new MapAndVectorJsonObject(Map.empty, Vector.empty)
+  final val empty: JsonObject = EmptyJsonObject
 
   /**
    * Construct a [[JsonObject]] with a single field.
@@ -307,6 +307,32 @@ object JsonObject {
 
   implicit final val showJsonObject: Show[JsonObject] = Show.fromToString
   implicit final val eqJsonObject: Eq[JsonObject] = Eq.fromUniversalEquals
+
+  /**
+   * An empty implementation of [[JsonObject]].
+   */
+  private[this] object EmptyJsonObject extends JsonObject {
+    override private[circe] def applyUnsafe(k: String): Json = null
+    override def apply(key: String): Option[Json] = None
+    override def contains(key: String): Boolean = false
+    override val size: Int = 0
+    override val isEmpty: Boolean = true
+    override val keys: Iterable[String] = Iterable.empty
+    override val values: Iterable[Json] = Iterable.empty
+    override val toMap: Map[String, Json] = Map.empty
+    override val toIterable: Iterable[(String, Json)] = Iterable.empty
+    override def add(k: String, j: Json): JsonObject = singleton(k, j)
+    override def +:(field: (String, Json)): JsonObject = singleton(field._1, field._2)
+    override def remove(key: String): JsonObject = this
+    override def traverse[F[_]](f: Json => F[Json])(implicit F: Applicative[F]): F[JsonObject] = F.pure(this)
+    override def mapValues(f: Json => Json): JsonObject = this
+
+    override private[circe] def appendToFolder(folder: Printer.PrintingFolder): Unit = {
+      val p = folder.pieces(folder.depth)
+      folder.writer.append(p.lBraces)
+      folder.writer.append(p.rBraces)
+    }
+  }
 
   /**
    * An implementation of [[JsonObject]] for objects containing a single field, with a lighter memory footprint

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -22,10 +22,8 @@ import cats.Foldable
 import cats.Show
 import cats.data.Kleisli
 
-import java.io.Serializable
 import java.util.LinkedHashMap
 import scala.annotation.switch
-import scala.collection.immutable.Map
 
 /**
  * A mapping from keys to JSON values that maintains insertion order.
@@ -337,16 +335,22 @@ object JsonObject {
     override def toIterable: Iterable[(String, Json)] =
       Iterable.single(field -> value)
 
-    override def add(k: String, j: Json): JsonObject = new LinkedHashMapJsonObject(
-      {
-        val map = new LinkedHashMap[String, Json](2)
-        map.put(field, value)
-        map.put(k, j)
-        map
+    private def addOrReplace(k: String, j: Json, append: Boolean): JsonObject = {
+      if (k == field) new SingletonJsonObject(k, j)
+      else {
+        val fields = Map.from(Seq((field, value), (k, j)))
+        val orderedKeys = if (append) Vector(field, k) else Vector(k, field)
+        new MapAndVectorJsonObject(fields, orderedKeys)
       }
-    )
-    override def +:(field: (String, Json)): JsonObject =
-      add(field._1, field._2)
+    }
+
+    override def add(k: String, j: Json): JsonObject =
+      addOrReplace(k, j, append = true)
+
+    override def +:(field: (String, Json)): JsonObject = {
+      val (k, j) = field
+      addOrReplace(k, j, append = false)
+    }
 
     override def remove(key: String): JsonObject = {
       if (key == field) empty

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -252,19 +252,20 @@ object JsonObject {
    * Construct a [[JsonObject]] from an [[scala.collection.Iterable]] (provided for optimization).
    */
   final def fromIterable(fields: Iterable[(String, Json)]): JsonObject = {
-    (fields.sizeIs: @switch) match {
-      case 0 => empty
-      case 1 =>
-        val (key, value) = fields.iterator.next
-        singleton(key, value)
-      case size =>
-        val map = new LinkedHashMap[String, Json](size)
-        val it = fields.iterator
-        while (it.hasNext) {
-          val (key, value) = it.next()
-          map.put(key, value)
-        }
-        new LinkedHashMapJsonObject(map)
+    val size = fields.sizeIs
+    if (size == 0) {
+      empty
+    } else if (size == 1) {
+      val (key, value) = fields.iterator.next
+      singleton(key, value)
+    } else {
+      val map = new LinkedHashMap[String, Json](2)
+      val it = fields.iterator
+      while (it.hasNext) {
+        val (key, value) = it.next()
+        map.put(key, value)
+      }
+      new LinkedHashMapJsonObject(map)
     }
   }
 
@@ -276,12 +277,16 @@ object JsonObject {
   final def fromMap(map: Map[String, Json]): JsonObject =
     fromMapAndVector(map, map.keys.toVector)
 
-  private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject =
-    (map.sizeIs: @switch) match {
-      case 0 => empty
-      case 1 => singleton(map.keys.iterator.next(), map.values.iterator.next())
-      case _ => new MapAndVectorJsonObject(map, keys)
+  private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject = {
+    val size = map.sizeIs
+    if (size == 0) {
+      empty
+    } else if (size == 1) {
+      singleton(map.keys.iterator.next(), map.values.iterator.next())
+    } else {
+      new MapAndVectorJsonObject(map, keys)
     }
+  }
 
   private[circe] final def fromLinkedHashMap(map: LinkedHashMap[String, Json]): JsonObject =
     (map.size: @switch) match {

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -24,6 +24,7 @@ import cats.data.Kleisli
 
 import java.io.Serializable
 import java.util.LinkedHashMap
+import scala.annotation.switch
 import scala.collection.immutable.Map
 
 /**
@@ -277,17 +278,19 @@ object JsonObject {
   final def fromMap(map: Map[String, Json]): JsonObject =
     fromMapAndVector(map, map.keys.toVector)
 
-  private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject = {
-    if (map.isEmpty) empty
-    else if (map.size == 1) new SingletonJsonObject(map.keys.iterator.next(), map.values.iterator.next())
-    else new MapAndVectorJsonObject(map, keys)
-  }
+  private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject =
+    (map.size: @switch) match {
+      case 0 => empty
+      case 1 => new SingletonJsonObject(map.keys.iterator.next(), map.values.iterator.next())
+      case _ => new MapAndVectorJsonObject(map, keys)
+    }
 
-  private[circe] final def fromLinkedHashMap(map: LinkedHashMap[String, Json]): JsonObject = {
-    if (map.isEmpty) empty
-    else if (map.size() == 1) new SingletonJsonObject(map.keySet().iterator.next(), map.values.iterator.next())
-    else new LinkedHashMapJsonObject(map)
-  }
+  private[circe] final def fromLinkedHashMap(map: LinkedHashMap[String, Json]): JsonObject =
+    (map.size: @switch) match {
+      case 0 => empty
+      case 1 => new SingletonJsonObject(map.keySet().iterator.next(), map.values.iterator.next())
+      case _ => new LinkedHashMapJsonObject(map)
+    }
 
   /**
    * Construct an empty [[JsonObject]].

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -253,19 +253,15 @@ object JsonObject {
    * Construct a [[JsonObject]] from an [[scala.collection.Iterable]] (provided for optimization).
    */
   final def fromIterable(fields: Iterable[(String, Json)]): JsonObject = {
-    if (fields.isEmpty) {
-      empty
-    } else {
-      val map = new LinkedHashMap[String, Json]
-      val iterator = fields.iterator
-
-      while (iterator.hasNext) {
-        val (key, value) = iterator.next()
-
-        map.put(key, value)
+    if (fields.isEmpty) empty
+    else {
+      val fieldsSeq = fields.iterator.toSeq
+      if (fields.sizeIs == 1) new SingletonJsonObject(fieldsSeq.head._1, fieldsSeq.head._2)
+      else {
+        val map = new LinkedHashMap[String, Json]
+        for ((key, value) <- fields) map.put(key, value)
+        new LinkedHashMapJsonObject(map)
       }
-
-      fromLinkedHashMap(map)
     }
   }
 
@@ -275,17 +271,19 @@ object JsonObject {
    * Note that the order of the fields is arbitrary.
    */
   final def fromMap(map: Map[String, Json]): JsonObject =
-    if (map.isEmpty) {
-      empty
-    } else {
-      fromMapAndVector(map, map.keys.toVector)
-    }
+    fromMapAndVector(map, map.keys.toVector)
 
-  private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject =
-    new MapAndVectorJsonObject(map, keys)
+  private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject = {
+    if (map.isEmpty) empty
+    else if (map.size == 1) new SingletonJsonObject(map.keys.iterator.next(), map.values.iterator.next())
+    else new MapAndVectorJsonObject(map, keys)
+  }
 
-  private[circe] final def fromLinkedHashMap(map: LinkedHashMap[String, Json]): JsonObject =
-    new LinkedHashMapJsonObject(map)
+  private[circe] final def fromLinkedHashMap(map: LinkedHashMap[String, Json]): JsonObject = {
+    if (map.isEmpty) empty
+    else if (map.size() == 1) new SingletonJsonObject(map.keySet().iterator.next(), map.values.iterator.next())
+    else new LinkedHashMapJsonObject(map)
+  }
 
   /**
    * Construct an empty [[JsonObject]].
@@ -299,6 +297,75 @@ object JsonObject {
 
   implicit final val showJsonObject: Show[JsonObject] = Show.fromToString
   implicit final val eqJsonObject: Eq[JsonObject] = Eq.fromUniversalEquals
+
+  private[this] final class SingletonJsonObject(field: String, value: Json) extends JsonObject {
+    override private[circe] def applyUnsafe(k: String): Json =
+      if (k == field) value else null
+
+    override def apply(key: String): Option[Json] =
+      Option.when(key == field)(value)
+
+    override def contains(key: String): Boolean =
+      key == field
+
+    override val size: Int =
+      1
+
+    override val isEmpty: Boolean =
+      false
+
+    override def keys: Iterable[String] =
+      Iterable.single(field)
+
+    override def values: Iterable[Json] =
+      Iterable.single(value)
+
+    override def toMap: Map[String, Json] =
+      Map(field -> value)
+
+    override def toIterable: Iterable[(String, Json)] =
+      Iterable.single(field -> value)
+
+    override def add(k: String, j: Json): JsonObject = new LinkedHashMapJsonObject(
+      {
+        val map = new LinkedHashMap[String, Json]
+        map.put(field, value)
+        map.put(k, j)
+        map
+      }
+    )
+    override def +:(field: (String, Json)): JsonObject =
+      add(field._1, field._2)
+
+    override def remove(key: String): JsonObject =
+      empty
+
+    override def traverse[F[_]](f: Json => F[Json])(implicit F: Applicative[F]): F[JsonObject] =
+      F.map(f(value))(new SingletonJsonObject(field, _))
+
+    override def mapValues(f: Json => Json): JsonObject = new SingletonJsonObject(field, f(value))
+
+    override private[circe] def appendToFolder(folder: Printer.PrintingFolder): Unit = {
+      val originalDepth = folder.depth
+      val p = folder.pieces(folder.depth)
+      var first = true
+
+      folder.writer.append(p.lBraces)
+
+      if (!folder.dropNullValues || !value.isNull) {
+        if (!first) folder.writer.append(p.objectCommas)
+        folder.onString(field)
+        folder.writer.append(p.colons)
+
+        folder.depth += 1
+        value.foldWith(folder)
+        folder.depth = originalDepth
+        first = false
+      }
+
+      folder.writer.append(p.rBraces)
+    }
+  }
 
   /**
    * An implementation of [[JsonObject]] built on `java.util.LinkedHashMap`.

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -252,11 +252,13 @@ object JsonObject {
    * Construct a [[JsonObject]] from an [[scala.collection.Iterable]] (provided for optimization).
    */
   final def fromIterable(fields: Iterable[(String, Json)]): JsonObject = {
-    if (fields.isEmpty) empty
-    else {
-      val fieldsSeq = fields.iterator.toSeq
-      if (fields.sizeIs == 1) new SingletonJsonObject(fieldsSeq.head._1, fieldsSeq.head._2)
-      else {
+    val fieldsSeq = fields.iterator.toSeq
+    (fieldsSeq.size: @switch) match {
+      case 0 => empty
+      case 1 =>
+        val (key, value) = fieldsSeq.head
+        new SingletonJsonObject(key, value)
+      case _ =>
         val map = new LinkedHashMap[String, Json](fields.size)
         val it = fields.iterator
         while (it.hasNext) {
@@ -264,7 +266,6 @@ object JsonObject {
           map.put(key, value)
         }
         new LinkedHashMapJsonObject(map)
-      }
     }
   }
 

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -256,7 +256,7 @@ object JsonObject {
       case 0 => empty
       case 1 =>
         val (key, value) = fields.iterator.next
-        new SingletonJsonObject(key, value)
+        singleton(key, value)
       case size =>
         val map = new LinkedHashMap[String, Json](size)
         val it = fields.iterator
@@ -279,14 +279,14 @@ object JsonObject {
   private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject =
     (map.sizeIs: @switch) match {
       case 0 => empty
-      case 1 => new SingletonJsonObject(map.keys.iterator.next(), map.values.iterator.next())
+      case 1 => singleton(map.keys.iterator.next(), map.values.iterator.next())
       case _ => new MapAndVectorJsonObject(map, keys)
     }
 
   private[circe] final def fromLinkedHashMap(map: LinkedHashMap[String, Json]): JsonObject =
     (map.size: @switch) match {
       case 0 => empty
-      case 1 => new SingletonJsonObject(map.keySet().iterator.next(), map.values.iterator.next())
+      case 1 => singleton(map.keySet().iterator.next(), map.values.iterator.next())
       case _ => new LinkedHashMapJsonObject(map)
     }
 
@@ -298,7 +298,7 @@ object JsonObject {
   /**
    * Construct a [[JsonObject]] with a single field.
    */
-  final def singleton(key: String, value: Json): JsonObject = new MapAndVectorJsonObject(Map((key, value)), Vector(key))
+  final def singleton(key: String, value: Json): JsonObject = new SingletonJsonObject(key, value)
 
   implicit final val showJsonObject: Show[JsonObject] = Show.fromToString
   implicit final val eqJsonObject: Eq[JsonObject] = Eq.fromUniversalEquals

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -258,8 +258,12 @@ object JsonObject {
       val fieldsSeq = fields.iterator.toSeq
       if (fields.sizeIs == 1) new SingletonJsonObject(fieldsSeq.head._1, fieldsSeq.head._2)
       else {
-        val map = new LinkedHashMap[String, Json]
-        for ((key, value) <- fields) map.put(key, value)
+        val map = new LinkedHashMap[String, Json]()
+        val it = fields.iterator
+        while (it.hasNext) {
+          val (key, value) = it.next()
+          map.put(key, value)
+        }
         new LinkedHashMapJsonObject(map)
       }
     }

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -252,11 +252,10 @@ object JsonObject {
    * Construct a [[JsonObject]] from an [[scala.collection.Iterable]] (provided for optimization).
    */
   final def fromIterable(fields: Iterable[(String, Json)]): JsonObject = {
-    val fieldsSeq = fields.iterator.toSeq
-    (fieldsSeq.size: @switch) match {
+    (fields.sizeIs: @switch) match {
       case 0 => empty
       case 1 =>
-        val (key, value) = fieldsSeq.head
+        val (key, value) = fields.iterator.next
         new SingletonJsonObject(key, value)
       case size =>
         val map = new LinkedHashMap[String, Json](size)
@@ -278,7 +277,7 @@ object JsonObject {
     fromMapAndVector(map, map.keys.toVector)
 
   private[circe] final def fromMapAndVector(map: Map[String, Json], keys: Vector[String]): JsonObject =
-    (map.size: @switch) match {
+    (map.sizeIs: @switch) match {
       case 0 => empty
       case 1 => new SingletonJsonObject(map.keys.iterator.next(), map.values.iterator.next())
       case _ => new MapAndVectorJsonObject(map, keys)


### PR DESCRIPTION
This pull request optimizes memory usage in the edge case where there are many objects with only one field, default `LinkedHashMap` container has a lot of memory overhead in such cases.

Notes:
 - it looks like existing tests cover the new implementation correctly, let me know if more are needed
 - the benchmarks for folding/printing [use a single field object](https://github.com/circe/circe/blob/ad8546ab0349583cf249256d762e4a50c247307b/modules/benchmark/src/main/scala-2/io/circe/benchmark/ExampleData.scala#L35), so this will make it biased. Not sure if I should add a more complex object / different benchmark ?