### PR TITLE
Scala 3 ConfiguredDecoder: cache member names transformation

### DIFF
--- a/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
+++ b/modules/core/shared/src/main/scala-3/io/circe/derivation/ConfiguredCodec.scala
@@ -19,7 +19,7 @@ package io.circe.derivation
 import scala.deriving.Mirror
 import scala.compiletime.{ constValue, summonInline }
 import scala.quoted.*
-import io.circe.{ Codec, Decoder, Encoder, HCursor, JsonObject }
+import io.circe.{ Codec, Decoder, Encoder, HCursor }
 
 trait ConfiguredCodec[A] extends Codec.AsObject[A], ConfiguredDecoder[A], ConfiguredEncoder[A]
 object ConfiguredCodec:


### PR DESCRIPTION
A recent CPU profiling in one of our production service uncovered an abnormal time spent in applying member names transformation.

Indeed, the `ConfiguredDecoder` (Scala 3 only) implementation recompute the transformation on the member names (e.g. snake case) for each decoding. This adds up to 20% of our CPU cycles spent on regex for case transformation.

The following line is the main culprit:

```scala
val cursor = c.downField(conf.transformMemberNames(elemLabels(index)))
```

---

This PR addresses the issue by pre-computing the transformed member names, similar to what was already done for the constructor names. 

I also took the chance to use an `IndexedSeq` instead of a `List` as the collection is accessed by index.

Other fields in `ConfiguredDecoder` and `ConfiguredEncoder` would benefit from moving away of the `List`, but the change would break binary compatibility. 
