### PR TITLE
fix: correct ConstantPieces rbraceLeft/rbraceRight order

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -117,7 +117,7 @@ final case class Printer(
       new Printer.ConstantPieces(
         Printer.Pieces(
           concat(lbraceLeft, openBraceText, lbraceRight),
-          concat(rbraceRight, closeBraceText, rbraceLeft),
+          concat(rbraceLeft, closeBraceText, rbraceRight),
           concat(lbracketLeft, openArrayText, lbracketRight),
           concat(rbracketLeft, closeArrayText, rbracketRight),
           concat(openArrayText, lrbracketsEmpty, closeArrayText),

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -29,6 +29,35 @@ class UnicodeEscapePrinterSuite extends PrinterSuite(Printer.noSpaces.copy(escap
   }
 }
 
+/**
+ * Empty-indent printers use [[Printer.ConstantPieces]], which previously swapped
+ * rbraceLeft / rbraceRight. Non-empty indent (MemoizedPieces) was already correct.
+ */
+class EmptyIndentRBracePaddingSuite extends io.circe.tests.CirceMunitSuite {
+  private val emptyIndent = Printer(
+    dropNullValues = false,
+    indent = "",
+    rbraceLeft = "L",
+    rbraceRight = "R"
+  )
+  private val indented = Printer(
+    dropNullValues = false,
+    indent = " ",
+    rbraceLeft = "L",
+    rbraceRight = "R"
+  )
+  private val json = Json.obj("key" -> Json.fromString("value"))
+  private val expected = """{"key":"value"L}R"""
+
+  test("ConstantPieces keeps rbraceLeft before } and rbraceRight after") {
+    assertEquals(emptyIndent.print(json), expected)
+  }
+
+  test("MemoizedPieces keeps the same rbraceLeft / rbraceRight order") {
+    assertEquals(indented.print(json), expected)
+  }
+}
+
 class Spaces2PrinterWithWriterReuseSuite
     extends PrinterSuite(
       Printer.spaces2.copy(reuseWriters = true),


### PR DESCRIPTION
## Summary

When `Printer` is configured with empty `indent`, the `ConstantPieces` path builds right-brace padding with `rbraceLeft` and `rbraceRight` swapped. The non-empty-indent `MemoizedPieces` path already used the correct order (`rbraceLeft` + `}` + `rbraceRight`).

Example (issue #2458):

```scala
Printer(dropNullValues = false, indent = "", rbraceLeft = "L", rbraceRight = "R")
  .print(Json.obj("key" -> Json.fromString("value")))
// was:  {"key":"value"R}L
// now:  {"key":"value"L}R
```

Other delimiters on the same block (`lbrace*`, `lbracket*`, `rbracket*`) were already left-then-right; only `rBraces` was inverted.

Fixes #2458

## Changes

- `Printer` `ConstantPieces`: `concat(rbraceLeft, closeBraceText, rbraceRight)`
- Regression tests for empty-indent (`ConstantPieces`) and non-empty-indent (`MemoizedPieces`) brace padding order

## Testing

```text
sbt "testsJVM/testOnly io.circe.EmptyIndentRBracePaddingSuite io.circe.UnicodeEscapePrinterSuite"
# Passed: Total 22, Failed 0 (EmptyIndent 2/2 + UnicodeEscape suite)
# Scala 2.13 / Corretto 8
```