### PR TITLE
Improve error messages for NonEmptyMap and Validated decoders

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -1188,7 +1188,7 @@ object Decoder
       final protected def createBuilder(): Builder[(K, V), SortedMap[K, V]] =
         SortedMap.newBuilder[K, V](Order.catsKernelOrderingForOrder(orderK))
     }.emap { map =>
-      NonEmptyMap.fromMap(map).toRight("[K, V]NonEmptyMap[K, V]")
+      NonEmptyMap.fromMap(map).toRight("NonEmptyMap: expected a non-empty JSON object")
     }
 
   /**
@@ -1248,7 +1248,8 @@ object Decoder
     decodeEither[E, A](
       failureKey,
       successKey
-    ).map(Validated.fromEither).withErrorMessage("[E, A]Validated[E, A]")
+    ).map(Validated.fromEither)
+      .withErrorMessage("Validated[E, A]: expected an object with either a failure or success key")
 
   private[this] abstract class JavaTimeDecoder[A](name: String) extends Decoder[A] {
     protected[this] def parseUnsafe(input: String): A

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -17,7 +17,7 @@
 package io.circe
 
 import cats.data.Validated.Invalid
-import cats.data.{ Chain, NonEmptyList, Validated }
+import cats.data.{ Chain, NonEmptyList, NonEmptyMap, Validated }
 import cats.implicits._
 import cats.kernel.Eq
 import cats.laws.discipline.{ DeferTests, MiniInt, MonadErrorTests, SemigroupKTests }
@@ -893,5 +893,18 @@ class DecoderSuite extends CirceMunitSuite with LargeNumberDecoderTestsMunit {
     // Without `Decoder.recursive`, this should create 5 instances of a `Decoder[List[Int]]`
     // (1 for each instance, and 1 that gets created but not called because because the last "cdr" field is missing)
     assertEquals(counter, 1)
+  }
+
+  test("decodeNonEmptyMap should provide a meaningful error message for empty objects") {
+    val result = Decoder[NonEmptyMap[String, Int]].decodeJson(parse("{}").getOrElse(Json.Null))
+    assert(result.isLeft)
+    assert(result.swap.exists(_.message === "NonEmptyMap: expected a non-empty JSON object"))
+  }
+
+  test("decodeValidated should provide a meaningful error message when keys are missing") {
+    val decoder = Decoder.decodeValidated[String, Int]("error", "value")
+    val result = decoder.decodeJson(parse("""{"other": 1}""").getOrElse(Json.Null))
+    assert(result.isLeft)
+    assert(result.swap.exists(_.message === "Validated[E, A]: expected an object with either a failure or success key"))
   }
 }


### PR DESCRIPTION
Replace cryptic type-parameter placeholders with human-readable messages that describe what was expected.

Before

```scala
decode[NonEmptyMap[String, Int]]("""{}""")
// Left(DecodingFailure at : [K, V]NonEmptyMap[K, V])

Decoder.decodeValidated[String, Int]("error", "value")
  .decodeJson(parse("""{"other": 1}""").getOrElse(Json.Null))
// Left(DecodingFailure at : [E, A]Validated[E, A])
```

After

```scala
decode[NonEmptyMap[String, Int]]("""{}""")
// Left(DecodingFailure at : NonEmptyMap: expected a non-empty JSON object)

Decoder.decodeValidated[String, Int]("error", "value")
  .decodeJson(parse("""{"other": 1}""").getOrElse(Json.Null))
// Left(DecodingFailure at : Validated[E, A]: expected an object with either a failure or success key)
```