### PR TITLE
Optimise `JsonObject`'s `equals` and `hashCode`

### DIFF
--- a/modules/benchmark/src/main/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmark.scala
+++ b/modules/benchmark/src/main/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmark.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.circe.benchmark
+
+import io.circe.{Json, JsonObject}
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.*
+import java.util
+
+/**
+ * Benchmark equality- and hash-based operations on JSON objects
+ *
+ * The following command will run the benchmarks with reasonable settings:
+ *
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.JsonObjectEqualityBenchmark"
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = Array("-Xms2G", "-Xmx2G", "-XX:+AlwaysPreTouch", "-XX:+UseSerialGC"))
+class JsonObjectEqualityBenchmark {
+
+  val count: Int = 100
+  val mapAndVectorObject1: JsonObject = buildMapAndVectorObject()
+  val mapAndVectorObject2: JsonObject = buildMapAndVectorObject()
+  val linkedHashMapObject1: JsonObject = buildLinkedHashMapObject()
+  val linkedHashMapObject2: JsonObject = buildLinkedHashMapObject()
+
+  private def buildMapAndVectorObject(): JsonObject = {
+    val orderedFields: Vector[(String, Json)] =
+      Vector.tabulate(count)(i => (i.toString, Json.fromInt(i)))
+    val vector: Vector[String] = orderedFields.map(_._1)
+    val map: Map[String, Json] = orderedFields.toMap
+    JsonObject.fromMapAndVector(map, vector)
+  }
+
+  private def buildLinkedHashMapObject(): JsonObject = {
+    val map = new util.LinkedHashMap[String, Json]()
+    Iterator.tabulate(count)(i => (i.toString, Json.fromInt(i)))
+      .foreach { case (key, value) => map.put(key, value) }
+    JsonObject.fromLinkedHashMap(map)
+  }
+
+  @Benchmark
+  def equalsMapAndVector: Boolean = mapAndVectorObject1 == mapAndVectorObject2
+
+  @Benchmark
+  def hashCodeMapAndVector: Int = mapAndVectorObject1.hashCode
+
+  @Benchmark
+  def equalsLinkedHashMap: Boolean = linkedHashMapObject1 == linkedHashMapObject2
+
+  @Benchmark
+  def hashCodeLinkedHashMap: Int = linkedHashMapObject1.hashCode
+
+  @Benchmark
+  def equalsMixed: Boolean = linkedHashMapObject1 == mapAndVectorObject1
+}
+

--- a/modules/benchmark/src/main/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmark.scala
+++ b/modules/benchmark/src/main/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmark.scala
@@ -16,7 +16,7 @@
 
 package io.circe.benchmark
 
-import io.circe.{Json, JsonObject}
+import io.circe.{ Json, JsonObject }
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations.*
 import java.util
@@ -50,8 +50,7 @@ class JsonObjectEqualityBenchmark {
 
   private def buildLinkedHashMapObject(): JsonObject = {
     val map = new util.LinkedHashMap[String, Json]()
-    Iterator.tabulate(count)(i => (i.toString, Json.fromInt(i)))
-      .foreach { case (key, value) => map.put(key, value) }
+    Iterator.tabulate(count)(i => (i.toString, Json.fromInt(i))).foreach { case (key, value) => map.put(key, value) }
     JsonObject.fromLinkedHashMap(map)
   }
 
@@ -70,4 +69,3 @@ class JsonObjectEqualityBenchmark {
   @Benchmark
   def equalsMixed: Boolean = linkedHashMapObject1 == mapAndVectorObject1
 }
-

--- a/modules/benchmark/src/test/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmarkSpec.scala
@@ -45,4 +45,3 @@ class JsonObjectEqualityBenchmarkSpec extends FunSuite {
     assertEquals(benchmark.equalsMixed, true)
   }
 }
-

--- a/modules/benchmark/src/test/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmarkSpec.scala
@@ -29,16 +29,16 @@ class JsonObjectEqualityBenchmarkSpec extends FunSuite {
     assertEquals(benchmark.equalsMapAndVector, true)
   }
 
-  test("hashCodeMapAndVector should match the JsonObject hash code") {
-    assertEquals(benchmark.hashCodeMapAndVector, -121680001)
+  test("hashCodeMapAndVector should match hash code calculated as in circe 0.14.15") {
+    assertEquals(benchmark.hashCodeMapAndVector, benchmark.mapAndVectorObject1.toMap.hashCode())
   }
 
   test("equalsLinkedHashMap should return true for equivalent JsonObjects") {
     assertEquals(benchmark.equalsLinkedHashMap, true)
   }
 
-  test("hashCodeLinkedHashMap should match the JsonObject hash code") {
-    assertEquals(benchmark.hashCodeLinkedHashMap, -121680001)
+  test("hashCodeLinkedHashMap should match hash code calculated as in circe 0.14.15") {
+    assertEquals(benchmark.hashCodeLinkedHashMap, benchmark.linkedHashMapObject1.toMap.hashCode())
   }
 
   test("equalsMixed should return true for differently constructed JsonObjects with identical data") {

--- a/modules/benchmark/src/test/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala-2/io/circe/benchmark/JsonObjectEqualityBenchmarkSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 circe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.circe.benchmark
+
+import munit.FunSuite
+
+class JsonObjectEqualityBenchmarkSpec extends FunSuite {
+  val benchmark: JsonObjectEqualityBenchmark = new JsonObjectEqualityBenchmark
+
+  test("LinkedHashMap and MapAndVector hashCodes should be identical") {
+    assertEquals(benchmark.hashCodeLinkedHashMap, benchmark.hashCodeMapAndVector)
+  }
+
+  test("equalsMapAndVector should return true for equivalent JsonObjects") {
+    assertEquals(benchmark.equalsMapAndVector, true)
+  }
+
+  test("hashCodeMapAndVector should match the JsonObject hash code") {
+    assertEquals(benchmark.hashCodeMapAndVector, -121680001)
+  }
+
+  test("equalsLinkedHashMap should return true for equivalent JsonObjects") {
+    assertEquals(benchmark.equalsLinkedHashMap, true)
+  }
+
+  test("hashCodeLinkedHashMap should match the JsonObject hash code") {
+    assertEquals(benchmark.hashCodeLinkedHashMap, -121680001)
+  }
+
+  test("equalsMixed should return true for differently constructed JsonObjects with identical data") {
+    assertEquals(benchmark.equalsMixed, true)
+  }
+}
+

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -24,7 +24,6 @@ import cats.data.Kleisli
 
 import java.io.Serializable
 import java.util.LinkedHashMap
-import scala.collection.immutable.Map
 import scala.util.hashing.MurmurHash3
 
 /**
@@ -220,6 +219,29 @@ sealed abstract class JsonObject extends Serializable {
     case (k, v) => s"$k -> ${Json.showJson.show(v)}"
   }.mkString("object[", ",", "]")
 
+  /**
+   * @group Other
+   */
+  final override def equals(that: Any): Boolean = that match {
+    case that: JsonObject =>
+      that match {
+        case that: JsonObject.LinkedHashMapJsonObject =>
+          that.equalsJsonObject(this)
+        case that: JsonObject.MapAndVectorJsonObject =>
+          that.equalsJsonObject(this)
+      }
+    case _ => false
+  }
+
+  /**
+   * @group Other
+   */
+  final override def hashCode: Int = {
+    this match {
+      case thiz: JsonObject.LinkedHashMapJsonObject => thiz.internalHashCode
+      case thiz: JsonObject.MapAndVectorJsonObject  => thiz.internalHashCode
+    }
+  }
 }
 
 /**
@@ -292,7 +314,7 @@ object JsonObject {
   /**
    * An implementation of [[JsonObject]] built on `java.util.LinkedHashMap`.
    */
-  private[this] final class LinkedHashMapJsonObject(fields: LinkedHashMap[String, Json]) extends JsonObject {
+  private final class LinkedHashMapJsonObject(fields: LinkedHashMap[String, Json]) extends JsonObject {
     private[circe] def applyUnsafe(key: String): Json = fields.get(key)
     final def apply(k: String): Option[Json] = Option(fields.get(k))
     final def size: Int = fields.size
@@ -402,7 +424,7 @@ object JsonObject {
 
     final def mapValues(f: Json => Json): JsonObject = toMapAndVectorJsonObject.mapValues(f)
 
-    final override def equals(that: Any): Boolean = that match {
+    final def equalsJsonObject(that: JsonObject): Boolean = that match {
       case that: LinkedHashMapJsonObject =>
         if (this.size != that.size)
           return false
@@ -415,20 +437,21 @@ object JsonObject {
           }
         }
         true
-      case that: MapAndVectorJsonObject => this.size == that.size &&
-        that.toMap.forall { case (k, v) =>
-          v == this.applyUnsafe(k)
+      case that: MapAndVectorJsonObject =>
+        this.size == that.size &&
+        that.toMap.forall {
+          case (k, v) =>
+            v == this.applyUnsafe(k)
         }
-      case _ => false
     }
 
-    final override def hashCode: Int = MurmurHash3.unorderedHash(toIterable, MurmurHash3.mapSeed)
+    final def internalHashCode: Int = MurmurHash3.unorderedHash(toIterable, MurmurHash3.mapSeed)
   }
 
   /**
    * A straightforward implementation of [[JsonObject]] with immutable collections.
    */
-  private[this] final class MapAndVectorJsonObject(
+  private final class MapAndVectorJsonObject(
     fields: Map[String, Json],
     orderedKeys: Vector[String]
   ) extends JsonObject {
@@ -503,16 +526,18 @@ object JsonObject {
       folder.writer.append(p.rBraces)
     }
 
-    final override def equals(that: Any): Boolean = that match {
-      case that: MapAndVectorJsonObject => this.size == that.size &&
+    final def equalsJsonObject(that: JsonObject): Boolean = that match {
+      case that: MapAndVectorJsonObject =>
+        this.size == that.size &&
         this.toMap == that.toMap
-      case that: LinkedHashMapJsonObject => this.size == that.size &&
-        this.toMap.forall { case (k, v) =>
-          v == that.applyUnsafe(k)
+      case that: LinkedHashMapJsonObject =>
+        this.size == that.size &&
+        this.toMap.forall {
+          case (k, v) =>
+            v == that.applyUnsafe(k)
         }
-      case _ => false
     }
 
-    final override def hashCode: Int = fields.hashCode()
+    final def internalHashCode: Int = fields.hashCode()
   }
 }

--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -25,6 +25,7 @@ import cats.data.Kleisli
 import java.io.Serializable
 import java.util.LinkedHashMap
 import scala.collection.immutable.Map
+import scala.util.hashing.MurmurHash3
 
 /**
  * A mapping from keys to JSON values that maintains insertion order.
@@ -219,18 +220,6 @@ sealed abstract class JsonObject extends Serializable {
     case (k, v) => s"$k -> ${Json.showJson.show(v)}"
   }.mkString("object[", ",", "]")
 
-  /**
-   * @group Other
-   */
-  final override def equals(that: Any): Boolean = that match {
-    case that: JsonObject => this.size == that.size && this.toMap == that.toMap
-    case _                => false
-  }
-
-  /**
-   * @group Other
-   */
-  final override def hashCode: Int = toMap.hashCode
 }
 
 /**
@@ -412,6 +401,28 @@ object JsonObject {
       toMapAndVectorJsonObject.traverse[F](f)(F)
 
     final def mapValues(f: Json => Json): JsonObject = toMapAndVectorJsonObject.mapValues(f)
+
+    final override def equals(that: Any): Boolean = that match {
+      case that: LinkedHashMapJsonObject =>
+        if (this.size != that.size)
+          return false
+
+        val iterator = fields.entrySet.iterator
+        while (iterator.hasNext) {
+          val entry = iterator.next
+          if (that.applyUnsafe(entry.getKey) != entry.getValue) {
+            return false
+          }
+        }
+        true
+      case that: MapAndVectorJsonObject => this.size == that.size &&
+        that.toMap.forall { case (k, v) =>
+          v == this.applyUnsafe(k)
+        }
+      case _ => false
+    }
+
+    final override def hashCode: Int = MurmurHash3.unorderedHash(toIterable, MurmurHash3.mapSeed)
   }
 
   /**
@@ -491,5 +502,17 @@ object JsonObject {
 
       folder.writer.append(p.rBraces)
     }
+
+    final override def equals(that: Any): Boolean = that match {
+      case that: MapAndVectorJsonObject => this.size == that.size &&
+        this.toMap == that.toMap
+      case that: LinkedHashMapJsonObject => this.size == that.size &&
+        this.toMap.forall { case (k, v) =>
+          v == that.applyUnsafe(k)
+        }
+      case _ => false
+    }
+
+    final override def hashCode: Int = fields.hashCode()
   }
 }


### PR DESCRIPTION
The current implementation of `equals` and `hashCode` is based on `toMap` which is efficient when dealing with `MapAndVectorJsonObject`, but when dealing with `LinkedHashMapJsonObject` it leads to time consuming, and allocation heavy `toMapAndVectorJsonObject` conversion. The result of the conversion is discarded, so use cases that repeatedly hash or compare `JsonObject`s keep paying that cost repeatedly. (I have a real world application that spends 51% of CPU time in GC because of that)

In this PR I propose a new implementation of `equals` and `hashCode` which is aware of the two representations of `JsonObject` and chooses to optimal way to hash/compare them without significant heap allocations. In addition to that I prepared benchmarks to justify the change and quantify the improvement.

 ### Benchmark results before (ccd1bcfc63922fe6bd6c32a8c35a0088bc91dbb5) (higher is better)

```
[info] Benchmark                                           Mode  Cnt       Score      Error  Units
[info] JsonObjectEqualityBenchmark.equalsLinkedHashMap    thrpt   20   110165.154 ±   462.699  ops/s
[info] JsonObjectEqualityBenchmark.equalsMapAndVector     thrpt   20  1565309.972 ± 32705.186  ops/s
[info] JsonObjectEqualityBenchmark.equalsMixed            thrpt   20   201005.477 ±  6505.266  ops/s
[info] JsonObjectEqualityBenchmark.hashCodeLinkedHashMap  thrpt   20   111157.147 ±  1450.116  ops/s
[info] JsonObjectEqualityBenchmark.hashCodeMapAndVector   thrpt   20   254723.666 ±  7074.196  ops/s
```

### Benchmark results after (cb6fb7c95ab2ae987632a179a15a8d57cb853f25) (higher is better)

```
[info] Benchmark                                           Mode  Cnt       Score      Error  Units
[info] JsonObjectEqualityBenchmark.equalsLinkedHashMap    thrpt   20  1027442.106 ±  36823.173  ops/s
[info] JsonObjectEqualityBenchmark.equalsMapAndVector     thrpt   20  1558090.245 ±  33794.294  ops/s
[info] JsonObjectEqualityBenchmark.equalsMixed            thrpt   20   865587.917 ±  11020.718  ops/s
[info] JsonObjectEqualityBenchmark.hashCodeLinkedHashMap  thrpt   20   254424.508 ±   3489.809  ops/s
[info] JsonObjectEqualityBenchmark.hashCodeMapAndVector   thrpt   20   264467.414 ±   3898.601  ops/s
```

### Summary

This resulted in 

* 9.3 times faster comparison of `LinkedHashMapJsonObject`, 
* 4.3 times faster comparison of `LinkedHashMapJsonObject` with `MapAndVectorJsonObject` 
* 2.2 times faster hashing of `LinkedHashMapJsonObject`

<img width="880" height="443" alt="image" src="https://github.com/user-attachments/assets/efee35ea-1313-4bb5-a89d-11d5e5644211" />


