### PR TITLE
Hierarchical configured enum codecs in Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ ThisBuild / tlFatalWarnings := false // we currently have a lot of warnings that
 
 ThisBuild / organization := "io.circe"
 ThisBuild / crossScalaVersions := List(Scala3V, Scala212V, Scala213V)
-ThisBuild / scalaVersion := Scala213V
+// ThisBuild / scalaVersion := Scala213V
+ThisBuild / scalaVersion := Scala3V
 
 ThisBuild / githubWorkflowJavaVersions := Seq("8", "11", "17").map(JavaSpec.temurin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,7 @@ ThisBuild / tlFatalWarnings := false // we currently have a lot of warnings that
 
 ThisBuild / organization := "io.circe"
 ThisBuild / crossScalaVersions := List(Scala3V, Scala212V, Scala213V)
-// ThisBuild / scalaVersion := Scala213V
-ThisBuild / scalaVersion := Scala3V
+ThisBuild / scalaVersion := Scala213V
 
 ThisBuild / githubWorkflowJavaVersions := Seq("8", "11", "17").map(JavaSpec.temurin)
 

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumDecoder.scala
@@ -27,7 +27,7 @@ object ConfiguredEnumDecoder:
   ): ConfiguredEnumDecoder[A] = new ConfiguredEnumDecoder[A]:
     private val labelsMap =
       cases.map(c => (conf.transformConstructorNames(c.label), c.value)).toMap[String, A]
-    
+
     def apply(c: HCursor) = c.as[String].flatMap { caseName =>
       labelsMap.get(caseName) match
         case None    => Left(DecodingFailure(s"enum $name does not contain case: $caseName", c.history))
@@ -37,7 +37,7 @@ object ConfiguredEnumDecoder:
   inline final def derived[A](using conf: Configuration, mirror: Mirror.SumOf[A]): ConfiguredEnumDecoder[A] =
     ConfiguredEnumDecoder.of[A](
       constValue[mirror.MirroredLabel],
-      summonSingletonCases[mirror.MirroredElemTypes, A](constValue[mirror.MirroredLabel]),
+      summonSingletonCases[mirror.MirroredElemTypes, A](constValue[mirror.MirroredLabel])
     )
 
   inline final def derive[R: Mirror.SumOf](

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumDecoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumDecoder.scala
@@ -25,13 +25,13 @@ object ConfiguredEnumDecoder:
   private def of[A](name: String, cases: List[SingletonCase[A]])(using
     conf: Configuration
   ): ConfiguredEnumDecoder[A] = new ConfiguredEnumDecoder[A]:
-    private val caseOf = cases.map(_.value).apply
-    private val lbls = cases.map(c => conf.transformConstructorNames(c.label)).toVector
+    private val labelsMap =
+      cases.map(c => (conf.transformConstructorNames(c.label), c.value)).toMap[String, A]
     
     def apply(c: HCursor) = c.as[String].flatMap { caseName =>
-      lbls.indexOf(caseName) match
-        case -1    => Left(DecodingFailure(s"enum $name does not contain case: $caseName", c.history))
-        case index => Right(caseOf(index))
+      labelsMap.get(caseName) match
+        case None    => Left(DecodingFailure(s"enum $name does not contain case: $caseName", c.history))
+        case Some(a) => Right(a)
     }
 
   inline final def derived[A](using conf: Configuration, mirror: Mirror.SumOf[A]): ConfiguredEnumDecoder[A] =

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumEncoder.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredEnumEncoder.scala
@@ -17,19 +17,17 @@
 package io.circe.derivation
 
 import scala.deriving.Mirror
-import scala.reflect.TypeTest
 import scala.compiletime.constValue
-import Predef.genericArrayOps
 import io.circe.{ Encoder, Json }
 
 trait ConfiguredEnumEncoder[A] extends Encoder[A]
 object ConfiguredEnumEncoder:
   private def of[A](cases: List[SingletonCase[A]])(using conf: Configuration): ConfiguredEnumEncoder[A] =
     new ConfiguredEnumEncoder[A]:
-      private val labelsMap =
+      private val valuesMap =
         cases.map(c => (c.value, conf.transformConstructorNames(c.label))).toMap[A, String]
 
-      def apply(a: A) = Json.fromString(labelsMap(a))
+      def apply(a: A) = Json.fromString(valuesMap(a))
 
   inline final def derived[A](using conf: Configuration, mirror: Mirror.SumOf[A]): ConfiguredEnumEncoder[A] =
     ConfiguredEnumEncoder.of[A](

--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/package.scala
@@ -71,8 +71,28 @@ private[circe] inline final def summonDecoder[A](inline derivingForSum: Boolean)
       else error("Failed to find an instance of Decoder[" + typeName[A] + "]")
   }
 
-private[circe] inline def summonSingletonCases[T <: Tuple, A](inline typeName: Any): List[A] =
-  loopUnrolled[A, Any, T](new SummonSingleton[A], typeName)
+private[circe] final case class SingletonCase[A](label: String, value: A)
+
+private[circe] inline final def summonSingletonCase[T, A](inline typeName: Any): List[SingletonCase[A]] =
+  summonFrom {
+    case m: Mirror.Of[T] => inline m match 
+      case m: Mirror.Singleton => List(SingletonCase(
+        value = m.fromProduct(EmptyTuple).asInstanceOf[A],
+        label = constValue[m.MirroredLabel]
+      ))
+      case m: Mirror.SumOf[T] => summonSingletonCases[m.MirroredElemTypes, A](typeName)
+      case m: Mirror =>
+        error("Enum " + codeOf(typeName) + " contains non singleton case " + codeOf(constValue[m.MirroredLabel]))
+
+    case _ => List(SingletonCase(
+      value = constValue[A],
+      label = constValue[T].asInstanceOf[String]
+    )
+    )
+  } 
+
+private[circe] inline def summonSingletonCases[T <: Tuple, A](inline typeName: Any): List[SingletonCase[A]] =
+  loopUnrolled[List[SingletonCase[A]], Any, T](new SummonSingleton[A], typeName).flatten
 
 private[circe] inline final def loopUnrolled[A, Arg, T <: Tuple](f: Inliner[A, Arg], inline arg: Arg): List[A] =
   inline erasedValue[T] match
@@ -109,9 +129,5 @@ class DecoderDeriveSum(using Configuration) extends Inliner[Decoder[_], Unit]:
 class DecoderNotDeriveSum(using Configuration) extends Inliner[Decoder[_], Unit]:
   inline def apply[T](inline arg: Unit): Decoder[?] = summonDecoder[T](false)
 
-class SummonSingleton[A] extends Inliner[A, Any]:
-  inline def apply[T](inline typeName: Any): A =
-    inline summonInline[Mirror.Of[T]] match
-      case m: Mirror.Singleton => m.fromProduct(EmptyTuple).asInstanceOf[A]
-      case m: Mirror =>
-        error("Enum " + codeOf(typeName) + " contains non singleton case " + codeOf(constValue[m.MirroredLabel]))
+class SummonSingleton[A] extends Inliner[List[SingletonCase[A]], Any]:
+  inline def apply[T](inline typeName: Any): List[SingletonCase[A]] = summonSingletonCase[T, A](typeName)


### PR DESCRIPTION
Hi !

This is another attempt at fixing derivation of configured enum codecs with nested hierarchies for Scala 3 to have a better feature parity with Scala 2 configured codecs from `circe-generic-extras`.

Discovered after testing [v0.14.5-RC1](https://github.com/circe/circe-generic-extras/releases/tag/v0.14.5-RC1) of `circe-generic-extras`.

Previous work: https://github.com/circe/circe/pull/2158