### PR TITLE
Fix NumberFormatException when parsing leading-dot-zero decimals

### DIFF
--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -374,7 +374,8 @@ object BiggerDecimal {
             }
 
           val unscaledString = integral + fractional
-          val unscaled = new BigInteger(unscaledString.substring(0, unscaledString.length - zeros))
+          val trimmed = unscaledString.substring(0, unscaledString.length - zeros)
+          val unscaled = if (trimmed.isEmpty || trimmed == "-") BigInteger.ZERO else new BigInteger(trimmed)
 
           if (unscaled == BigInteger.ZERO) {
             if (input.charAt(0) == '-') NegativeZero else UnsignedZero

--- a/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -277,4 +277,35 @@ class BiggerDecimalSuite extends ScalaCheckSuite {
       )
     }
   }
+
+  property("numbers without a leading digit before decimal point should be parseable") {
+    val genSign = Gen.oneOf("", "-")
+    val genFractional = for {
+      nonZero <- Gen.choose('1', '9')
+      rest <- Gen.listOf(Gen.numChar)
+      position <- Gen.choose(0, rest.length)
+    } yield (rest.take(position) ::: nonZero :: rest.drop(position)).mkString
+    forAll(genSign, genFractional) { (sign: String, fractional: String) =>
+      println("Sign: " + sign)
+      println("Fractional: " + fractional)
+      val input = s"$sign.$fractional"
+      assert(BiggerDecimal.parseBiggerDecimal(input).nonEmpty)
+    }
+  }
+
+  test("parseBiggerDecimal should parse .0 as zero") {
+    assertEquals(BiggerDecimal.parseBiggerDecimal(".0"), BiggerDecimal.parseBiggerDecimal("0"))
+  }
+
+  test("parseBiggerDecimal should parse -.0 as NegativeZero") {
+    assertEquals(BiggerDecimal.parseBiggerDecimal("-.0"), Some(BiggerDecimal.NegativeZero))
+  }
+
+  test("parseBiggerDecimal should parse .00 as zero") {
+    assertEquals(BiggerDecimal.parseBiggerDecimal(".00"), BiggerDecimal.parseBiggerDecimal("0"))
+  }
+
+  test("parseBiggerDecimal should parse -.00 as NegativeZero") {
+    assertEquals(BiggerDecimal.parseBiggerDecimal("-.00"), Some(BiggerDecimal.NegativeZero))
+  }
 }

--- a/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -286,8 +286,6 @@ class BiggerDecimalSuite extends ScalaCheckSuite {
       position <- Gen.choose(0, rest.length)
     } yield (rest.take(position) ::: nonZero :: rest.drop(position)).mkString
     forAll(genSign, genFractional) { (sign: String, fractional: String) =>
-      println("Sign: " + sign)
-      println("Fractional: " + fractional)
       val input = s"$sign.$fractional"
       assert(BiggerDecimal.parseBiggerDecimal(input).nonEmpty)
     }


### PR DESCRIPTION
When parsing `.0` or `-.0`, for example, stripping the trailing zero from the unscaled string leaves an empty string, causing `new BigInteger("")` to throw before the existing zero-check is reached. This fix addresses this by assigning `BigInteger.ZERO` to `unscaled` when the unscaled string is empty or `-`.

Should fix https://github.com/circe/circe/issues/2432.