### PR TITLE
Fix superfluous keys not being ignored

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredDecoder.scala
@@ -49,12 +49,18 @@ trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
   /** Decodes a class/object/case of a Sum type handling discriminator and strict decoding. */
   private def decodeSumElement[R](c: HCursor)(fail: DecodingFailure => R, decode: Decoder[A] => ACursor => R): R =
 
-    def fromName(sumTypeName: String, cursor: ACursor): R =
+    def fromName(sumTypeName: String, cursor: ACursor, fallBacks: Iterator[(String, ACursor)]): R =
       decodersDict
         .get(sumTypeName)
-        .fold(
-          fail(DecodingFailure(s"type $name has no class/object/case named '$sumTypeName'.", cursor.history))
-        ) { decoder =>
+        .fold {
+          if (fallBacks.hasNext) {
+            val (sumTypeName, cursor) = fallBacks.next()
+            fromName(sumTypeName, cursor, fallBacks)
+          } else {
+            fail(DecodingFailure(s"type $name has no class/object/case named '$sumTypeName'.", cursor.history))
+          }
+
+        } { decoder =>
           decode(decoder.asInstanceOf[Decoder[A]])(cursor)
         }
 
@@ -70,7 +76,7 @@ trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
                 cursor.history
               )
             )
-          case Right(Some(sumTypeName)) => fromName(sumTypeName, c)
+          case Right(Some(sumTypeName)) => fromName(sumTypeName, c, Iterator.empty)
       case _ =>
         c.keys match
           case None => fail(DecodingFailure(WrongTypeExpectation("object", c.value), c.history))
@@ -87,7 +93,7 @@ trait ConfiguredDecoder[A](using conf: Configuration) extends Decoder[A]:
                     s"expected a single key json object with one of: ${constructorNames.iterator.mkString(", ")}."
                   )
                 )
-              else fromName(sumTypeName, c.downField(sumTypeName))
+              else fromName(sumTypeName, c.downField(sumTypeName), iter.map(key => (key, c.downField(key))))
 
   final def decodeSum(c: HCursor): Decoder.Result[A] =
     decodeSumElement(c)(Left.apply, _.tryDecode)

--- a/modules/tests/shared/src/test/scala-3/io/circe/SemiautoDerivationSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/SemiautoDerivationSuite.scala
@@ -297,4 +297,12 @@ class SemiautoDerivationSuite extends CirceMunitSuite {
 
   testLocalCaseClasses()
   testLocalAdts()
+
+  test("Decoder for ADT/Encoder ignores superfluous keys") {
+    import io.circe.parser.decode
+    val expected = Right(Adt1.Class1(3))
+    assertEquals(decode[Adt1]("""{"Class1":{"int":3}}"""), expected)
+    assertEquals(decode[Adt1]("""{"extraField":true,"Class1":{"int":3}}"""), expected)
+    assertEquals(decode[Adt1]("""{"Class1":{"int":3},"extraField":true}"""), expected)
+  }
 }

--- a/modules/tests/shared/src/test/scala-3/io/circe/SemiautoDerivationSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/SemiautoDerivationSuite.scala
@@ -298,11 +298,12 @@ class SemiautoDerivationSuite extends CirceMunitSuite {
   testLocalCaseClasses()
   testLocalAdts()
 
-  test("Decoder for ADT/Encoder ignores superfluous keys") {
+  test("Decoder for ADT/Enum ignores superfluous keys") {
     import io.circe.parser.decode
     val expected = Right(Adt1.Class1(3))
     assertEquals(decode[Adt1]("""{"Class1":{"int":3}}"""), expected)
     assertEquals(decode[Adt1]("""{"extraField":true,"Class1":{"int":3}}"""), expected)
+    assertEquals(decode[Adt1]("""{"extraField":true,"extraField2":15,"Class1":{"int":3}}"""), expected)
     assertEquals(decode[Adt1]("""{"Class1":{"int":3},"extraField":true}"""), expected)
   }
 }


### PR DESCRIPTION
Fix superfluous keys not being ignored when decoding ADTs/Enums.

Fixes #2368