### PR TITLE
Simplify strict decoding and make it not fail fast in the accumulating variant

### DIFF
--- a/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredDerivesSuite.scala
+++ b/modules/tests/shared/src/test/scala-3/io/circe/ConfiguredDerivesSuite.scala
@@ -439,12 +439,12 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
     assert(Decoder[ConfigExampleBase].decodeJson(json) === Left(failure("unexpected fields: anotherField")))
     assert(
       Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor) === Validated.invalidNel(
-        failure("unexpected field: anotherField")
+        failure("unexpected fields: anotherField")
       )
     )
   }
 
-    test(
+  test(
     "Configuration#strictDecoding on product types should not fail fast on decodeAccumulating if there are unexpected fields"
   ) {
     given Configuration = Configuration.default.withStrictDecoding
@@ -466,8 +466,8 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
     assert(
       Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor) === Validated.invalid(
         NonEmptyList(
-          strictFailure("unexpected field: invalidField"),
-          List(DecodingFailure("Double", List(DownField("ConfigExampleFoo"), DownField("b"))))
+          strictFailure("unexpected fields: invalidField"),
+          List(DecodingFailure("Double", List(DownField("b"), DownField("ConfigExampleFoo"))))
         )
       )
     )


### PR DESCRIPTION
Closes #2379. This is a **breaking change** (at least for those who depend on parsing the messages) to the behavior of the `decodeAccumulating` API, for `Decoder`s derived with a configuration (Scala 3-only):

- Unexpected fields are reported under a single failure. For example, for a product `Foo(a, b)`, if a `c` and a `d` fields are given, we report `unexpected fields: c,d; valid fields: a,b.` instead of `unexpected field: c; valid fields: a,b.` and `unexpected field: d; valid fields: a,b.`. This seems cleaner to me and makes sense under the semantic "a single verification for expected fields" which is exactly what the code is doing, but was artificially split for the accumulating variant. (As far as I can tell, the accumulating variant implies "do not fail fast", not "split errors", although this is not well documented.)
- Even if the strict matching fails, expected fields are now validated. This was the behavior in Scala 2 in https://github.com/circe/circe-generic-extras and I'm not sure they are aware it got lost in https://github.com/circe/circe-generic-extras/pull/401 when resorting to the new core API. I noticed it when migrating a project to Scala 3.

Please let me know if this makes sense. I'm open to suggestions.