### PR TITLE
fix: guard BiggerDecimal.integralIsValidLong on invalid input

### DIFF
--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -245,12 +245,27 @@ object BiggerDecimal {
    * Is a string representing an integral value a valid [[scala.Long]]?
    *
    * Note that this method assumes that the input is a valid integral JSON
-   * number string (e.g. that it does have leading zeros).
+   * number string (e.g. that it does not have leading zeros). Invalid inputs
+   * (empty string, bare sign, non-digit characters) return `false` rather
+   * than throwing.
    */
   def integralIsValidLong(s: String): Boolean = {
-    val bound = if (s.charAt(0) == '-') MinLongString else MaxLongString
+    val len = s.length
+    if (len == 0) return false
 
-    s.length < bound.length || (s.length == bound.length && s.compareTo(bound) <= 0)
+    val negative = s.charAt(0) == '-'
+    val digitStart = if (negative) 1 else 0
+    if (digitStart >= len) return false
+
+    var i = digitStart
+    while (i < len) {
+      val c = s.charAt(i)
+      if (c < '0' || c > '9') return false
+      i += 1
+    }
+
+    val bound = if (negative) MinLongString else MaxLongString
+    len < bound.length || (len == bound.length && s.compareTo(bound) <= 0)
   }
 
   private[this] final val FAILED = 0

--- a/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/modules/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -212,6 +212,30 @@ class BiggerDecimalSuite extends ScalaCheckSuite {
     }
   }
 
+  // #2457: invalid integral strings must return false without throwing
+  test("integralIsValidLong should return false for empty and non-integral inputs") {
+    assertEquals(BiggerDecimal.integralIsValidLong(""), false)
+    assertEquals(BiggerDecimal.integralIsValidLong("-"), false)
+    assertEquals(BiggerDecimal.integralIsValidLong("+"), false)
+    assertEquals(BiggerDecimal.integralIsValidLong("a"), false)
+    assertEquals(BiggerDecimal.integralIsValidLong("+1"), false)
+    assertEquals(BiggerDecimal.integralIsValidLong("1a"), false)
+    assertEquals(BiggerDecimal.integralIsValidLong("-a"), false)
+  }
+
+  test("integralIsValidLong should accept in-range integral strings") {
+    assertEquals(BiggerDecimal.integralIsValidLong("0"), true)
+    assertEquals(BiggerDecimal.integralIsValidLong("1"), true)
+    assertEquals(BiggerDecimal.integralIsValidLong("-1"), true)
+    assertEquals(BiggerDecimal.integralIsValidLong(Long.MaxValue.toString), true)
+    assertEquals(BiggerDecimal.integralIsValidLong(Long.MinValue.toString), true)
+  }
+
+  test("integralIsValidLong should reject out-of-range integral strings") {
+    assertEquals(BiggerDecimal.integralIsValidLong("9223372036854775808"), false)
+    assertEquals(BiggerDecimal.integralIsValidLong("-9223372036854775809"), false)
+  }
+
   property("parseBiggerDecimal should parse any BigDecimal string") {
     forAll { (value: SBigDecimal) =>
       val d = BiggerDecimal.parseBiggerDecimal(value.toString)


### PR DESCRIPTION
## Summary

`BiggerDecimal.integralIsValidLong` assumed a valid integral JSON number string but did not enforce that precondition:

- `""` threw `StringIndexOutOfBoundsException` via `charAt(0)`
- `"-"`, `"+"`, `"a"` (and other short non-integrals) returned `true` because any string shorter than the Long bound was accepted

This change validates emptiness, a bare leading `-`, and that remaining characters are digits, then applies the existing length/lexicographic Long-range check. Invalid inputs return `false` without throwing.

Call sites such as `JsonNumber.fromIntegralStringUnsafe` still expect pre-validated JSON number strings; this only makes the helper fail closed when that assumption does not hold.

Fixes #2457

## Changes

- `BiggerDecimal.integralIsValidLong`: empty / bare `-` / non-digits → `false`; no SIOOBE
- Docs note that invalid inputs return `false` (and correct "does have leading zeros" → "does not")
- Regression tests for empty/non-integral inputs, in-range, and out-of-range bounds

## Testing

```text
sbt "numbersJVM/testOnly io.circe.numbers.BiggerDecimalSuite"
# Passed: Total 35, Failed 0 (Scala 2.13 / Temurin 8)
```