### PR TITLE
Replace deprecated `JavaConverters` with `CollectionConverters`

### DIFF
--- a/modules/tests/jvm/src/test/scala/io/circe/JavaCurrencySuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/JavaCurrencySuite.scala
@@ -21,7 +21,7 @@ import io.circe.testing.CodecTests
 import io.circe.tests.CirceMunitSuite
 import java.util.Currency
 import org.scalacheck._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 final class JavaCurrencySuite extends CirceMunitSuite {
   import JavaCurrencySuite._

--- a/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JavaTimeCodecSuite.scala
@@ -23,7 +23,7 @@ import java.time._
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class JavaTimeCaseClass(foo: Duration, bar: Option[LocalTime], baz: List[ZoneId])
 


### PR DESCRIPTION
This change addresses deprecation introduced in Scala 2.13, where JavaConverters was replaced in favor of CollectionConverters. Aside from the updated import path, this avoids unintended type inference issues caused by implicit conversions.
This update is limited to test code and does not affect runtime behavior.

