### PR TITLE
fix: indent rbraceRight/rbracketRight at parent depth

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Printer.scala
@@ -141,7 +141,7 @@ final case class Printer(
 
           addIndentation(builder, rbraceLeft, i)
           builder.append(closeBraceText)
-          addIndentation(builder, rbraceRight, i + 1)
+          addIndentation(builder, rbraceRight, i)
 
           val rBraces = builder.toString
 
@@ -157,7 +157,7 @@ final case class Printer(
 
           addIndentation(builder, rbracketLeft, i)
           builder.append(closeArrayText)
-          addIndentation(builder, rbracketRight, i + 1)
+          addIndentation(builder, rbracketRight, i)
 
           val rBrackets = builder.toString
 

--- a/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -16,6 +16,7 @@
 
 package io.circe
 
+import io.circe.tests.CirceMunitSuite
 import io.circe.tests.PrinterSuite
 
 class Spaces2PrinterSuite extends PrinterSuite(Printer.spaces2, parser.`package`) with Spaces2PrinterExample
@@ -59,3 +60,61 @@ class NoSpacesSortKeysPrinterSuite extends PrinterSuite(Printer.noSpacesSortKeys
 class CustomIndentWithSortKeysPrinterSuite
     extends PrinterSuite(Printer.indented("   ").withSortedKeys, parser.`package`)
     with SortedKeysSuite
+
+/**
+ * Regression for #2459: content after `}` / `]` must be indented at the brace's depth,
+ * not one level deeper (child depth).
+ */
+class RbraceRightIndentSuite extends CirceMunitSuite {
+  private val bracePrinter = Printer(
+    dropNullValues = false,
+    indent = "  ",
+    lbraceRight = "\n",
+    rbraceLeft = "\n",
+    rbraceRight = "\n",
+    objectCommaRight = "\n"
+  )
+
+  private val bracketPrinter = Printer(
+    dropNullValues = false,
+    indent = "  ",
+    lbracketRight = "\n",
+    rbracketLeft = "\n",
+    rbracketRight = "\n",
+    arrayCommaRight = "\n"
+  )
+
+  test("rbraceRight should indent at the closed object's depth, not child depth") {
+    val json = Json.obj(
+      "outer" -> Json.obj("inner" -> Json.fromString("value"))
+    )
+
+    val expected =
+      "{\n" +
+        "  \"outer\":{\n" +
+        "    \"inner\":\"value\"\n" +
+        "  }\n" +
+        "  \n" +
+        "}\n"
+
+    assertEquals(bracePrinter.print(json), expected)
+  }
+
+  test("rbracketRight should indent at the closed array's depth, not child depth") {
+    val json = Json.arr(
+      Json.arr(Json.fromInt(1)),
+      Json.fromInt(2)
+    )
+
+    val expected =
+      "[\n" +
+        "  [\n" +
+        "    1\n" +
+        "  ]\n" +
+        "  ,\n" +
+        "  2\n" +
+        "]\n"
+
+    assertEquals(bracketPrinter.print(json), expected)
+  }
+}


### PR DESCRIPTION
## Summary

When building a custom `Printer` with non-empty `indent` and `rbraceRight` / `rbracketRight` containing a newline, content after a closing `}` or `]` was indented one level too deep (child depth `i + 1` instead of the brace's depth `i`).

`lbraceRight` / `lbracketRight` correctly use `i + 1` because content after `{` / `[` is inside the construct. After `}` / `]` the construct has closed, so the right-side pieces should use depth `i`.

Fixes #2459

## Changes

- `Printer.MemoizedPieces.compute`: `rbraceRight` and `rbracketRight` indent at depth `i` (was `i + 1`)
- Regression tests for object and array printers that use visible `rbraceRight` / `rbracketRight` whitespace

## Testing

```text
sbt "testsJVM/testOnly io.circe.RbraceRightIndentSuite"
# Passed: Total 2, Failed 0 (Scala 2.13 / Corretto 8)

sbt "testsJVM/testOnly io.circe.*Printer*"
# Passed: Total 224, Failed 0
```